### PR TITLE
Add optional `namespace` for `service` in APIRule

### DIFF
--- a/api/v1alpha1/apiRule_types.go
+++ b/api/v1alpha1/apiRule_types.go
@@ -20,7 +20,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
-//StatusCode .
+// StatusCode .
 type StatusCode string
 
 const (
@@ -53,7 +53,7 @@ type APIRuleStatus struct {
 	AccessRuleStatus     *APIRuleResourceStatus `json:"accessRuleStatus,omitempty"`
 }
 
-//APIRule is the Schema for the apis ApiRule
+// APIRule is the Schema for the apis ApiRule
 // +kubebuilder:deprecatedversion:warning=v1alpha1 is deprecated as of Kyma 2.5.X
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
@@ -74,7 +74,7 @@ type APIRuleList struct {
 	Items           []APIRule `json:"items"`
 }
 
-//Service .
+// Service .
 type Service struct {
 	// Name of the service
 	Name *string `json:"name"`
@@ -92,7 +92,7 @@ type Service struct {
 	IsExternal *bool `json:"external,omitempty"`
 }
 
-//Rule .
+// Rule .
 type Rule struct {
 	// Path to be exposed
 	// +kubebuilder:validation:Pattern=^([0-9a-zA-Z./*()?!\\_-]+)
@@ -108,7 +108,7 @@ type Rule struct {
 	Mutators []*Mutator `json:"mutators,omitempty"`
 }
 
-//APIRuleResourceStatus .
+// APIRuleResourceStatus .
 type APIRuleResourceStatus struct {
 	Code        StatusCode `json:"code,omitempty"`
 	Description string     `json:"desc,omitempty"`

--- a/api/v1alpha1/groupversion_info.go
+++ b/api/v1alpha1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1alpha1 contains API Schema definitions for the gateway v1alpha1 API group
-//+kubebuilder:object:generate=true
-//+groupName=gateway.kyma-project.io
+// +kubebuilder:object:generate=true
+// +groupName=gateway.kyma-project.io
 package v1alpha1
 
 import (

--- a/api/v1alpha1/internal_types.go
+++ b/api/v1alpha1/internal_types.go
@@ -1,6 +1,6 @@
 package v1alpha1
 
-//JWTAccStrConfig is used to deserialize jwt accessStrategy configuration for the validation purposes
+// JWTAccStrConfig is used to deserialize jwt accessStrategy configuration for the validation purposes
 type JWTAccStrConfig struct {
 	TrustedIssuers []string `json:"trusted_issuers,omitempty"`
 	JWKSUrls       []string `json:"jwks_urls,omitempty"`

--- a/api/v1beta1/apirule_types.go
+++ b/api/v1beta1/apirule_types.go
@@ -80,7 +80,7 @@ type APIRuleList struct {
 	Items           []APIRule `json:"items"`
 }
 
-// Service .
+//Service .
 type Service struct {
 	// Name of the service
 	Name *string `json:"name"`

--- a/api/v1beta1/apirule_types.go
+++ b/api/v1beta1/apirule_types.go
@@ -20,7 +20,7 @@ import (
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 
-//StatusCode .
+// StatusCode .
 type StatusCode string
 
 const (
@@ -59,7 +59,7 @@ type APIRuleStatus struct {
 	AccessRuleStatus     *APIRuleResourceStatus `json:"accessRuleStatus,omitempty"`
 }
 
-//APIRule is the Schema for the apis ApiRule
+// APIRule is the Schema for the apis ApiRule
 // +kubebuilder:storageversion
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
@@ -80,7 +80,7 @@ type APIRuleList struct {
 	Items           []APIRule `json:"items"`
 }
 
-//Service .
+// Service .
 type Service struct {
 	// Name of the service
 	Name *string `json:"name"`
@@ -97,7 +97,7 @@ type Service struct {
 	IsExternal *bool `json:"external,omitempty"`
 }
 
-//Rule .
+// Rule .
 type Rule struct {
 	// Path to be exposed
 	// +kubebuilder:validation:Pattern=^([0-9a-zA-Z./*()?!\\_-]+)
@@ -116,7 +116,7 @@ type Rule struct {
 	Mutators []*Mutator `json:"mutators,omitempty"`
 }
 
-//APIRuleResourceStatus .
+// APIRuleResourceStatus .
 type APIRuleResourceStatus struct {
 	Code        StatusCode `json:"code,omitempty"`
 	Description string     `json:"desc,omitempty"`

--- a/api/v1beta1/apirule_types.go
+++ b/api/v1beta1/apirule_types.go
@@ -80,10 +80,14 @@ type APIRuleList struct {
 	Items           []APIRule `json:"items"`
 }
 
-//Service .
+// Service .
 type Service struct {
 	// Name of the service
 	Name *string `json:"name"`
+	// Namespace of the service, if omitted will default to the APIRule namespace
+	// +kubebuilder:validation:Pattern=^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+	// +optional
+	Namespace *string `json:"namespace,omitempty"`
 	// Port of the service to expose
 	// +kubebuilder:validation:Minimum=1
 	// +kubebuilder:validation:Maximum=65535

--- a/api/v1beta1/groupversion_info.go
+++ b/api/v1beta1/groupversion_info.go
@@ -15,8 +15,8 @@ limitations under the License.
 */
 
 // Package v1beta1 contains API Schema definitions for the gateway v1beta1 API group
-//+kubebuilder:object:generate=true
-//+groupName=gateway.kyma-project.io
+// +kubebuilder:object:generate=true
+// +groupName=gateway.kyma-project.io
 package v1beta1
 
 import (

--- a/api/v1beta1/internal_types.go
+++ b/api/v1beta1/internal_types.go
@@ -1,6 +1,6 @@
 package v1beta1
 
-//JWTAccStrConfig is used to deserialize jwt accessStrategy configuration for the validation purposes
+// JWTAccStrConfig is used to deserialize jwt accessStrategy configuration for the validation purposes
 type JWTAccStrConfig struct {
 	TrustedIssuers []string `json:"trusted_issuers,omitempty"`
 	JWKSUrls       []string `json:"jwks_urls,omitempty"`

--- a/api/v1beta1/zz_generated.deepcopy.go
+++ b/api/v1beta1/zz_generated.deepcopy.go
@@ -315,6 +315,11 @@ func (in *Service) DeepCopyInto(out *Service) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.Namespace != nil {
+		in, out := &in.Namespace, &out.Namespace
+		*out = new(string)
+		**out = **in
+	}
 	if in.Port != nil {
 		in, out := &in.Port, &out.Port
 		*out = new(uint32)

--- a/config/crd/bases/gateway.kyma-project.io_apirules.yaml
+++ b/config/crd/bases/gateway.kyma-project.io_apirules.yaml
@@ -293,6 +293,11 @@ spec:
                         name:
                           description: Name of the service
                           type: string
+                        namespace:
+                          description: Namespace of the service, if omitted will default
+                            to the APIRule namespace
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
                         port:
                           description: Port of the service to expose
                           format: int32
@@ -319,6 +324,11 @@ spec:
                     type: boolean
                   name:
                     description: Name of the service
+                    type: string
+                  namespace:
+                    description: Namespace of the service, if omitted will default
+                      to the APIRule namespace
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                   port:
                     description: Port of the service to expose

--- a/controllers/apirule_controller.go
+++ b/controllers/apirule_controller.go
@@ -140,7 +140,7 @@ func (r *APIRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
-//Sets status of APIRule. Accepts an auxilary status code that is used to report VirtualService and AccessRule status.
+// Sets status of APIRule. Accepts an auxilary status code that is used to report VirtualService and AccessRule status.
 func (r *APIRuleReconciler) setStatus(ctx context.Context, api *gatewayv1beta1.APIRule, apiStatus *gatewayv1beta1.APIRuleResourceStatus, auxStatusCode gatewayv1beta1.StatusCode) (ctrl.Result, error) {
 	virtualServiceStatus := &gatewayv1beta1.APIRuleResourceStatus{
 		Code: auxStatusCode,
@@ -151,7 +151,7 @@ func (r *APIRuleReconciler) setStatus(ctx context.Context, api *gatewayv1beta1.A
 	return r.updateStatusOrRetry(ctx, api, apiStatus, virtualServiceStatus, accessRuleStatus)
 }
 
-//Sets status of APIRule in error condition. Accepts an auxilary status code that is used to report VirtualService and AccessRule status.
+// Sets status of APIRule in error condition. Accepts an auxilary status code that is used to report VirtualService and AccessRule status.
 func (r *APIRuleReconciler) setStatusForError(ctx context.Context, api *gatewayv1beta1.APIRule, err error, auxStatusCode gatewayv1beta1.StatusCode) (ctrl.Result, error) {
 	r.Log.Error(err, "Error during reconciliation")
 
@@ -165,7 +165,7 @@ func (r *APIRuleReconciler) setStatusForError(ctx context.Context, api *gatewayv
 	return r.updateStatusOrRetry(ctx, api, generateErrorStatus(err), virtualServiceStatus, accessRuleStatus)
 }
 
-//Updates api status. If there was an error during update, returns the error so that entire reconcile loop is retried. If there is no error, returns a "reconcile success" value.
+// Updates api status. If there was an error during update, returns the error so that entire reconcile loop is retried. If there is no error, returns a "reconcile success" value.
 func (r *APIRuleReconciler) updateStatusOrRetry(ctx context.Context, api *gatewayv1beta1.APIRule, apiStatus, virtualServiceStatus, accessRuleStatus *gatewayv1beta1.APIRuleResourceStatus) (ctrl.Result, error) {
 	_, updateStatusErr := r.updateStatus(ctx, api, apiStatus, virtualServiceStatus, accessRuleStatus)
 	if updateStatusErr != nil {

--- a/internal/helpers/namespace.go
+++ b/internal/helpers/namespace.go
@@ -1,0 +1,16 @@
+package helpers
+
+import (
+	gatewayv1beta1 "github.com/kyma-incubator/api-gateway/api/v1beta1"
+)
+
+func FindServiceNamespace(api *gatewayv1beta1.APIRule, rule *gatewayv1beta1.Rule) *string {
+	// Fallback direction for the upstream service namespace: Rule.Service > Spec.Service > APIRule
+	if rule != nil && rule.Service != nil && rule.Service.Namespace != nil {
+		return rule.Service.Namespace
+	}
+	if api.Spec.Service != nil && api.Spec.Service.Namespace != nil {
+		return api.Spec.Service.Namespace
+	}
+	return &api.ObjectMeta.Namespace
+}

--- a/internal/processing/access_rule_helpers.go
+++ b/internal/processing/access_rule_helpers.go
@@ -44,7 +44,7 @@ func generateAccessRuleSpec(api *gatewayv1beta1.APIRule, rule gatewayv1beta1.Rul
 		Authenticators(builders.Authenticators().From(accessStrategies)).
 		Mutators(builders.Mutators().From(rule.Mutators))
 
-	serviceNamespace := findServiceNamespace(api, &rule)
+	serviceNamespace := helpers.FindServiceNamespace(api, &rule)
 
 	// Use rule level service if it exists
 	if rule.Service != nil {

--- a/internal/processing/access_rule_helpers.go
+++ b/internal/processing/access_rule_helpers.go
@@ -44,12 +44,14 @@ func generateAccessRuleSpec(api *gatewayv1beta1.APIRule, rule gatewayv1beta1.Rul
 		Authenticators(builders.Authenticators().From(accessStrategies)).
 		Mutators(builders.Mutators().From(rule.Mutators))
 
+	serviceNamespace := findServiceNamespace(api, &rule)
+
 	// Use rule level service if it exists
 	if rule.Service != nil {
 		return accessRuleSpec.Upstream(builders.Upstream().
-			URL(fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", *rule.Service.Name, api.ObjectMeta.Namespace, int(*rule.Service.Port)))).Get()
+			URL(fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", *rule.Service.Name, *serviceNamespace, int(*rule.Service.Port)))).Get()
 	}
 	// Otherwise use service defined on APIRule spec level
 	return accessRuleSpec.Upstream(builders.Upstream().
-		URL(fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", *api.Spec.Service.Name, api.ObjectMeta.Namespace, int(*api.Spec.Service.Port)))).Get()
+		URL(fmt.Sprintf("http://%s.%s.svc.cluster.local:%d", *api.Spec.Service.Name, *serviceNamespace, int(*api.Spec.Service.Port)))).Get()
 }

--- a/internal/processing/helpers.go
+++ b/internal/processing/helpers.go
@@ -27,14 +27,3 @@ func generateOwnerRef(api *gatewayv1beta1.APIRule) k8sMeta.OwnerReference {
 		Controller(true).
 		Get()
 }
-
-func findServiceNamespace(api *gatewayv1beta1.APIRule, rule *gatewayv1beta1.Rule) *string {
-	// Fallback direction for the upstream service namespace: Rule.Service > Spec.Service > APIRule
-	if rule.Service != nil && rule.Service.Namespace != nil {
-		return rule.Service.Namespace
-	}
-	if api.Spec.Service != nil && api.Spec.Service.Namespace != nil {
-		return api.Spec.Service.Namespace
-	}
-	return &api.ObjectMeta.Namespace
-}

--- a/internal/processing/helpers.go
+++ b/internal/processing/helpers.go
@@ -27,3 +27,14 @@ func generateOwnerRef(api *gatewayv1beta1.APIRule) k8sMeta.OwnerReference {
 		Controller(true).
 		Get()
 }
+
+func findServiceNamespace(api *gatewayv1beta1.APIRule, rule *gatewayv1beta1.Rule) *string {
+	// Fallback direction for the upstream service namespace: Rule.Service > Spec.Service > APIRule
+	if rule.Service != nil && rule.Service.Namespace != nil {
+		return rule.Service.Namespace
+	}
+	if api.Spec.Service != nil && api.Spec.Service.Namespace != nil {
+		return api.Spec.Service.Namespace
+	}
+	return &api.ObjectMeta.Namespace
+}

--- a/internal/processing/processing_test.go
+++ b/internal/processing/processing_test.go
@@ -314,7 +314,7 @@ var _ = Describe("Factory", func() {
 				Expect(len(vs.Spec.Http[0].Route)).To(Equal(1))
 				Expect(vs.Spec.Http[0].Route[0].Destination.Host).To(Equal(overrideServiceName + "." + overrideServiceNamespace + ".svc.cluster.local"))
 
-				//Verify AR has rule level upstream
+				//Verify AR does not exist
 				Expect(len(accessRules)).To(Equal(0))
 			})
 

--- a/internal/processing/processing_test.go
+++ b/internal/processing/processing_test.go
@@ -124,7 +124,7 @@ var _ = Describe("Factory", func() {
 				Expect(len(accessRules)).To(Equal(0))
 			})
 
-			It("should override upstream for specified spec level service namespace", func() {
+			It("should override VS destination host for specified spec level service namespace", func() {
 				strategies := []*gatewayv1beta1.Authenticator{
 					{
 						Handler: &gatewayv1beta1.Handler{

--- a/internal/processing/processing_test.go
+++ b/internal/processing/processing_test.go
@@ -1007,7 +1007,6 @@ var _ = Describe("Factory", func() {
 
 				apiRule := getAPIRuleFor(rules)
 
-
 				rule := rulev1alpha1.Rule{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: map[string]string{

--- a/internal/processing/processing_test.go
+++ b/internal/processing/processing_test.go
@@ -158,7 +158,7 @@ var _ = Describe("Factory", func() {
 				Expect(len(vs.Spec.Http[0].Route)).To(Equal(1))
 				Expect(vs.Spec.Http[0].Route[0].Destination.Host).To(Equal(overrideServiceName + "." + overrideServiceNamespace + ".svc.cluster.local"))
 
-				//Verify AR has rule level upstream
+				//Verify AR does not exist
 				Expect(len(accessRules)).To(Equal(0))
 			})
 

--- a/internal/processing/virtual_service_helpers.go
+++ b/internal/processing/virtual_service_helpers.go
@@ -27,14 +27,16 @@ func (f *Factory) generateVirtualService(api *gatewayv1beta1.APIRule) *networkin
 		httpRouteBuilder := builders.HTTPRoute()
 		host, port := f.oathkeeperSvc, f.oathkeeperSvcPort
 
+		serviceNamespace := findServiceNamespace(api, &rule)
+
 		if !isSecured(rule) {
 			// Use rule level service if it exists
 			if rule.Service != nil {
-				host = fmt.Sprintf("%s.%s.svc.cluster.local", *rule.Service.Name, api.ObjectMeta.Namespace)
+				host = fmt.Sprintf("%s.%s.svc.cluster.local", *rule.Service.Name, *serviceNamespace)
 				port = *rule.Service.Port
 			} else {
 				// Otherwise use service defined on APIRule spec level
-				host = fmt.Sprintf("%s.%s.svc.cluster.local", *api.Spec.Service.Name, api.ObjectMeta.Namespace)
+				host = fmt.Sprintf("%s.%s.svc.cluster.local", *api.Spec.Service.Name, *serviceNamespace)
 				port = *api.Spec.Service.Port
 			}
 		}

--- a/internal/processing/virtual_service_helpers.go
+++ b/internal/processing/virtual_service_helpers.go
@@ -27,7 +27,7 @@ func (f *Factory) generateVirtualService(api *gatewayv1beta1.APIRule) *networkin
 		httpRouteBuilder := builders.HTTPRoute()
 		host, port := f.oathkeeperSvc, f.oathkeeperSvcPort
 
-		serviceNamespace := findServiceNamespace(api, &rule)
+		serviceNamespace := helpers.FindServiceNamespace(api, &rule)
 
 		if !isSecured(rule) {
 			// Use rule level service if it exists

--- a/internal/validation/dummy.go
+++ b/internal/validation/dummy.go
@@ -2,7 +2,7 @@ package validation
 
 import gatewayv1beta1 "github.com/kyma-incubator/api-gateway/api/v1beta1"
 
-//dummy is an accessStrategy validator that does nothing
+// dummy is an accessStrategy validator that does nothing
 type dummyAccStrValidator struct{}
 
 func (dummy *dummyAccStrValidator) Validate(attrPath string, handler *gatewayv1beta1.Handler) []Failure {

--- a/internal/validation/jwt.go
+++ b/internal/validation/jwt.go
@@ -7,7 +7,7 @@ import (
 	gatewayv1beta1 "github.com/kyma-incubator/api-gateway/api/v1beta1"
 )
 
-//jwtAccStrValidator is an accessStrategy validator for jwt ORY authenticator
+// jwtAccStrValidator is an accessStrategy validator for jwt ORY authenticator
 type jwtAccStrValidator struct{}
 
 func (j *jwtAccStrValidator) Validate(attributePath string, handler *gatewayv1beta1.Handler) []Failure {

--- a/internal/validation/labels.go
+++ b/internal/validation/labels.go
@@ -19,12 +19,12 @@ var (
 	labelValueRegexp     = labelKeyNameRegexp
 )
 
-//VerifyLabelKey returns error if the provided string is not a proper k8s label key
+// VerifyLabelKey returns error if the provided string is not a proper k8s label key
 func VerifyLabelKey(key string) error {
 	return validateLabelKey(key)
 }
 
-//VerifyLabelValue returns error if the provided string is not a proper k8s label value
+// VerifyLabelValue returns error if the provided string is not a proper k8s label value
 func VerifyLabelValue(value string) error {
 	return validateLabelValue(value)
 }

--- a/internal/validation/no_config.go
+++ b/internal/validation/no_config.go
@@ -6,7 +6,7 @@ import (
 	gatewayv1beta1 "github.com/kyma-incubator/api-gateway/api/v1beta1"
 )
 
-//noConfig is an accessStrategy validator that does not accept nested config
+// noConfig is an accessStrategy validator that does not accept nested config
 type noConfigAccStrValidator struct{}
 
 func (a *noConfigAccStrValidator) Validate(attrPath string, handler *gatewayv1beta1.Handler) []Failure {

--- a/internal/validation/validate.go
+++ b/internal/validation/validate.go
@@ -128,7 +128,7 @@ func (v *APIRule) validateService(attributePath string, api *gatewayv1beta1.APIR
 	for namespace, services := range v.ServiceBlockList {
 		for _, svc := range services {
 			serviceNamespace := helpers.FindServiceNamespace(api, nil)
-			if svc == *api.Spec.Service.Name && namespace == *serviceNamespace {
+			if svc == *api.Spec.Service.Name && serviceNamespace != nil && namespace == *serviceNamespace {
 				problems = append(problems, Failure{
 					AttributePath: attributePath + ".name",
 					Message:       fmt.Sprintf("Service %s in namespace %s is blocklisted", svc, namespace),
@@ -169,7 +169,7 @@ func (v *APIRule) validateRules(attributePath string, checkForService bool, api 
 			for namespace, services := range v.ServiceBlockList {
 				for _, svc := range services {
 					serviceNamespace := helpers.FindServiceNamespace(api, &r)
-					if svc == *r.Service.Name && namespace == *serviceNamespace {
+					if svc == *r.Service.Name && serviceNamespace != nil && namespace == *serviceNamespace {
 						problems = append(problems, Failure{
 							AttributePath: attributePathWithRuleIndex + ".service.name",
 							Message:       fmt.Sprintf("Service %s in namespace %s is blocklisted", svc, namespace),

--- a/internal/validation/validate.go
+++ b/internal/validation/validate.go
@@ -128,7 +128,11 @@ func (v *APIRule) validateService(attributePath string, api *gatewayv1beta1.APIR
 
 	for namespace, services := range v.ServiceBlockList {
 		for _, svc := range services {
-			if svc == *api.Spec.Service.Name && namespace == api.ObjectMeta.Namespace {
+			serviceNamespace := api.Spec.Service.Namespace
+			if serviceNamespace == nil {
+				serviceNamespace = &api.ObjectMeta.Namespace
+			}
+			if svc == *api.Spec.Service.Name && namespace == *serviceNamespace {
 				problems = append(problems, Failure{
 					AttributePath: attributePath + ".name",
 					Message:       fmt.Sprintf("Service %s in namespace %s is blocklisted", svc, namespace),
@@ -167,7 +171,11 @@ func (v *APIRule) validateRules(attributePath string, checkForService bool, rule
 		if r.Service != nil {
 			for namespace, services := range v.ServiceBlockList {
 				for _, svc := range services {
-					if svc == *r.Service.Name && namespace == rulesNamespace {
+					serviceNamespace := r.Service.Namespace
+					if serviceNamespace == nil {
+						serviceNamespace = apiRuleNamespace
+					}
+					if svc == *r.Service.Name && namespace == *serviceNamespace {
 						problems = append(problems, Failure{
 							AttributePath: attributePathWithRuleIndex + ".service.name",
 							Message:       fmt.Sprintf("Service %s in namespace %s is blocklisted", svc, namespace),

--- a/internal/validation/validate_test.go
+++ b/internal/validation/validate_test.go
@@ -95,6 +95,44 @@ var _ = Describe("Validate function", func() {
 		Expect(problems[0].Message).To(Equal("Service kubernetes in namespace default is blocklisted"))
 	})
 
+	It("Should fail for blocklisted service for specific namespace", func() {
+		//given
+		sampleBlocklistedService := "service"
+		sampleBlocklistedNamespace := "service-namespace"
+		validHost := sampleBlocklistedService + "." + allowlistedDomain
+		testBlockList := map[string][]string{
+			"default":                  {"kube-dns"},
+			sampleBlocklistedNamespace: {sampleBlocklistedService}}
+		input := &gatewayv1beta1.APIRule{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: "default",
+			},
+			Spec: gatewayv1beta1.APIRuleSpec{
+				Service: getService(sampleBlocklistedService, uint32(443), &sampleBlocklistedNamespace),
+				Host:    getHost(validHost),
+				Rules: []gatewayv1beta1.Rule{
+					{
+						Path: "/abc",
+						AccessStrategies: []*gatewayv1beta1.Authenticator{
+							toAuthenticator("jwt", simpleJWTConfig()),
+							toAuthenticator("noop", emptyConfig()),
+						},
+					},
+				},
+			}}
+
+		//when
+		problems := (&APIRule{
+			ServiceBlockList: testBlockList,
+			DomainAllowList:  testDomainAllowlist,
+		}).Validate(input, networkingv1beta1.VirtualServiceList{})
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal(".spec.service.name"))
+		Expect(problems[0].Message).To(Equal(fmt.Sprintf("Service %s in namespace %s is blocklisted", sampleBlocklistedService, sampleBlocklistedNamespace)))
+	})
+
 	It("Should fail for not allowlisted domain", func() {
 		//given
 		invalidHost := sampleServiceName + "." + notAllowlistedDomain
@@ -504,6 +542,51 @@ var _ = Describe("Validate function", func() {
 		Expect(problems[0].Message).To(Equal(fmt.Sprintf("Service %s in namespace default is blocklisted", sampleBlocklistedService)))
 	})
 
+	It("Should return an error when rule is defined with blocklisted service in specific namespace", func() {
+		//given
+		sampleBlocklistedService := "service"
+		sampleBlocklistedNamespace := "service-namespace"
+		validHost := sampleBlocklistedService + "." + allowlistedDomain
+		testBlockList := map[string][]string{
+			"default":                  {"kube-dns"},
+			sampleBlocklistedNamespace: {sampleBlocklistedService}}
+
+		input := &gatewayv1beta1.APIRule{
+			ObjectMeta: v1.ObjectMeta{
+				Namespace: "default",
+			},
+			Spec: gatewayv1beta1.APIRuleSpec{
+				Host: getHost(validHost),
+				Rules: []gatewayv1beta1.Rule{
+					{
+						Path: "/abc",
+						AccessStrategies: []*gatewayv1beta1.Authenticator{
+							toAuthenticator("noop", emptyConfig()),
+						},
+						Service: getService(sampleServiceName, uint32(8080)),
+					},
+					{
+						Path: "/abcd",
+						AccessStrategies: []*gatewayv1beta1.Authenticator{
+							toAuthenticator("noop", emptyConfig()),
+						},
+						Service: getService(sampleBlocklistedService, uint32(8080), &sampleBlocklistedNamespace),
+					},
+				},
+			},
+		}
+		//when
+		problems := (&APIRule{
+			ServiceBlockList: testBlockList,
+			DomainAllowList:  testDomainAllowlist,
+		}).Validate(input, networkingv1beta1.VirtualServiceList{})
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal(".spec.rules[1].service.name"))
+		Expect(problems[0].Message).To(Equal(fmt.Sprintf("Service %s in namespace %s is blocklisted", sampleBlocklistedService, sampleBlocklistedNamespace)))
+	})
+
 	It("Should detect several problems", func() {
 		//given
 		input := &gatewayv1beta1.APIRule{
@@ -784,10 +867,15 @@ func toAuthenticator(name string, config *runtime.RawExtension) *gatewayv1beta1.
 	}
 }
 
-func getService(serviceName string, servicePort uint32) *gatewayv1beta1.Service {
+func getService(serviceName string, servicePort uint32, namespace ...*string) *gatewayv1beta1.Service {
+	var serviceNamespace *string
+	if len(namespace) > 0 {
+		serviceNamespace = namespace[0]
+	}
 	return &gatewayv1beta1.Service{
-		Name: &serviceName,
-		Port: &servicePort,
+		Name:      &serviceName,
+		Namespace: serviceNamespace,
+		Port:      &servicePort,
 	}
 }
 


### PR DESCRIPTION
**Description**

Added optional `namespace` in `service` for APIRule CRD (on root `spec` or as subelement in `rules`)

Changes in this pull request:

- [x] Update API-Rule CRD
- [x] Adapt target for ory-proxy Ory Rule and upstream for VirtualService
- [x] Unit tests

**Related issue(s)**
https://github.com/kyma-project/kyma/issues/9936
https://github.com/kyma-project/api-gateway/issues/12