### PR TITLE
Make Cert Handler CRD Configurable

### DIFF
--- a/cmd/cronjob/cronjob.go
+++ b/cmd/cronjob/cronjob.go
@@ -11,26 +11,20 @@ import (
 
 func main() {
 	logger := zap.New()
-	logger.WithName("api-gateway-cert-cronjob")
+	logger.WithName("cert-generation-cronjob")
+	crdName, ok := os.LookupEnv("CRD_NAME")
+	if !ok {
+		logger.Error(errors.New("CRD_NAME environment variable wasn't set"), "setup")
+		return
+	}
+
 	secretName, ok := os.LookupEnv("SECRET_NAME")
 	if !ok {
 		logger.Error(errors.New("SECRET_NAME environment variable wasn't set"), "setup")
 		return
 	}
 
-	secretNamespace, ok := os.LookupEnv("SECRET_NAMESPACE")
-	if !ok {
-		logger.Error(errors.New("SECRET_NAMESPACE environment variable wasn't set"), "setup")
-		return
-	}
-
-	serviceName, ok := os.LookupEnv("SERVICE_NAME")
-	if !ok {
-		logger.Error(errors.New("SERVICE_NAME environment variable wasn't set"), "setup")
-		return
-	}
-
-	err := webhook.SetupCertificates(context.Background(), logger, secretName, secretNamespace, serviceName)
+	err := webhook.SetupCertificates(context.Background(), logger, crdName, secretName)
 	if err != nil {
 		panic(err)
 	}

--- a/config/certificates/jobs.yaml
+++ b/config/certificates/jobs.yaml
@@ -19,10 +19,8 @@ spec:
         image: init-certificates:latest
         imagePullPolicy: IfNotPresent
         env:
-        - name: SERVICE_NAME
-          value: api-gateway-webhook-service
-        - name: SECRET_NAMESPACE
-          value: kyma-system
+        - name: CRD_NAME
+          value: "apirules.gateway.kyma-project.io"
         - name: SECRET_NAME
           value: api-gateway-webhook-server-cert
       serviceAccountName: certificates-account
@@ -51,10 +49,8 @@ spec:
             image: init-certificates:latest
             imagePullPolicy: IfNotPresent
             env:
-            - name: SERVICE_NAME
-              value: api-gateway-webhook-service
-            - name: SECRET_NAMESPACE
-              value: kyma-system
+            - name: CRD_NAME
+              value: "apirules.gateway.kyma-project.io"
             - name: SECRET_NAME
               value: api-gateway-webhook-server-cert
           serviceAccountName: certificates-account


### PR DESCRIPTION
* Make CRD configurable so that the app can generate for different CRDs
* Adap kustomize resources to use CRD name

**Description**
Make CRD configurable so that cert-handler can be configured for a different CRD too
Changes proposed in this pull request:

- Make CRD configurable so that the app can generate for different CRDs
- Adap kustomize resources to use CRD name

**Related issue(s)**
#15346