### PR TITLE
Config fail early

### DIFF
--- a/config/configmap/configmap.yaml
+++ b/config/configmap/configmap.yaml
@@ -3,5 +3,5 @@ kind: ConfigMap
 metadata:
   name: config
 data:
-  api-gateway-config.yaml: >
+  api-gateway-config: >
     jwtHandler: "ory"

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -59,14 +59,5 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
-        volumeMounts:
-        - mountPath: /api-gateway-config
-          name: api-gateway-config
-          readOnly: true
-      volumes:
-      - configMap:
-          defaultMode: 420
-          name: api-gateway-config
-        name: api-gateway-config
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -18,6 +18,18 @@ rules:
   - update
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
   - gateway.kyma-project.io
   resources:
   - apirules

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -6,9 +6,9 @@ metadata:
   name: manager-role
 rules:
 - apiGroups:
-  - apiextensions.k8s.io
+  - ""
   resources:
-  - customresourcedefinitions
+  - configmaps
   verbs:
   - create
   - delete
@@ -18,9 +18,9 @@ rules:
   - update
   - watch
 - apiGroups:
-  - ""
+  - apiextensions.k8s.io
   resources:
-  - configmaps
+  - customresourcedefinitions
   verbs:
   - create
   - delete

--- a/controllers/api_controller_test.go
+++ b/controllers/api_controller_test.go
@@ -76,6 +76,10 @@ var _ = Describe("Controller", func() {
 				fakeReader := FakeConfigMapReader{Content: fmt.Sprintf("jwtHandler: %s", helpers.JWT_HANDLER_ORY)}
 				helpers.ReadConfigMapHandle = fakeReader.ReadConfigMap
 
+				defer func() {
+					helpers.ReadConfigMapHandle = helpers.ReadConfigMap
+				}()
+
 				result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: testAPI.Namespace, Name: testAPI.Name}})
 				Expect(err).ToNot(HaveOccurred())
 				Expect(result.Requeue).To(BeFalse())
@@ -98,6 +102,10 @@ var _ = Describe("Controller", func() {
 				errorReader := FakeConfigMapReader{}
 				helpers.ReadConfigMapHandle = errorReader.ReadConfigMap
 
+				defer func() {
+					helpers.ReadConfigMapHandle = helpers.ReadConfigMap
+				}()
+
 				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: testAPI.Namespace, Name: testAPI.Name}})
 				Expect(err).ToNot(HaveOccurred())
 
@@ -117,6 +125,10 @@ var _ = Describe("Controller", func() {
 				fakeReader := FakeConfigMapReader{Content: "<xml/>"}
 				helpers.ReadConfigMapHandle = fakeReader.ReadConfigMap
 
+				defer func() {
+					helpers.ReadConfigMapHandle = helpers.ReadConfigMap
+				}()
+
 				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: testAPI.Namespace, Name: testAPI.Name}})
 				Expect(err).ToNot(HaveOccurred())
 
@@ -135,6 +147,10 @@ var _ = Describe("Controller", func() {
 
 				fakeReader := FakeConfigMapReader{Content: "jwtHandler: foo"}
 				helpers.ReadConfigMapHandle = fakeReader.ReadConfigMap
+
+				defer func() {
+					helpers.ReadConfigMapHandle = helpers.ReadConfigMap
+				}()
 
 				_, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: testAPI.Namespace, Name: testAPI.Name}})
 				Expect(err).ToNot(HaveOccurred())
@@ -157,6 +173,10 @@ var _ = Describe("Controller", func() {
 
 					fakeReader := FakeConfigMapReader{Content: fmt.Sprintf("jwtHandler: %s", helpers.JWT_HANDLER_ISTIO)}
 					helpers.ReadConfigMapHandle = fakeReader.ReadConfigMap
+
+					defer func() {
+						helpers.ReadConfigMapHandle = helpers.ReadConfigMap
+					}()
 
 					result, err := reconciler.Reconcile(ctx, reconcile.Request{NamespacedName: types.NamespacedName{Namespace: testAPI.Namespace, Name: testAPI.Name}})
 					Expect(err).ToNot(HaveOccurred())

--- a/controllers/apirule_controller.go
+++ b/controllers/apirule_controller.go
@@ -101,6 +101,7 @@ func (p configMapPredicate) Generic(e event.GenericEvent) bool {
 //+kubebuilder:rbac:groups=security.istio.io,resources=authorizationpolicies,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups=security.istio.io,resources=requestauthentications,verbs=get;list;watch;create;update;patch;delete
 //+kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=get;list;watch;create;update;patch;delete
+//+kubebuilder:rbac:groups="",resources=configmaps,verbs=get;list;watch;create;update;patch;delete
 
 func (r *APIRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	r.Log.Info("Starting reconcilation")

--- a/controllers/apirule_controller.go
+++ b/controllers/apirule_controller.go
@@ -182,6 +182,8 @@ func (r *APIRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 func (r *APIRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&gatewayv1beta1.APIRule{}).
+		For(&corev1.ConfigMap{}).
+		WithEventFilter(&configMapPredicate{Log: r.Log}).
 		Complete(r)
 }
 

--- a/controllers/apirule_controller.go
+++ b/controllers/apirule_controller.go
@@ -113,7 +113,7 @@ func (r *APIRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				r.Log.Info( fmt.Sprintf(`ConfigMap %s in namespace %s was not found {"controller": "Api"}, will use default config`, helpers.CM_NAME, helpers.CM_NS))
 				r.Config.ResetToDefault()
 			} else {
-				r.Log.Error(err, fmt.Sprintf(`ConfigMap read failure {"controller": "Api"}`))
+				r.Log.Error(err, fmt.Sprintf(`could not read ConfigMap %s in namespace %s {"controller": "Api"}`, helpers.CM_NAME, helpers.CM_NS))
 				r.Config.Reset()
 			}
 		}

--- a/controllers/apirule_controller.go
+++ b/controllers/apirule_controller.go
@@ -112,7 +112,7 @@ func (r *APIRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		err := r.Config.ReadFromConfigMap(ctx, r.Client)
 		if err != nil {
 			if apierrs.IsNotFound(err) {
-				r.Log.Info( fmt.Sprintf(`ConfigMap %s in namespace %s was not found {"controller": "Api"}, will use default config`, helpers.CM_NAME, helpers.CM_NS))
+				r.Log.Info(fmt.Sprintf(`ConfigMap %s in namespace %s was not found {"controller": "Api"}, will use default config`, helpers.CM_NAME, helpers.CM_NS))
 				r.Config.ResetToDefault()
 			} else {
 				r.Log.Error(err, fmt.Sprintf(`could not read ConfigMap %s in namespace %s {"controller": "Api"}`, helpers.CM_NAME, helpers.CM_NS))

--- a/controllers/apirule_controller.go
+++ b/controllers/apirule_controller.go
@@ -110,7 +110,7 @@ func (r *APIRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		err := r.Config.ReadFromConfigMap(ctx, r.Client)
 		if err != nil {
 			if apierrs.IsNotFound(err) {
-				r.Log.Error(err, fmt.Sprintf(`ConfigMap not found {"controller": "Api"}, will use default config`))
+				r.Log.Info( fmt.Sprintf(`ConfigMap %s in namespace %s was not found {"controller": "Api"}, will use default config`, helpers.CM_NAME, helpers.CM_NS))
 				r.Config.ResetToDefault()
 			} else {
 				r.Log.Error(err, fmt.Sprintf(`ConfigMap read failure {"controller": "Api"}`))

--- a/controllers/apirule_controller.go
+++ b/controllers/apirule_controller.go
@@ -108,7 +108,6 @@ func (r *APIRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	isCMReconcile := (req.NamespacedName.String() == types.NamespacedName{Namespace: helpers.CM_NS, Name: helpers.CM_NAME}.String())
 	if isCMReconcile || r.Config.JWTHandler == "" {
 		err := r.Config.ReadFromConfigMap(ctx, r.Client)
-
 		if err != nil {
 			if apierrs.IsNotFound(err) {
 				r.Log.Error(err, fmt.Sprintf(`ConfigMap not found {"controller": "Api"}, will use default config`))
@@ -118,7 +117,6 @@ func (r *APIRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 				r.Config.Reset()
 			}
 		}
-
 		if isCMReconcile {
 			return doneReconcile()
 		}

--- a/controllers/apirule_controller.go
+++ b/controllers/apirule_controller.go
@@ -38,8 +38,10 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 // APIRuleReconciler reconciles a APIRule object
@@ -203,7 +205,7 @@ func (r *APIRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 func (r *APIRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&gatewayv1beta1.APIRule{}).
-		Owns(&corev1.ConfigMap{}).
+		Watches(&source.Kind{Type: &corev1.ConfigMap{}}, &handler.EnqueueRequestForObject{}).
 		WithEventFilter(&configMapPredicate{Log: r.Log}).
 		Complete(r)
 }

--- a/controllers/apirule_controller.go
+++ b/controllers/apirule_controller.go
@@ -182,7 +182,7 @@ func (r *APIRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 func (r *APIRuleReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&gatewayv1beta1.APIRule{}).
-		For(&corev1.ConfigMap{}).
+		Owns(&corev1.ConfigMap{}).
 		WithEventFilter(&configMapPredicate{Log: r.Log}).
 		Complete(r)
 }

--- a/controllers/apirule_controller.go
+++ b/controllers/apirule_controller.go
@@ -89,8 +89,9 @@ func (p configMapPredicate) Generic(e event.GenericEvent) bool {
 		p.Log.Error(nil, "Generic event has no object", "event", e)
 		return false
 	}
-	configMap, ok := e.Object.(*corev1.ConfigMap)
-	return ok && configMap.GetNamespace() == CONFIGMAP_NS && configMap.GetName() == CONFIGMAP_NAME
+	_, okAP := e.Object.(*gatewayv1beta1.APIRule)
+	configMap, okCM := e.Object.(*corev1.ConfigMap)
+	return okAP || (okCM && configMap.GetNamespace() == CONFIGMAP_NS && configMap.GetName() == CONFIGMAP_NAME)
 }
 
 //+kubebuilder:rbac:groups=gateway.kyma-project.io,resources=apirules,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -2,6 +2,7 @@ package controllers_test
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 	"time"
@@ -11,6 +12,7 @@ import (
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	securityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
 	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -18,6 +20,7 @@ import (
 
 	gatewayv1beta1 "github.com/kyma-incubator/api-gateway/api/v1beta1"
 	"github.com/kyma-incubator/api-gateway/controllers"
+	"github.com/kyma-incubator/api-gateway/internal/helpers"
 	"github.com/kyma-incubator/api-gateway/internal/processing"
 
 	. "github.com/onsi/ginkgo"
@@ -104,6 +107,25 @@ var _ = BeforeSuite(func(done Done) {
 	err = c.Create(context.TODO(), ns)
 	Expect(err).NotTo(HaveOccurred())
 
+	nsKyma := &corev1.Namespace{
+		ObjectMeta: v1.ObjectMeta{Name: helpers.CM_NS},
+		Spec:       corev1.NamespaceSpec{},
+	}
+	err = c.Create(context.TODO(), nsKyma)
+	Expect(err).NotTo(HaveOccurred())
+
+	cm := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      helpers.CM_NAME,
+			Namespace: helpers.CM_NS,
+		},
+		Data: map[string]string{
+			helpers.CM_KEY: fmt.Sprintf("jwtHandler: %s", helpers.JWT_HANDLER_ORY),
+		},
+	}
+	err = c.Create(context.TODO(), cm)
+	Expect(err).NotTo(HaveOccurred())
+
 	apiReconciler := &controllers.APIRuleReconciler{
 		Client:            mgr.GetClient(),
 		Log:               ctrl.Log.WithName("controllers").WithName("Api"),
@@ -116,6 +138,7 @@ var _ = BeforeSuite(func(done Done) {
 			AllowHeaders: TestAllowHeaders,
 		},
 		GeneratedObjectsLabels: map[string]string{},
+		Config:                 &helpers.Config{},
 	}
 	Expect(err).NotTo(HaveOccurred())
 	var recFn reconcile.Reconciler

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -141,6 +141,7 @@ var _ = BeforeSuite(func(done Done) {
 		Config:                 &helpers.Config{},
 	}
 	Expect(err).NotTo(HaveOccurred())
+
 	var recFn reconcile.Reconciler
 	recFn, requests = SetupTestReconcile(apiReconciler)
 	Expect(add(mgr, recFn)).To(Succeed())

--- a/internal/builders/istio.go
+++ b/internal/builders/istio.go
@@ -2,6 +2,7 @@ package builders
 
 import (
 	"encoding/json"
+
 	gatewayv1beta1 "github.com/kyma-incubator/api-gateway/api/v1beta1"
 	"istio.io/api/security/v1beta1"
 	apiv1beta1 "istio.io/api/type/v1beta1"
@@ -288,8 +289,9 @@ func (jr *JwtRule) From(val []*gatewayv1beta1.Authenticator) *JwtRule {
 		authentications := &Authentications{
 			Authentications: []*Authentication{},
 		}
-		_ = json.Unmarshal(accessStrategy.Config.Raw, authentications)
-
+		if accessStrategy.Config != nil {
+			_ = json.Unmarshal(accessStrategy.Config.Raw, authentications)
+		}
 		for _, authentication := range authentications.Authentications {
 			*jr.value = append(*jr.value, &v1beta1.JWTRule{
 				Issuer:  authentication.Issuer,

--- a/internal/helpers/config.go
+++ b/internal/helpers/config.go
@@ -17,6 +17,10 @@ type Config struct {
 	JWTHandler string `yaml:"jwtHandler"`
 }
 
+func DefaultConfig() *Config {
+	return &Config{JWTHandler: JWT_HANDLER_ORY}
+}
+
 func LoadConfig() (*Config, error) {
 	configData, err := ReadFileHandle(CONFIG_FILE)
 	if err != nil {

--- a/internal/helpers/config.go
+++ b/internal/helpers/config.go
@@ -24,7 +24,7 @@ func ReadConfigMap(ctx context.Context, client client.Client) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return cm.BinaryData[CM_KEY], nil
+	return []byte(cm.Data[CM_KEY]), nil
 }
 
 var ReadConfigMapHandle = ReadConfigMap
@@ -46,11 +46,9 @@ func (c *Config) ReadFromConfigMap(ctx context.Context, client client.Client) er
 	if err != nil {
 		return err
 	}
-
 	err = yaml.Unmarshal(cmData, c)
 	if err != nil {
 		return err
 	}
-
 	return nil
 }

--- a/internal/validation/validate.go
+++ b/internal/validation/validate.go
@@ -44,12 +44,16 @@ type APIRule struct {
 	DefaultDomainName string
 }
 
+// Failure carries validation failures for a single attribute of an object.
+type Failure struct {
+	AttributePath string
+	Message       string
+}
+
 // Validate performs APIRule validation
 func (v *APIRule) Validate(api *gatewayv1beta1.APIRule, vsList networkingv1beta1.VirtualServiceList, config *helpers.Config) []Failure {
-
 	res := []Failure{}
 
-	res = append(res, v.validateConfig(config)...)
 	//Validate service on path level if it is created
 	if api.Spec.Service != nil {
 		res = append(res, v.validateService(".spec.service", api)...)
@@ -64,13 +68,7 @@ func (v *APIRule) Validate(api *gatewayv1beta1.APIRule, vsList networkingv1beta1
 	return res
 }
 
-// Failure carries validation failures for a single attribute of an object.
-type Failure struct {
-	AttributePath string
-	Message       string
-}
-
-func (v *APIRule) validateConfig(config *helpers.Config) []Failure {
+func (v *APIRule) ValidateConfig(config *helpers.Config) []Failure {
 	var problems []Failure
 
 	if config == nil {

--- a/internal/validation/validate_test.go
+++ b/internal/validation/validate_test.go
@@ -37,45 +37,33 @@ var (
 	config              = helpers.Config{JWTHandler: helpers.JWT_HANDLER_ORY}
 )
 
-var _ = Describe("Validate function", func() {
+var _ = Describe("ValidateConfig function", func() {
 
 	It("Should fail for missing config", func() {
 
-		//given
-		input := &gatewayv1beta1.APIRule{
-			Spec: gatewayv1beta1.APIRuleSpec{
-				Rules:   nil,
-				Service: getService(sampleServiceName, uint32(8080)),
-				Host:    getHost(sampleValidHost),
-			},
-		}
-
 		//when
-		problems := (&APIRule{}).Validate(input, networkingv1beta1.VirtualServiceList{}, nil)
+		problems := (&APIRule{}).ValidateConfig(nil)
 
 		//then
-		Expect(problems).To(HaveLen(2))
+		Expect(problems).To(HaveLen(1))
 		Expect(problems[0].Message).To(Equal("Configuration is missing"))
 	})
 
 	It("Should fail for wrong config", func() {
 
 		//given
-		input := &gatewayv1beta1.APIRule{
-			Spec: gatewayv1beta1.APIRuleSpec{
-				Rules:   nil,
-				Service: getService(sampleServiceName, uint32(8080)),
-				Host:    getHost(sampleValidHost),
-			},
-		}
+		input := &helpers.Config{JWTHandler: "foo"}
 
 		//when
-		problems := (&APIRule{}).Validate(input, networkingv1beta1.VirtualServiceList{}, &helpers.Config{JWTHandler: "foo"})
+		problems := (&APIRule{}).ValidateConfig(input)
 
 		//then
-		Expect(problems).To(HaveLen(2))
+		Expect(problems).To(HaveLen(1))
 		Expect(problems[0].Message).To(Equal("Unsupported JWT Handler: foo"))
 	})
+})
+
+var _ = Describe("Validate function", func() {
 
 	It("Should fail for empty rules", func() {
 

--- a/main.go
+++ b/main.go
@@ -44,6 +44,7 @@ import (
 	gatewayv1alpha1 "github.com/kyma-incubator/api-gateway/api/v1alpha1"
 	gatewayv1beta1 "github.com/kyma-incubator/api-gateway/api/v1beta1"
 	"github.com/kyma-incubator/api-gateway/controllers"
+	"github.com/kyma-incubator/api-gateway/internal/helpers"
 	"github.com/kyma-incubator/api-gateway/internal/processing"
 	"github.com/kyma-incubator/api-gateway/internal/validation"
 	"github.com/pkg/errors"
@@ -173,6 +174,7 @@ func main() {
 		},
 		GeneratedObjectsLabels: additionalLabels,
 		Scheme:                 mgr.GetScheme(),
+		Config:                 &helpers.Config{},
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "APIRule")
 		os.Exit(1)


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- default to `ory` if ConfigMap is missing
- move config validation in controller `reconcile()` before actually checking if is a new APIRule
- add watcher for the config map to APIRule controller (update event case)
- do not crash api-gateway pod, just log an error in controller logs and also set status of reconciled APIRule to error

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/api-gateway/issues/40