### PR TITLE
APIRule conversion failure for v1beta1 resource update on resources created in v1alpha1

### DIFF
--- a/api/v1beta1/apirule_types.go
+++ b/api/v1beta1/apirule_types.go
@@ -41,7 +41,7 @@ type APIRuleSpec struct {
 	Host *string `json:"host"`
 	// Definition of the service to expose
 	// +optional
-	Service *Service `json:"service"`
+	Service *Service `json:"service,omitempty"`
 	// Gateway to be used
 	// +kubebuilder:validation:Pattern=`^[0-9a-z-_]+(\/[0-9a-z-_]+|(\.[0-9a-z-_]+)*)$`
 	Gateway *string `json:"gateway"`
@@ -111,7 +111,7 @@ type Rule struct {
 	Path string `json:"path"`
 	// Definition of the service to expose, overwrites spec level service if defined
 	// +optional
-	Service *Service `json:"service"`
+	Service *Service `json:"service,omitempty"`
 	// Set of allowed HTTP methods
 	// +kubebuilder:validation:MinItems=1
 	Methods []string `json:"methods"`


### PR DESCRIPTION


<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
The version conversion for server-side apply of ApiRule v1alpha1 to v1beta1 failed with the error 
`The APIRule "my-rule" is invalid: spec.rules[0].service: Invalid value: "null": spec.rules[0].service in body must be of type object: "null"`

The reason for this was that the service field is defined as an object and was not set in the Go object. The default representation in JSON for an object that is not defined with omitempty is "null". This means that marshaling this object then resulted in a "null" value in the JSON, which led to an error during validation.

Changes proposed in this pull request:

- Add `omitempty` JSON tag to optional Service fields
- ...
- ...

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
- https://github.com/kyma-project/api-gateway/issues/50