### PR TITLE
Use aud claim instead of audiences

### DIFF
--- a/internal/processing/istio/audience_test.go
+++ b/internal/processing/istio/audience_test.go
@@ -73,8 +73,8 @@ var _ = Describe("JwtAuthorization Policy Processor", func() {
 		Expect(ap1).NotTo(BeNil())
 		Expect(ap1.Spec.Rules).To(HaveLen(1))
 		Expect(ap1.Spec.Rules[0].When).To(HaveLen(2))
-		Expect(ap1.Spec.Rules[0].When).To(ContainElement(builders.NewConditionBuilder().WithKey("request.auth.audiences").WithValues([]string{TestAudience1}).Get()))
-		Expect(ap1.Spec.Rules[0].When).To(ContainElement(builders.NewConditionBuilder().WithKey("request.auth.audiences").WithValues([]string{TestAudience2}).Get()))
+		Expect(ap1.Spec.Rules[0].When).To(ContainElement(builders.NewConditionBuilder().WithKey("request.auth.claims[aud]").WithValues([]string{TestAudience1}).Get()))
+		Expect(ap1.Spec.Rules[0].When).To(ContainElement(builders.NewConditionBuilder().WithKey("request.auth.claims[aud]").WithValues([]string{TestAudience2}).Get()))
 	})
 
 	It("should produce one AP for a rule with two scopes and two audiences", func() {
@@ -102,7 +102,7 @@ var _ = Describe("JwtAuthorization Policy Processor", func() {
 		Expect(ap1).NotTo(BeNil())
 		Expect(ap1.Spec.Rules).To(HaveLen(3))
 		Expect(ap1.Spec.Rules[0].When).To(HaveLen(4))
-		Expect(ap1.Spec.Rules[0].When).To(ContainElement(builders.NewConditionBuilder().WithKey("request.auth.audiences").WithValues([]string{TestAudience1}).Get()))
-		Expect(ap1.Spec.Rules[0].When).To(ContainElement(builders.NewConditionBuilder().WithKey("request.auth.audiences").WithValues([]string{TestAudience2}).Get()))
+		Expect(ap1.Spec.Rules[0].When).To(ContainElement(builders.NewConditionBuilder().WithKey("request.auth.claims[aud]").WithValues([]string{TestAudience1}).Get()))
+		Expect(ap1.Spec.Rules[0].When).To(ContainElement(builders.NewConditionBuilder().WithKey("request.auth.claims[aud]").WithValues([]string{TestAudience2}).Get()))
 	})
 })

--- a/internal/processing/istio/authorization_policy_processor.go
+++ b/internal/processing/istio/authorization_policy_processor.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	audienceKey string = "request.auth.audiences"
+	audienceKey string = "request.auth.claims[aud]"
 )
 
 var (


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
Istio AP validates requests based only on the first of presented JWT audiences when using `request.auth.audiences`. This doesn't cover our original Ory scenario. This however can be achieved by using `request.auth.claims[aud]`, as this will verify all JWT audiences, same as for scopes

Changes proposed in this pull request:

- Change `request.auth.audiences` to `request.auth.claims[aud]`
