### PR TITLE
add default http timeout value for virtual services

### DIFF
--- a/controllers/api_controller_integration_test.go
+++ b/controllers/api_controller_integration_test.go
@@ -679,12 +679,14 @@ var _ = Describe("APIRule Controller", func() {
 								Match(builders.MatchRequest().Uri().Regex("/img")).
 								Route(builders.RouteDestination().Host(testOathkeeperSvcURL).Port(testOathkeeperPort)).
 								Headers(builders.Headers().SetHostHeader(serviceHost)).
-								CorsPolicy(defaultCorsPolicy).Timeout(time.Second * helpers.DEFAULT_HTTP_TIMEOUT)).
+								CorsPolicy(defaultCorsPolicy).
+								Timeout(time.Second * helpers.DEFAULT_HTTP_TIMEOUT)).
 							HTTP(builders.HTTPRoute().
 								Match(builders.MatchRequest().Uri().Regex("/headers")).
 								Route(builders.RouteDestination().Host(testOathkeeperSvcURL).Port(testOathkeeperPort)).
 								Headers(builders.Headers().SetHostHeader(serviceHost)).
-								CorsPolicy(defaultCorsPolicy).Timeout(time.Second * helpers.DEFAULT_HTTP_TIMEOUT)).
+								CorsPolicy(defaultCorsPolicy).
+								Timeout(time.Second * helpers.DEFAULT_HTTP_TIMEOUT)).
 							HTTP(builders.HTTPRoute().
 								Match(builders.MatchRequest().Uri().Regex("/status")).
 								Route(builders.RouteDestination().Host(testOathkeeperSvcURL).Port(testOathkeeperPort)).

--- a/controllers/api_controller_integration_test.go
+++ b/controllers/api_controller_integration_test.go
@@ -184,7 +184,8 @@ var _ = Describe("APIRule Controller", func() {
 								Match(builders.MatchRequest().Uri().Regex(testPath)).
 								Route(builders.RouteDestination().Host(testOathkeeperSvcURL).Port(testOathkeeperPort)).
 								Headers(builders.Headers().SetHostHeader(serviceHost)).
-								CorsPolicy(defaultCorsPolicy))
+								CorsPolicy(defaultCorsPolicy).
+								Timeout(time.Second * helpers.DEFAULT_HTTP_TIMEOUT))
 
 						gotSpec := *expectedSpec.Get()
 						Expect(*vs.Spec.DeepCopy()).To(Equal(*gotSpec.DeepCopy()))
@@ -286,12 +287,14 @@ var _ = Describe("APIRule Controller", func() {
 									Match(builders.MatchRequest().Uri().Regex("/img")).
 									Route(builders.RouteDestination().Host(testOathkeeperSvcURL).Port(testOathkeeperPort)).
 									Headers(builders.Headers().SetHostHeader(serviceHost)).
-									CorsPolicy(defaultCorsPolicy)).
+									CorsPolicy(defaultCorsPolicy).
+									Timeout(time.Second * helpers.DEFAULT_HTTP_TIMEOUT)).
 								HTTP(builders.HTTPRoute().
 									Match(builders.MatchRequest().Uri().Regex("/headers")).
 									Route(builders.RouteDestination().Host(testOathkeeperSvcURL).Port(testOathkeeperPort)).
 									Headers(builders.Headers().SetHostHeader(serviceHost)).
-									CorsPolicy(defaultCorsPolicy))
+									CorsPolicy(defaultCorsPolicy).
+									Timeout(time.Second * helpers.DEFAULT_HTTP_TIMEOUT))
 							gotSpec := *expectedSpec.Get()
 							Expect(*vs.Spec.DeepCopy()).To(Equal(*gotSpec.DeepCopy()))
 
@@ -442,12 +445,14 @@ var _ = Describe("APIRule Controller", func() {
 									Match(builders.MatchRequest().Uri().Regex("/img")).
 									Route(builders.RouteDestination().Host(fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, testNamespace)).Port(testServicePort)).
 									Headers(builders.Headers().SetHostHeader(serviceHost)).
-									CorsPolicy(defaultCorsPolicy)).
+									CorsPolicy(defaultCorsPolicy).
+									Timeout(time.Second * helpers.DEFAULT_HTTP_TIMEOUT)).
 								HTTP(builders.HTTPRoute().
 									Match(builders.MatchRequest().Uri().Regex("/headers")).
 									Route(builders.RouteDestination().Host(fmt.Sprintf("%s.%s.svc.cluster.local", serviceName, testNamespace)).Port(testServicePort)).
 									Headers(builders.Headers().SetHostHeader(serviceHost)).
-									CorsPolicy(defaultCorsPolicy))
+									CorsPolicy(defaultCorsPolicy).
+									Timeout(time.Second * helpers.DEFAULT_HTTP_TIMEOUT))
 							gotSpec := *expectedSpec.Get()
 							Expect(*vs.Spec.DeepCopy()).To(Equal(*gotSpec.DeepCopy()))
 
@@ -674,22 +679,24 @@ var _ = Describe("APIRule Controller", func() {
 								Match(builders.MatchRequest().Uri().Regex("/img")).
 								Route(builders.RouteDestination().Host(testOathkeeperSvcURL).Port(testOathkeeperPort)).
 								Headers(builders.Headers().SetHostHeader(serviceHost)).
-								CorsPolicy(defaultCorsPolicy)).
+								CorsPolicy(defaultCorsPolicy).Timeout(time.Second * helpers.DEFAULT_HTTP_TIMEOUT)).
 							HTTP(builders.HTTPRoute().
 								Match(builders.MatchRequest().Uri().Regex("/headers")).
 								Route(builders.RouteDestination().Host(testOathkeeperSvcURL).Port(testOathkeeperPort)).
 								Headers(builders.Headers().SetHostHeader(serviceHost)).
-								CorsPolicy(defaultCorsPolicy)).
+								CorsPolicy(defaultCorsPolicy).Timeout(time.Second * helpers.DEFAULT_HTTP_TIMEOUT)).
 							HTTP(builders.HTTPRoute().
 								Match(builders.MatchRequest().Uri().Regex("/status")).
 								Route(builders.RouteDestination().Host(testOathkeeperSvcURL).Port(testOathkeeperPort)).
 								Headers(builders.Headers().SetHostHeader(serviceHost)).
-								CorsPolicy(defaultCorsPolicy)).
+								CorsPolicy(defaultCorsPolicy).
+								Timeout(time.Second * helpers.DEFAULT_HTTP_TIMEOUT)).
 							HTTP(builders.HTTPRoute().
 								Match(builders.MatchRequest().Uri().Regex("/favicon")).
 								Route(builders.RouteDestination().Host("httpbin.atgo-system.svc.cluster.local").Port(443)). // "allow", no oathkeeper rule!
 								Headers(builders.Headers().SetHostHeader(serviceHost)).
-								CorsPolicy(defaultCorsPolicy))
+								CorsPolicy(defaultCorsPolicy).
+								Timeout(time.Second * helpers.DEFAULT_HTTP_TIMEOUT))
 
 						gotSpec := *expectedSpec.Get()
 						Expect(*vs.Spec.DeepCopy()).To(Equal(*gotSpec.DeepCopy()))

--- a/controllers/apirule_controller.go
+++ b/controllers/apirule_controller.go
@@ -123,7 +123,7 @@ func (r *APIRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 	r.Log.Info("Checking if it's ConfigMap reconciliation")
 	r.Log.Info("Reconciling for", "namespacedName", req.NamespacedName.String())
-	isCMReconcile := (req.NamespacedName.String() == types.NamespacedName{Namespace: helpers.CM_NS, Name: helpers.CM_NAME}.String())
+	isCMReconcile := req.NamespacedName.String() == types.NamespacedName{Namespace: helpers.CM_NS, Name: helpers.CM_NAME}.String()
 	if isCMReconcile || r.Config.JWTHandler == "" {
 		r.Log.Info("Starting ConfigMap reconciliation")
 		err := r.Config.ReadFromConfigMap(ctx, r.Client)
@@ -149,14 +149,15 @@ func (r *APIRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	r.Log.Info("Starting ApiRule reconciliation")
 
 	c := processing.ReconciliationConfig{
-		OathkeeperSvc:     r.OathkeeperSvc,
-		OathkeeperSvcPort: r.OathkeeperSvcPort,
-		CorsConfig:        r.CorsConfig,
-		AdditionalLabels:  r.GeneratedObjectsLabels,
-		DefaultDomainName: r.DefaultDomainName,
-		ServiceBlockList:  r.ServiceBlockList,
-		DomainAllowList:   r.DomainAllowList,
-		HostBlockList:     r.HostBlockList,
+		OathkeeperSvc:       r.OathkeeperSvc,
+		OathkeeperSvcPort:   r.OathkeeperSvcPort,
+		CorsConfig:          r.CorsConfig,
+		AdditionalLabels:    r.GeneratedObjectsLabels,
+		DefaultDomainName:   r.DefaultDomainName,
+		ServiceBlockList:    r.ServiceBlockList,
+		DomainAllowList:     r.DomainAllowList,
+		HostBlockList:       r.HostBlockList,
+		HTTPTimeoutDuration: helpers.DEFAULT_HTTP_TIMEOUT,
 	}
 
 	cmd := r.getReconciliation(c)

--- a/internal/builders/virtual_service.go
+++ b/internal/builders/virtual_service.go
@@ -1,8 +1,10 @@
 package builders
 
 import (
+	"google.golang.org/protobuf/types/known/durationpb"
 	"istio.io/api/networking/v1beta1"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	"time"
 )
 
 // VirtualService returns builder for istio.io/client-go/pkg/apis/networking/v1beta1/VirtualService type
@@ -121,6 +123,11 @@ func (hr *httpRoute) CorsPolicy(cc *corsPolicy) *httpRoute {
 
 func (hr *httpRoute) Headers(hd *headers) *httpRoute {
 	hr.value.Headers = hd.Get()
+	return hr
+}
+
+func (hr *httpRoute) Timeout(value time.Duration) *httpRoute {
+	hr.value.Timeout = durationpb.New(value)
 	return hr
 }
 

--- a/internal/helpers/config.go
+++ b/internal/helpers/config.go
@@ -2,7 +2,6 @@ package helpers
 
 import (
 	"context"
-
 	"gopkg.in/yaml.v2"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -10,8 +9,9 @@ import (
 )
 
 const (
-	JWT_HANDLER_ORY   = "ory"
-	JWT_HANDLER_ISTIO = "istio"
+	JWT_HANDLER_ORY      = "ory"
+	JWT_HANDLER_ISTIO    = "istio"
+	DEFAULT_HTTP_TIMEOUT = 120
 
 	CM_NS   = "kyma-system"
 	CM_NAME = "api-gateway-config"

--- a/internal/processing/types.go
+++ b/internal/processing/types.go
@@ -59,12 +59,13 @@ type CorsConfig struct {
 }
 
 type ReconciliationConfig struct {
-	OathkeeperSvc     string
-	OathkeeperSvcPort uint32
-	CorsConfig        *CorsConfig
-	AdditionalLabels  map[string]string
-	DefaultDomainName string
-	ServiceBlockList  map[string][]string
-	DomainAllowList   []string
-	HostBlockList     []string
+	OathkeeperSvc       string
+	OathkeeperSvcPort   uint32
+	CorsConfig          *CorsConfig
+	AdditionalLabels    map[string]string
+	DefaultDomainName   string
+	ServiceBlockList    map[string][]string
+	DomainAllowList     []string
+	HostBlockList       []string
+	HTTPTimeoutDuration int
 }


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- added default http timeout value as 120s for virtual services created from an apirule

Followup Task: To make this value configurable either via configmap or through the CRD

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/api-gateway/issues/169