### PR TITLE
Add custom domain integration script

### DIFF
--- a/tests/integration/env_vars_custom_domain.sh
+++ b/tests/integration/env_vars_custom_domain.sh
@@ -17,23 +17,26 @@ if [[ -z ${TEST_SA_ACCESS_KEY_PATH} ]]; then
   exit 2
 fi
 
-if [[ -z ${TEST_OIDC_ISSUER_URL} ]]; then
-  >&2 echo "Environment variable TEST_OIDC_ISSUER_URL is required but not set"
+if [[ -z ${OIDC_ISSUER_URL} ]]; then
+  >&2 echo "Environment variable OIDC_ISSUER_URL is required but not set"
   exit 2
 fi
 
-if [[ -z ${TEST_CLIENT_ID} ]]; then
-  >&2 echo "Environment variable TEST_CLIENT_ID is required but not set"
+if [[ -z ${CLIENT_ID} ]]; then
+  >&2 echo "Environment variable CLIENT_ID is required but not set"
   exit 2
 fi
 
-if [[ -z ${TEST_CLIENT_SECRET} ]]; then
-  >&2 echo "Environment variable TEST_CLIENT_SECRET is required but not set"
+if [[ -z ${CLIENT_SECRET} ]]; then
+  >&2 echo "Environment variable CLIENT_SECRET is required but not set"
   exit 2
 fi
 
+export TEST_OIDC_ISSUER_URL="${OIDC_ISSUER_URL}"
+export TEST_CLIENT_ID="${CLIENT_ID}"
+export TEST_CLIENT_SECRET="${CLIENT_SECRET}"
 export TEST_REQUEST_TIMEOUT="180"
 export TEST_REQUEST_DELAY="2"
 export TEST_CLIENT_TIMEOUT=30s
-export TEST_CONCURENCY="1"
+export TEST_CONCURRENCY="1"
 export EXPORT_RESULT="true"

--- a/tests/integration/scenario_custom_domain_test.go
+++ b/tests/integration/scenario_custom_domain_test.go
@@ -134,8 +134,8 @@ func (c *CustomDomainScenario) thereIsAnCloudCredentialsSecret(secretName string
 func (c *CustomDomainScenario) isDNSReady() error {
 	err := wait.ExponentialBackoff(wait.Backoff{
 		Duration: time.Second,
-		Factor:   10,
-		Steps:    5,
+		Factor:   2,
+		Steps:    10,
 	}, func() (done bool, err error) {
 		testName := generateRandomString(3)
 		ips, err := net.LookupIP(fmt.Sprintf("%s.%s.%s", testName, c.testID, c.domain))

--- a/tests/integration/scenario_custom_domain_test.go
+++ b/tests/integration/scenario_custom_domain_test.go
@@ -134,7 +134,7 @@ func (c *CustomDomainScenario) thereIsAnCloudCredentialsSecret(secretName string
 func (c *CustomDomainScenario) isDNSReady() error {
 	err := wait.ExponentialBackoff(wait.Backoff{
 		Duration: time.Second,
-		Factor:   2,
+		Factor:   10,
 		Steps:    5,
 	}, func() (done bool, err error) {
 		testName := generateRandomString(3)

--- a/tests/integration/scripts/integration-gardener-custom-domain.sh
+++ b/tests/integration/scripts/integration-gardener-custom-domain.sh
@@ -1,0 +1,78 @@
+##!/usr/bin/env bash
+#
+##Description: This scripts installs and test api-gateway custom domain test using the CLI on a real Gardener GCP cluster.
+## exit on error, and raise error when variable is not set when used
+set -e
+
+cleanup() {
+kubectl annotate shoot "${CLUSTER_NAME}" confirmation.gardener.cloud/deletion=true \
+    --overwrite \
+    -n "garden-${GARDENER_KYMA_PROW_PROJECT_NAME}" \
+    --kubeconfig "${GARDENER_KYMA_PROW_KUBECONFIG}"
+
+kubectl delete shoot "${CLUSTER_NAME}" \
+  --wait="false" \
+  --kubeconfig "${GARDENER_KYMA_PROW_KUBECONFIG}" \
+  -n "garden-${GARDENER_KYMA_PROW_PROJECT_NAME}"
+}
+
+# Cleanup on exit, be it successful or on fail
+trap cleanup EXIT INT
+
+# wait for build job
+JOB_NAME_PATTERN="rel-.*-build" ./tests/integration/scripts/jobguard.sh
+
+# Install Kyma CLI in latest version
+echo "--> Install kyma CLI locally to /tmp/bin"
+curl -Lo kyma.tar.gz "https://github.com/kyma-project/cli/releases/latest/download/kyma_linux_x86_64.tar.gz" \
+&& tar -zxvf kyma.tar.gz && chmod +x kyma \
+&& rm -f kyma.tar.gz
+chmod +x kyma
+# Add pwd to path to be able to use Kyma binary
+export PATH="${PATH}:${PWD}"
+kyma version --client
+
+# Provision gardener cluster
+CLUSTER_NAME=$(LC_ALL=C tr -dc 'a-z' < /dev/urandom | head -c10)
+GARDENER_REGION="europe-west4"
+GARDENER_ZONES="europe-west4-b"
+kyma provision gardener gcp \
+        --secret "${GARDENER_KYMA_PROW_PROVIDER_SECRET_NAME}" \
+        --name "${CLUSTER_NAME}" \
+        --project "${GARDENER_KYMA_PROW_PROJECT_NAME}" \
+        --credentials "${GARDENER_KYMA_PROW_KUBECONFIG}" \
+        --region "${GARDENER_REGION}" \
+        -z "${GARDENER_ZONES}" \
+        -t "n1-standard-4" \
+        --scaler-max 3 \
+        --scaler-min 1 \
+        --kube-version="${GARDENER_CLUSTER_VERSION}" \
+        --attempts 1 \
+        --verbose
+
+echo "sleeping for 60 seconds..." && sleep 60
+# KYMA_DOMAIN is required by the tests
+export TEST_DOMAIN="${CLUSTER_NAME}.${GARDENER_KYMA_PROW_PROJECT_NAME}.shoot.live.k8s-hana.ondemand.com"
+export TEST_CUSTOM_DOMAIN="a.build.kyma-project.io"
+
+cat <<EOF > patch.yaml
+spec:
+  extensions:
+    - type: shoot-dns-service
+      providerConfig:
+        apiVersion: service.dns.extensions.gardener.cloud/v1alpha1
+        dnsProviderReplication:
+          enabled: true
+        kind: DNSConfig
+        syncProvidersFromShootSpecDNS: true
+    - type: shoot-cert-service
+      providerConfig:
+        apiVersion: service.cert.extensions.gardener.cloud/v1alpha1
+        kind: CertConfig
+        shootIssuers:
+          enabled: true
+EOF
+kubectl patch shoot "$CLUSTER_NAME" --patch-file patch.yaml --kubeconfig "${GARDENER_KYMA_PROW_KUBECONFIG}"
+make install-kyma
+echo "Sleeping for 60 seconds..." && sleep 60
+make test-custom-domain


### PR DESCRIPTION
/kind feature
/area ci

Added custom domain integration script that, much similar to standard integration script:
* provisions gardener cluster
* patches gardener shoot to enable Cert issuer extension
* Adds volatile secret to a cluster for managing DNS entries
* Install needed kyma components
* runs custom domain test

Some small changes had to be made:
* Increased factor timeout in `isDNSReady()` function to reduce flakiness of a test
* Adjusted `env_vars_custom_domain.sh` script to be aligned with `env_vars.sh` so re-using the same credentials is possible
* Had to add additional sleeps to reduce flakiness of the test, because Gardener clusters are so slow to provision and even if the APIServer is up, then not always it's possible to actually operate on a cluster
