### PR TITLE
Update dependabot config to ignore istio packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,7 +16,7 @@ updates:
         patterns:
           - "k8s.io/*"
     ignore:
-      # We want to ignore Istio PRs because the update cycle is tied to the release of the Istio module and PRs can therefore be open for a long time.
+      # We want to ignore Istio dependencies because the update cycle is tied to the release of the Istio module and PRs can therefore be open for a long time.
       - dependency-name: "istio.io/client-go"
       - dependency-name: "istio.io/api"
 
@@ -50,7 +50,7 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
-      # We want to ignore Istio PRs because the update cycle is tied to the release of the Istio module and PRs can therefore be open for a long time.
+      # We want to ignore Istio dependencies because the update cycle is tied to the release of the Istio module and PRs can therefore be open for a long time.
       - dependency-name: "istio.io/client-go"
       - dependency-name: "istio.io/api"
 

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,11 @@ updates:
       k8s-dependencies:
         patterns:
           - "k8s.io/*"
+    ignore:
+      # We want to ignore Istio PRs because the update cycle is tied to the release of the Istio module and PRs can therefore be open for a long time.
+      - dependency-name: "istio.io/client-go"
+      - dependency-name: "istio.io/api"
+
   - package-ecosystem: "docker"
     directory: "/"
     labels:
@@ -26,7 +31,7 @@ updates:
       prefix: "docker"
       include: "scope"
 
-# release branch  configuration
+# release branch configuration
   - package-ecosystem: "gomod"
     directory: "/"
     target-branch: "release-2.0"
@@ -45,6 +50,10 @@ updates:
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major", "version-update:semver-minor"]
+      # We want to ignore Istio PRs because the update cycle is tied to the release of the Istio module and PRs can therefore be open for a long time.
+      - dependency-name: "istio.io/client-go"
+      - dependency-name: "istio.io/api"
+
   - package-ecosystem: "docker"
     target-branch: "release-2.0"
     directory: "/"

--- a/.github/workflows/vulnerabilities-check.yaml
+++ b/.github/workflows/vulnerabilities-check.yaml
@@ -16,7 +16,7 @@ jobs:
     - name: vulncheck
       uses: golang/govulncheck-action@7da72f730e37eeaad891fcff0a532d27ed737cd4
       with:
-        go-version-input: 1.21.3
+        go-version-input: 1.21.4
         go-package: ./...
   slack_failed_notification:
     name: Slack Notification


### PR DESCRIPTION

<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Update dependabot config to ignore istio packages, since we neever used this PRs in the past. We often did it manually after the Istio module release. In the current form the PRs might stay open for very long time. Also the version might not be correct, e.g. if we skip an Istio version.
- Update go version for vulnerability check.

**Related issue(s)**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->