### PR TITLE
Use warning instead of error on duplicate APIGateway CRs

### DIFF
--- a/controllers/operator/apigateway_controller.go
+++ b/controllers/operator/apigateway_controller.go
@@ -93,7 +93,7 @@ func (r *APIGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		oldestCr := r.getOldestCR(existingAPIGateways)
 		if apiGatewayCR.GetUID() != oldestCr.GetUID() {
 			err := fmt.Errorf("stopped APIGateway CR reconciliation: only APIGateway CR %s reconciles the module", oldestCr.GetName())
-			return r.terminateReconciliation(ctx, apiGatewayCR, controllers.ErrorStatus(err, err.Error()))
+			return r.terminateReconciliation(ctx, apiGatewayCR, controllers.WarningStatus(err, err.Error()))
 		}
 	}
 

--- a/controllers/operator/apigateway_controller_integration_test.go
+++ b/controllers/operator/apigateway_controller_integration_test.go
@@ -62,9 +62,15 @@ var _ = Describe("API Gateway Controller", Serial, func() {
 					Name: generateName(),
 				},
 			}
+			apiGateway2 := v1alpha1.APIGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: generateName(),
+				},
+			}
 
 			// when
 			Expect(k8sClient.Create(context.Background(), &apiGateway)).Should(Succeed())
+			Expect(k8sClient.Create(context.Background(), &apiGateway2)).Should(Succeed())
 
 			// then
 			Eventually(func(g Gomega) {
@@ -73,25 +79,13 @@ var _ = Describe("API Gateway Controller", Serial, func() {
 				g.Expect(created.ObjectMeta.Finalizers).To(HaveLen(1))
 				g.Expect(created.ObjectMeta.Finalizers[0]).To(Equal(ApiGatewayFinalizer))
 				g.Expect(created.Status.State).To(Equal(v1alpha1.Ready))
-			}, eventuallyTimeout).Should(Succeed())
 
-			// when
-			apiGateway2 := v1alpha1.APIGateway{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: generateName(),
-				},
-			}
-
-			Expect(k8sClient.Create(context.Background(), &apiGateway2)).Should(Succeed())
-
-			// then
-			Eventually(func(g Gomega) {
-				created := v1alpha1.APIGateway{}
-				g.Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: apiGateway2.Name}, &created)).Should(Succeed())
-				g.Expect(created.ObjectMeta.Finalizers).To(HaveLen(1))
-				g.Expect(created.ObjectMeta.Finalizers[0]).To(Equal(ApiGatewayFinalizer))
-				g.Expect(created.Status.State).To(Equal(v1alpha1.Warning))
-				g.Expect(created.Status.Description).To(Equal("There are APIGateway(s) that block the creation of API-Gateway CR. Please take a look at kyma-system/api-gateway-controller-manager logs to see more information about the warning"))
+				created2 := v1alpha1.APIGateway{}
+				g.Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: apiGateway2.Name}, &created2)).Should(Succeed())
+				g.Expect(created2.ObjectMeta.Finalizers).To(HaveLen(1))
+				g.Expect(created2.ObjectMeta.Finalizers[0]).To(Equal(ApiGatewayFinalizer))
+				g.Expect(created2.Status.State).To(Equal(v1alpha1.Warning))
+				g.Expect(created2.Status.Description).To(Equal("There are APIGateway(s) that block the creation of API-Gateway CR. Please take a look at kyma-system/api-gateway-controller-manager logs to see more information about the warning"))
 			}, eventuallyTimeout).Should(Succeed())
 
 			Expect(k8sClient.Delete(context.Background(), &apiGateway)).Should(Succeed())

--- a/controllers/operator/apigateway_controller_integration_test.go
+++ b/controllers/operator/apigateway_controller_integration_test.go
@@ -84,10 +84,9 @@ var _ = Describe("API Gateway Controller", Serial, func() {
 			Eventually(func(g Gomega) {
 				created := v1alpha1.APIGateway{}
 				g.Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: apiGateway2.Name}, &created)).Should(Succeed())
-				g.Expect(created.ObjectMeta.Finalizers).To(HaveLen(1))
-				g.Expect(created.ObjectMeta.Finalizers[0]).To(Equal(ApiGatewayFinalizer))
+				g.Expect(created.ObjectMeta.Finalizers).To(HaveLen(0))
 				g.Expect(created.Status.State).To(Equal(v1alpha1.Warning))
-				g.Expect(created.Status.Description).To(Equal("There are APIGateway(s) that block the creation of API-Gateway CR. Please take a look at kyma-system/api-gateway-controller-manager logs to see more information about the warning"))
+				g.Expect(created.Status.Description).To(Equal(fmt.Sprintf("stopped APIGateway CR reconciliation: only APIGateway CR %s reconciles the module", apiGateway.Name)))
 			}, eventuallyTimeout).Should(Succeed())
 
 			Expect(k8sClient.Delete(context.Background(), &apiGateway)).Should(Succeed())

--- a/controllers/operator/apigateway_controller_integration_test.go
+++ b/controllers/operator/apigateway_controller_integration_test.go
@@ -55,6 +55,49 @@ var _ = Describe("API Gateway Controller", Serial, func() {
 			Expect(k8sClient.Delete(context.Background(), &apiGateway)).Should(Succeed())
 		})
 
+		It("Should set ready state on first APIGateway CR and warning on second APIGateway CR when reconciliation succeeds", func() {
+			// given
+			apiGateway := v1alpha1.APIGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: generateName(),
+				},
+			}
+
+			// when
+			Expect(k8sClient.Create(context.Background(), &apiGateway)).Should(Succeed())
+
+			// then
+			Eventually(func(g Gomega) {
+				created := v1alpha1.APIGateway{}
+				g.Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: apiGateway.Name}, &created)).Should(Succeed())
+				g.Expect(created.ObjectMeta.Finalizers).To(HaveLen(1))
+				g.Expect(created.ObjectMeta.Finalizers[0]).To(Equal(ApiGatewayFinalizer))
+				g.Expect(created.Status.State).To(Equal(v1alpha1.Ready))
+			}, eventuallyTimeout).Should(Succeed())
+
+			// when
+			apiGateway2 := v1alpha1.APIGateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: generateName(),
+				},
+			}
+
+			Expect(k8sClient.Create(context.Background(), &apiGateway2)).Should(Succeed())
+
+			// then
+			Eventually(func(g Gomega) {
+				created := v1alpha1.APIGateway{}
+				g.Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: apiGateway2.Name}, &created)).Should(Succeed())
+				g.Expect(created.ObjectMeta.Finalizers).To(HaveLen(1))
+				g.Expect(created.ObjectMeta.Finalizers[0]).To(Equal(ApiGatewayFinalizer))
+				g.Expect(created.Status.State).To(Equal(v1alpha1.Warning))
+				g.Expect(created.Status.Description).To(Equal("There are APIGateway(s) that block the creation of API-Gateway CR. Please take a look at kyma-system/api-gateway-controller-manager logs to see more information about the warning"))
+			}, eventuallyTimeout).Should(Succeed())
+
+			Expect(k8sClient.Delete(context.Background(), &apiGateway)).Should(Succeed())
+			Expect(k8sClient.Delete(context.Background(), &apiGateway2)).Should(Succeed())
+		})
+
 		It("Should delete APIGateway CR when there are no blocking resources", func() {
 			// given
 			apiGateway := v1alpha1.APIGateway{

--- a/controllers/operator/apigateway_controller_integration_test.go
+++ b/controllers/operator/apigateway_controller_integration_test.go
@@ -70,22 +70,24 @@ var _ = Describe("API Gateway Controller", Serial, func() {
 
 			// when
 			Expect(k8sClient.Create(context.Background(), &apiGateway)).Should(Succeed())
-			Expect(k8sClient.Create(context.Background(), &apiGateway2)).Should(Succeed())
-
-			// then
 			Eventually(func(g Gomega) {
 				created := v1alpha1.APIGateway{}
 				g.Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: apiGateway.Name}, &created)).Should(Succeed())
 				g.Expect(created.ObjectMeta.Finalizers).To(HaveLen(1))
 				g.Expect(created.ObjectMeta.Finalizers[0]).To(Equal(ApiGatewayFinalizer))
 				g.Expect(created.Status.State).To(Equal(v1alpha1.Ready))
+			}, eventuallyTimeout).Should(Succeed())
 
-				created2 := v1alpha1.APIGateway{}
-				g.Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: apiGateway2.Name}, &created2)).Should(Succeed())
-				g.Expect(created2.ObjectMeta.Finalizers).To(HaveLen(1))
-				g.Expect(created2.ObjectMeta.Finalizers[0]).To(Equal(ApiGatewayFinalizer))
-				g.Expect(created2.Status.State).To(Equal(v1alpha1.Warning))
-				g.Expect(created2.Status.Description).To(Equal("There are APIGateway(s) that block the creation of API-Gateway CR. Please take a look at kyma-system/api-gateway-controller-manager logs to see more information about the warning"))
+			Expect(k8sClient.Create(context.Background(), &apiGateway2)).Should(Succeed())
+
+			// then
+			Eventually(func(g Gomega) {
+				created := v1alpha1.APIGateway{}
+				g.Expect(k8sClient.Get(context.Background(), client.ObjectKey{Name: apiGateway2.Name}, &created)).Should(Succeed())
+				g.Expect(created.ObjectMeta.Finalizers).To(HaveLen(1))
+				g.Expect(created.ObjectMeta.Finalizers[0]).To(Equal(ApiGatewayFinalizer))
+				g.Expect(created.Status.State).To(Equal(v1alpha1.Warning))
+				g.Expect(created.Status.Description).To(Equal("There are APIGateway(s) that block the creation of API-Gateway CR. Please take a look at kyma-system/api-gateway-controller-manager logs to see more information about the warning"))
 			}, eventuallyTimeout).Should(Succeed())
 
 			Expect(k8sClient.Delete(context.Background(), &apiGateway)).Should(Succeed())

--- a/controllers/operator/apigateway_controller_test.go
+++ b/controllers/operator/apigateway_controller_test.go
@@ -177,7 +177,7 @@ var _ = Describe("API-Gateway Controller", func() {
 			Expect(result.Requeue).To(BeFalse())
 
 			Expect(c.Get(context.Background(), client.ObjectKeyFromObject(secondApiGatewayCR), secondApiGatewayCR)).Should(Succeed())
-			Expect(secondApiGatewayCR.Status.State).To(Equal(operatorv1alpha1.Error))
+			Expect(secondApiGatewayCR.Status.State).To(Equal(operatorv1alpha1.Warning))
 			Expect(secondApiGatewayCR.Status.Description).To(Equal(fmt.Sprintf("stopped APIGateway CR reconciliation: only APIGateway CR %s reconciles the module", apiGatewayCRName)))
 
 		})

--- a/tests/integration/testsuites/gateway/features/kyma_gateway.feature
+++ b/tests/integration/testsuites/gateway/features/kyma_gateway.feature
@@ -48,6 +48,6 @@ Feature: Checking default kyma gateway
 
   Scenario: Second APIGateway CR is applied to the cluster
     When APIGateway CR "second-api-gateway-cr" is applied
-    Then Custom APIGateway CR "second-api-gateway-cr" is in "Error" state with description "stopped APIGateway CR reconciliation: only APIGateway CR default reconciles the module"
+    Then Custom APIGateway CR "second-api-gateway-cr" is in "Warning" state with description "stopped APIGateway CR reconciliation: only APIGateway CR default reconciles the module"
     And APIGateway CR is in "Ready" state with description ""
     And APIGateway CR "second-api-gateway-cr" is removed


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Use warning status when there is more than one APIGateway CR

**Related issues**
#879 