### PR TITLE
Fix gardenlinux image version

### DIFF
--- a/tests/integration/scripts/custom-domain-gardener-aws-gh.sh
+++ b/tests/integration/scripts/custom-domain-gardener-aws-gh.sh
@@ -17,6 +17,6 @@ export GARDENER_ZONES="eu-west-1b,eu-west-1c,eu-west-1a"
 export GARDENER_PROVIDER_SECRET_NAME="aws-gardener-access"
 export GARDENER_PROJECT_NAME="goatz"
 export GARDENER_CLUSTER_VERSION="1.27.8"
-export GARDENER_GARDENLINUX_VERSION="gardenlinux:1312.3.0"
+export GARDENER_GARDENLINUX_VERSION="1312.3.0"
 
 ./tests/integration/scripts/custom-domain-gardener-gh.sh

--- a/tests/integration/scripts/custom-domain-gardener-gcp-gh.sh
+++ b/tests/integration/scripts/custom-domain-gardener-gcp-gh.sh
@@ -17,6 +17,6 @@ export GARDENER_ZONES="europe-west3-c,europe-west3-b,europe-west3-a"
 export GARDENER_PROVIDER_SECRET_NAME="goat"
 export GARDENER_PROJECT_NAME="goatz"
 export GARDENER_CLUSTER_VERSION="1.27.8"
-export GARDENER_GARDENLINUX_VERSION="gardenlinux:1312.3.0"
+export GARDENER_GARDENLINUX_VERSION="1312.3.0"
 
 ./tests/integration/scripts/custom-domain-gardener-gh.sh


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Use proper version instead of full name

As in: https://github.com/kyma-project/cli/blob/b160f58672b18703783e0045abc91fccb8ea5580/cmd/kyma/provision/cmd.go#L9