### PR TITLE
bug: ignore NoKindMatch error in oathkeeper reconciliation

### DIFF
--- a/controllers/operator/apigateway_controller.go
+++ b/controllers/operator/apigateway_controller.go
@@ -268,7 +268,7 @@ func oryRulesExist(ctx context.Context, k8sClient client.Client) ([]string, erro
 	})
 
 	err := k8sClient.List(ctx, &oryRulesList)
-	if err != nil && meta.IsNoMatchError(err) {
+	if meta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
 		// Oathkeeper CRD does not exist, there are no blocking rules
 		return nil, nil
 	}

--- a/controllers/operator/apigateway_controller.go
+++ b/controllers/operator/apigateway_controller.go
@@ -18,13 +18,14 @@ package operator
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"github.com/kyma-project/api-gateway/internal/conditions"
 	"k8s.io/apimachinery/pkg/api/meta"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"strings"
+
+	oryv1alpha1 "github.com/ory/oathkeeper-maester/api/v1alpha1"
+
+	"errors"
 
 	"github.com/kyma-project/api-gateway/apis/gateway/v1beta1"
 	"github.com/kyma-project/api-gateway/apis/operator/v1alpha1"
@@ -242,13 +243,17 @@ func (r *APIGatewayReconciler) reconcileFinalizer(ctx context.Context, apiGatewa
 func apiRulesExist(ctx context.Context, k8sClient client.Client) ([]string, error) {
 	apiRuleList := v1beta1.APIRuleList{}
 	err := k8sClient.List(ctx, &apiRuleList)
+	if meta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
+		// ApiRule CRD does not exist, there are no blocking rules
+		return nil, nil
+	}
 	if err != nil {
 		return nil, err
 	}
 	ctrl.Log.Info(fmt.Sprintf("There are %d APIRule(s) found on cluster", len(apiRuleList.Items)))
 	var blockingApiRules []string
 	for _, rule := range apiRuleList.Items {
-		blocking := rule.Kind + "/" + rule.GetName()
+		blocking := rule.GetNamespace() + "/" + rule.GetName()
 		ctrl.Log.Info("APIRule blocking deletion", "rule", blocking)
 		if len(blockingApiRules) < 5 {
 			blockingApiRules = append(blockingApiRules, blocking)
@@ -258,15 +263,7 @@ func apiRulesExist(ctx context.Context, k8sClient client.Client) ([]string, erro
 }
 
 func oryRulesExist(ctx context.Context, k8sClient client.Client) ([]string, error) {
-	// To prevent reconciliation errors during Oathkeeper uninstallation, which arise from the absence of the Oathkeeper CRD,
-	// we exclude calls to the rules from utilizing the cache. This can be achieved by using unstructured objects, as they are excluded from caching.
-	oryRulesList := unstructured.UnstructuredList{}
-	oryRulesList.SetGroupVersionKind(schema.GroupVersionKind{
-		Group:   "oathkeeper.ory.sh",
-		Version: "v1alpha1",
-		Kind:    "rule",
-	})
-
+	oryRulesList := oryv1alpha1.RuleList{}
 	err := k8sClient.List(ctx, &oryRulesList)
 	if meta.IsNoMatchError(err) || apierrors.IsNotFound(err) {
 		// Oathkeeper CRD does not exist, there are no blocking rules
@@ -279,7 +276,7 @@ func oryRulesExist(ctx context.Context, k8sClient client.Client) ([]string, erro
 	ctrl.Log.Info(fmt.Sprintf("There are %d ORY Oathkeeper Rule(s) found on cluster", len(oryRulesList.Items)))
 	var blockingOryRules []string
 	for _, rule := range oryRulesList.Items {
-		blocking := rule.GetKind() + "/" + rule.GetName()
+		blocking := rule.GetNamespace() + "/" + rule.GetName()
 		ctrl.Log.Info("ORY Oathkeeper rule blocking deletion", "rule", blocking)
 		if len(blockingOryRules) < 5 {
 			blockingOryRules = append(blockingOryRules, blocking)

--- a/controllers/operator/apigateway_controller_test.go
+++ b/controllers/operator/apigateway_controller_test.go
@@ -5,9 +5,6 @@ import (
 	goerrors "errors"
 	"fmt"
 	"github.com/kyma-project/api-gateway/internal/conditions"
-	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"time"
 
 	"github.com/go-logr/logr"
@@ -305,7 +302,7 @@ var _ = Describe("API-Gateway Controller", func() {
 
 			Expect(apiGatewayCR.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
 				"Type":    Equal(conditions.DeletionBlockedExistingResources.Condition().Type),
-				"Message": Equal("API Gateway deletion blocked because of the existing custom resources: APIRule/api-rule-0, APIRule/api-rule-1, APIRule/api-rule-2, APIRule/api-rule-3, APIRule/api-rule-4"),
+				"Message": Equal("API Gateway deletion blocked because of the existing custom resources: default/api-rule-0, default/api-rule-1, default/api-rule-2, default/api-rule-3, default/api-rule-4"),
 				"Status":  Equal(metav1.ConditionFalse),
 			})))
 		})
@@ -324,19 +321,12 @@ var _ = Describe("API-Gateway Controller", func() {
 			var rules []client.Object
 			for i := 0; i < 6; i++ {
 				// we initialize more than 5 objects, so we validate if we show only 5 in a condition
-				oryRule, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&oryv1alpha1.Rule{
+				r := &oryv1alpha1.Rule{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:      fmt.Sprintf("ory-rule-%d", i),
 						Namespace: "default",
 					},
-				})
-				Expect(err).ToNot(HaveOccurred())
-				r := &unstructured.Unstructured{Object: oryRule}
-				r.SetGroupVersionKind(schema.GroupVersionKind{
-					Group:   "oathkeeper.ory.sh",
-					Version: "v1alpha1",
-					Kind:    "rule",
-				})
+				}
 
 				rules = append(rules, r)
 			}
@@ -363,7 +353,7 @@ var _ = Describe("API-Gateway Controller", func() {
 
 			Expect(apiGatewayCR.Status.Conditions).To(ContainElement(MatchFields(IgnoreExtras, Fields{
 				"Type":    Equal(conditions.DeletionBlockedExistingResources.Condition().Type),
-				"Message": Equal("API Gateway deletion blocked because of the existing custom resources: rule/ory-rule-0, rule/ory-rule-1, rule/ory-rule-2, rule/ory-rule-3, rule/ory-rule-4"),
+				"Message": Equal("API Gateway deletion blocked because of the existing custom resources: default/ory-rule-0, default/ory-rule-1, default/ory-rule-2, default/ory-rule-3, default/ory-rule-4"),
 				"Status":  Equal(metav1.ConditionFalse),
 			})))
 		})


### PR DESCRIPTION
/kind bug
/area api-gateway

When Oathkeeper managed rule CRDs are removed there is nothing to List in oryRuleExist function.
If that happens, ignore the error and return nil