### PR TITLE
Revert "Bump golangci/golangci-lint-action from 4.0.0 to 5.1.0 (#1035)"

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -35,7 +35,7 @@ jobs:
           go-version-file: 'go.mod'
           cache: false # We need to disable caching here, since this is handled by the golangci-lint action
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@9d1e0624a798bb64f6c3cea93db47765312263dc #v5.1.0
+        uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804 #v4.0.0
         with:
           version: 'latest'
           args: --timeout=10m --verbose


### PR DESCRIPTION
This reverts commit 61322abc649c3733b721f715d3a8004c22e79295.

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Revert "Bump golangci/golangci-lint-action from 4.0.0 to 5.1.0 (#1035)"
