### PR TITLE
Add rules validation for v2alpha1

### DIFF
--- a/controllers/gateway/config_map.go
+++ b/controllers/gateway/config_map.go
@@ -14,7 +14,6 @@ const (
 )
 
 func (r *APIRuleReconciler) reconcileConfigMap(ctx context.Context, isCMReconcile bool) (finishReconciliation bool) {
-	r.Log.Info("Starting ConfigMap reconciliation")
 	err := r.Config.ReadFromConfigMap(ctx, r.Client)
 	if err != nil {
 		if apierrs.IsNotFound(err) {
@@ -25,7 +24,9 @@ func (r *APIRuleReconciler) reconcileConfigMap(ctx context.Context, isCMReconcil
 			r.Config.Reset()
 		}
 	}
+
 	if isCMReconcile {
+		r.Log.Info("Starting ConfigMap reconciliation")
 		configValidationFailures := validation.ValidateConfig(r.Config)
 		r.Log.Info("ConfigMap changed", "config", r.Config)
 		if len(configValidationFailures) > 0 {

--- a/internal/validation/injection.go
+++ b/internal/validation/injection.go
@@ -19,7 +19,7 @@ func NewInjectionValidator(ctx context.Context, client client.Client) *Injection
 	return &InjectionValidator{Ctx: ctx, Client: client}
 }
 
-func (v *InjectionValidator) Validate(attributePath string, selector *apiv1beta1.WorkloadSelector, namespace string) (problems []Failure, err error) {
+func (v *InjectionValidator) Validate(attributePath string, selector *apiv1beta1.WorkloadSelector, workloadNamespace string) (problems []Failure, err error) {
 	if selector == nil {
 		problems = append(problems, Failure{
 			AttributePath: attributePath + ".injection",
@@ -30,7 +30,7 @@ func (v *InjectionValidator) Validate(attributePath string, selector *apiv1beta1
 	}
 
 	var podList corev1.PodList
-	err = v.Client.List(v.Ctx, &podList, client.InNamespace(namespace), client.MatchingLabels(selector.MatchLabels))
+	err = v.Client.List(v.Ctx, &podList, client.InNamespace(workloadNamespace), client.MatchingLabels(selector.MatchLabels))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/validation/injection_test.go
+++ b/internal/validation/injection_test.go
@@ -1,0 +1,133 @@
+package validation_test
+
+import (
+	"context"
+	gatewayv1beta1 "github.com/kyma-project/api-gateway/apis/gateway/v1beta1"
+	"github.com/kyma-project/api-gateway/internal/validation"
+
+	"istio.io/api/type/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("Istio injection validation", func() {
+
+	scheme := runtime.NewScheme()
+	err := gatewayv1beta1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+	var k8sFakeClient client.WithWatch
+
+	BeforeEach(func() {
+		k8sFakeClient = fake.NewClientBuilder().Build()
+	})
+
+	It("Should not fail when the Pod for which the service is specified is in different ns", func() {
+		//given
+		err := k8sFakeClient.Create(context.Background(), &corev1.Pod{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-pod",
+				Namespace: "test",
+				Labels: map[string]string{
+					"app": "test",
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		//when
+		problems, err := (&validation.InjectionValidator{Ctx: context.Background(), Client: k8sFakeClient}).Validate("some.attribute", &v1beta1.WorkloadSelector{MatchLabels: map[string]string{"app": "test"}}, "default")
+		Expect(err).NotTo(HaveOccurred())
+
+		//then
+		Expect(problems).To(HaveLen(0))
+	})
+
+	It("Should fail when the workload selector is nil", func() {
+		//when
+		problems, err := (&validation.InjectionValidator{Ctx: context.Background(), Client: k8sFakeClient}).Validate("some.attribute", nil, "default")
+		Expect(err).NotTo(HaveOccurred())
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal("some.attribute.injection"))
+		Expect(problems[0].Message).To(Equal("Service cannot have empty label selectors when the API Rule strategy is JWT"))
+	})
+
+	It("Should fail when the Pod for which the service is specified is not istio injected and in the same not default namespace", func() {
+		//given
+		err := k8sFakeClient.Create(context.Background(), &corev1.Pod{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-pod",
+				Namespace: "test",
+				Labels: map[string]string{
+					"app": "test",
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		//when
+		problems, err := (&validation.InjectionValidator{Ctx: context.Background(), Client: k8sFakeClient}).Validate("some.attribute", &v1beta1.WorkloadSelector{MatchLabels: map[string]string{"app": "test"}}, "test")
+		Expect(err).NotTo(HaveOccurred())
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal("some.attribute"))
+		Expect(problems[0].Message).To(Equal("Pod test/test-pod does not have an injected istio sidecar"))
+	})
+
+	It("Should fail when the Pod for which the service is specified is not istio injected", func() {
+		//given
+		err := k8sFakeClient.Create(context.Background(), &corev1.Pod{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-pod",
+				Namespace: "default",
+				Labels: map[string]string{
+					"app": "test",
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		//when
+		problems, err := (&validation.InjectionValidator{Ctx: context.Background(), Client: k8sFakeClient}).Validate("some.attribute", &v1beta1.WorkloadSelector{MatchLabels: map[string]string{"app": "test"}}, "default")
+		Expect(err).NotTo(HaveOccurred())
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal("some.attribute"))
+		Expect(problems[0].Message).To(Equal("Pod default/test-pod does not have an injected istio sidecar"))
+	})
+
+	It("Should not fail when the Pod for which the service is specified is istio injected", func() {
+		//given
+		err := k8sFakeClient.Create(context.Background(), &corev1.Pod{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test-pod-injected",
+				Namespace: "default",
+				Labels: map[string]string{
+					"app": "test-injected",
+				},
+			},
+			Spec: corev1.PodSpec{
+				Containers: []corev1.Container{
+					{Name: "istio-proxy"},
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		//when
+		problems, err := (&validation.InjectionValidator{Ctx: context.Background(), Client: k8sFakeClient}).Validate("some.attribute", &v1beta1.WorkloadSelector{MatchLabels: map[string]string{"app": "test-injected"}}, "default")
+		Expect(err).NotTo(HaveOccurred())
+
+		//then
+		Expect(problems).To(HaveLen(0))
+	})
+})

--- a/internal/validation/v1beta1/istio/jwt_validator_test.go
+++ b/internal/validation/v1beta1/istio/jwt_validator_test.go
@@ -1,140 +1,16 @@
 package istio
 
 import (
-	"context"
 	"encoding/json"
 	gatewayv1beta1 "github.com/kyma-project/api-gateway/apis/gateway/v1beta1"
-	"github.com/kyma-project/api-gateway/internal/validation"
-
 	processingtest "github.com/kyma-project/api-gateway/internal/processing/processing_test"
-	"istio.io/api/type/v1beta1"
-	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
 	"github.com/kyma-project/api-gateway/internal/types/ory"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ = Describe("JWT Handler validation", func() {
-
-	Context("Istio injection validation", func() {
-		scheme := runtime.NewScheme()
-		err := gatewayv1beta1.AddToScheme(scheme)
-		Expect(err).NotTo(HaveOccurred())
-		var k8sfakeClient client.WithWatch
-
-		BeforeEach(func() {
-			k8sfakeClient = fake.NewClientBuilder().Build()
-		})
-
-		It("Should not fail when the Pod for which the service is specified is in different ns", func() {
-			//given
-			err := k8sfakeClient.Create(context.Background(), &corev1.Pod{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "test",
-					Labels: map[string]string{
-						"app": "test",
-					},
-				},
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			//when
-			problems, err := (&validation.InjectionValidator{Ctx: context.Background(), Client: k8sfakeClient}).Validate("some.attribute", &v1beta1.WorkloadSelector{MatchLabels: map[string]string{"app": "test"}}, "default")
-			Expect(err).NotTo(HaveOccurred())
-
-			//then
-			Expect(problems).To(HaveLen(0))
-		})
-
-		It("Should fail when the workload selector is nil", func() {
-			//when
-			problems, err := (&validation.InjectionValidator{Ctx: context.Background(), Client: k8sfakeClient}).Validate("some.attribute", nil, "default")
-			Expect(err).NotTo(HaveOccurred())
-
-			//then
-			Expect(problems).To(HaveLen(1))
-			Expect(problems[0].AttributePath).To(Equal("some.attribute.injection"))
-			Expect(problems[0].Message).To(Equal("Service cannot have empty label selectors when the API Rule strategy is JWT"))
-		})
-
-		It("Should fail when the Pod for which the service is specified is not istio injected and in the same not default namespace", func() {
-			//given
-			err := k8sfakeClient.Create(context.Background(), &corev1.Pod{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "test",
-					Labels: map[string]string{
-						"app": "test",
-					},
-				},
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			//when
-			problems, err := (&validation.InjectionValidator{Ctx: context.Background(), Client: k8sfakeClient}).Validate("some.attribute", &v1beta1.WorkloadSelector{MatchLabels: map[string]string{"app": "test"}}, "test")
-			Expect(err).NotTo(HaveOccurred())
-
-			//then
-			Expect(problems).To(HaveLen(1))
-			Expect(problems[0].AttributePath).To(Equal("some.attribute"))
-			Expect(problems[0].Message).To(Equal("Pod test/test-pod does not have an injected istio sidecar"))
-		})
-
-		It("Should fail when the Pod for which the service is specified is not istio injected", func() {
-			//given
-			err := k8sfakeClient.Create(context.Background(), &corev1.Pod{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: "default",
-					Labels: map[string]string{
-						"app": "test",
-					},
-				},
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			//when
-			problems, err := (&validation.InjectionValidator{Ctx: context.Background(), Client: k8sfakeClient}).Validate("some.attribute", &v1beta1.WorkloadSelector{MatchLabels: map[string]string{"app": "test"}}, "default")
-			Expect(err).NotTo(HaveOccurred())
-
-			//then
-			Expect(problems).To(HaveLen(1))
-			Expect(problems[0].AttributePath).To(Equal("some.attribute"))
-			Expect(problems[0].Message).To(Equal("Pod default/test-pod does not have an injected istio sidecar"))
-		})
-
-		It("Should not fail when the Pod for which the service is specified is istio injected", func() {
-			//given
-			err := k8sfakeClient.Create(context.Background(), &corev1.Pod{
-				ObjectMeta: v1.ObjectMeta{
-					Name:      "test-pod-injected",
-					Namespace: "default",
-					Labels: map[string]string{
-						"app": "test-injected",
-					},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{Name: "istio-proxy"},
-					},
-				},
-			})
-			Expect(err).NotTo(HaveOccurred())
-
-			//when
-			problems, err := (&validation.InjectionValidator{Ctx: context.Background(), Client: k8sfakeClient}).Validate("some.attribute", &v1beta1.WorkloadSelector{MatchLabels: map[string]string{"app": "test-injected"}}, "default")
-			Expect(err).NotTo(HaveOccurred())
-
-			//then
-			Expect(problems).To(HaveLen(0))
-		})
-	})
 
 	It("Should fail with empty config", func() {
 		//given

--- a/internal/validation/v2alpha1/jwt.go
+++ b/internal/validation/v2alpha1/jwt.go
@@ -16,10 +16,10 @@ func validateJwt(parentAttributePath string, rule *gatewayv2alpha1.Rule) []valid
 		return nil
 	}
 
-	parentAttributePath = fmt.Sprintf("%s%s", parentAttributePath, ".jwt")
+	jwtAttributePath := parentAttributePath + ".jwt"
 
-	failures = append(failures, hasInvalidAuthorizations(parentAttributePath, rule.Jwt.Authorizations)...)
-	failures = append(failures, hasInvalidAuthentications(parentAttributePath, rule.Jwt.Authentications)...)
+	failures = append(failures, hasInvalidAuthorizations(jwtAttributePath, rule.Jwt.Authorizations)...)
+	failures = append(failures, hasInvalidAuthentications(jwtAttributePath, rule.Jwt.Authentications)...)
 
 	return failures
 }
@@ -56,7 +56,7 @@ func hasInvalidAudiences(authorization gatewayv2alpha1.JwtAuthorization) error {
 
 func hasInvalidAuthentications(parentAttributePath string, authentications []*gatewayv2alpha1.JwtAuthentication) []validation.Failure {
 	var failures []validation.Failure
-	authenticationsAttrPath := fmt.Sprintf("%s%s", parentAttributePath, ".authentications")
+	authenticationsAttrPath := parentAttributePath + ".authentications"
 
 	hasFromHeaders, hasFromParams := false, false
 	if len(authentications) == 0 {
@@ -107,7 +107,7 @@ func hasInvalidAuthentications(parentAttributePath string, authentications []*ga
 
 func hasInvalidAuthorizations(parentAttributePath string, authorizations []*gatewayv2alpha1.JwtAuthorization) []validation.Failure {
 	var failures []validation.Failure
-	authorizationsAttrPath := fmt.Sprintf("%s%s", parentAttributePath, ".authorizations")
+	authorizationsAttrPath := parentAttributePath + ".authorizations"
 
 	if authorizations == nil {
 		return nil

--- a/internal/validation/v2alpha1/jwt.go
+++ b/internal/validation/v2alpha1/jwt.go
@@ -62,7 +62,7 @@ func hasInvalidAuthentications(parentAttributePath string, authentications []*ga
 		return []validation.Failure{
 			{
 				AttributePath: authenticationsAttrPath,
-				Message:       "Authentications are required",
+				Message:       "A JWT config must have at least one authentication",
 			},
 		}
 	}
@@ -111,7 +111,7 @@ func hasInvalidAuthorizations(parentAttributePath string, authorizations []*gate
 		return nil
 	}
 	if len(authorizations) == 0 {
-		failures = append(failures, validation.Failure{AttributePath: authorizationsAttrPath, Message: "value is empty"})
+		failures = append(failures, validation.Failure{AttributePath: authorizationsAttrPath, Message: "authorizations defined, but no configuration exists"})
 		return
 	}
 

--- a/internal/validation/v2alpha1/jwt.go
+++ b/internal/validation/v2alpha1/jwt.go
@@ -54,7 +54,8 @@ func hasInvalidAudiences(authorization gatewayv2alpha1.JwtAuthorization) error {
 	return nil
 }
 
-func hasInvalidAuthentications(parentAttributePath string, authentications []*gatewayv2alpha1.JwtAuthentication) (failures []validation.Failure) {
+func hasInvalidAuthentications(parentAttributePath string, authentications []*gatewayv2alpha1.JwtAuthentication) []validation.Failure {
+	var failures []validation.Failure
 	authenticationsAttrPath := fmt.Sprintf("%s%s", parentAttributePath, ".authentications")
 
 	hasFromHeaders, hasFromParams := false, false
@@ -104,15 +105,15 @@ func hasInvalidAuthentications(parentAttributePath string, authentications []*ga
 	return failures
 }
 
-func hasInvalidAuthorizations(parentAttributePath string, authorizations []*gatewayv2alpha1.JwtAuthorization) (failures []validation.Failure) {
+func hasInvalidAuthorizations(parentAttributePath string, authorizations []*gatewayv2alpha1.JwtAuthorization) []validation.Failure {
+	var failures []validation.Failure
 	authorizationsAttrPath := fmt.Sprintf("%s%s", parentAttributePath, ".authorizations")
 
 	if authorizations == nil {
 		return nil
 	}
 	if len(authorizations) == 0 {
-		failures = append(failures, validation.Failure{AttributePath: authorizationsAttrPath, Message: "authorizations defined, but no configuration exists"})
-		return
+		return append(failures, validation.Failure{AttributePath: authorizationsAttrPath, Message: "authorizations defined, but no configuration exists"})
 	}
 
 	for i, authorization := range authorizations {
@@ -135,7 +136,7 @@ func hasInvalidAuthorizations(parentAttributePath string, authorizations []*gate
 		}
 	}
 
-	return
+	return failures
 }
 
 // validateJwtAuthenticationEquality validates that all JWT authorizations with the same issuer and JWKS URI have the same configuration

--- a/internal/validation/v2alpha1/jwt.go
+++ b/internal/validation/v2alpha1/jwt.go
@@ -1,0 +1,202 @@
+package v2alpha1
+
+import (
+	"errors"
+	"fmt"
+	gatewayv2alpha1 "github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
+	"strings"
+
+	"github.com/kyma-project/api-gateway/internal/validation"
+)
+
+func validateJwt(parentAttributePath string, rule *gatewayv2alpha1.Rule) []validation.Failure {
+	var failures []validation.Failure
+
+	if rule.Jwt == nil {
+		return nil
+	}
+
+	parentAttributePath = fmt.Sprintf("%s%s", parentAttributePath, ".jwt")
+
+	failures = append(failures, hasInvalidAuthorizations(parentAttributePath, rule.Jwt.Authorizations)...)
+	failures = append(failures, hasInvalidAuthentications(parentAttributePath, rule.Jwt.Authentications)...)
+
+	return failures
+}
+
+func hasInvalidRequiredScopes(authorization gatewayv2alpha1.JwtAuthorization) error {
+	if authorization.RequiredScopes == nil {
+		return nil
+	}
+	if len(authorization.RequiredScopes) == 0 {
+		return errors.New("value is empty")
+	}
+	for _, scope := range authorization.RequiredScopes {
+		if scope == "" {
+			return errors.New("scope value is empty")
+		}
+	}
+	return nil
+}
+
+func hasInvalidAudiences(authorization gatewayv2alpha1.JwtAuthorization) error {
+	if authorization.Audiences == nil {
+		return nil
+	}
+	if len(authorization.Audiences) == 0 {
+		return errors.New("value is empty")
+	}
+	for _, audience := range authorization.Audiences {
+		if audience == "" {
+			return errors.New("audience value is empty")
+		}
+	}
+	return nil
+}
+
+func hasInvalidAuthentications(parentAttributePath string, authentications []*gatewayv2alpha1.JwtAuthentication) (failures []validation.Failure) {
+	authenticationsAttrPath := fmt.Sprintf("%s%s", parentAttributePath, ".authentications")
+
+	hasFromHeaders, hasFromParams := false, false
+	if len(authentications) == 0 {
+		return []validation.Failure{
+			{
+				AttributePath: authenticationsAttrPath,
+				Message:       "Authentications are required",
+			},
+		}
+	}
+	for i, authentication := range authentications {
+		issuerErr := validateJwtIssuer(authentication.Issuer)
+		if issuerErr != nil {
+			attrPath := fmt.Sprintf("%s[%d]%s", authenticationsAttrPath, i, ".issuer")
+			failures = append(failures, validation.Failure{AttributePath: attrPath, Message: fmt.Sprintf("value is empty or not a valid uri err=%s", issuerErr)})
+		}
+
+		invalidJwksUri, err := validation.IsInvalidURL(authentication.JwksUri)
+		if invalidJwksUri {
+			attrPath := fmt.Sprintf("%s[%d]%s", authenticationsAttrPath, i, ".jwksUri")
+			failures = append(failures, validation.Failure{AttributePath: attrPath, Message: fmt.Sprintf("value is empty or not a valid uri err=%s", err)})
+		}
+		if len(authentication.FromHeaders) > 0 {
+			if hasFromParams {
+				attrPath := fmt.Sprintf("%s[%d]%s", authenticationsAttrPath, i, ".fromHeaders")
+				failures = append(failures, validation.Failure{AttributePath: attrPath, Message: "mixture of multiple fromHeaders and fromParams is not supported"})
+			}
+			hasFromHeaders = true
+		}
+		if len(authentication.FromParams) > 0 {
+			if hasFromHeaders {
+				attrPath := fmt.Sprintf("%s[%d]%s", authenticationsAttrPath, i, ".fromParams")
+				failures = append(failures, validation.Failure{AttributePath: attrPath, Message: "mixture of multiple fromHeaders and fromParams is not supported"})
+			}
+			hasFromParams = true
+		}
+		if len(authentication.FromHeaders) > 1 {
+			attrPath := fmt.Sprintf("%s[%d]%s", authenticationsAttrPath, i, ".fromHeaders")
+			failures = append(failures, validation.Failure{AttributePath: attrPath, Message: "multiple fromHeaders are not supported"})
+		}
+		if len(authentication.FromParams) > 1 {
+			attrPath := fmt.Sprintf("%s[%d]%s", authenticationsAttrPath, i, ".fromParams")
+			failures = append(failures, validation.Failure{AttributePath: attrPath, Message: "multiple fromParams are not supported"})
+		}
+	}
+	return failures
+}
+
+func hasInvalidAuthorizations(parentAttributePath string, authorizations []*gatewayv2alpha1.JwtAuthorization) (failures []validation.Failure) {
+	authorizationsAttrPath := fmt.Sprintf("%s%s", parentAttributePath, ".authorizations")
+
+	if authorizations == nil {
+		return nil
+	}
+	if len(authorizations) == 0 {
+		failures = append(failures, validation.Failure{AttributePath: authorizationsAttrPath, Message: "value is empty"})
+		return
+	}
+
+	for i, authorization := range authorizations {
+		if authorization == nil {
+			attrPath := fmt.Sprintf("%s[%d]", authorizationsAttrPath, i)
+			failures = append(failures, validation.Failure{AttributePath: attrPath, Message: "authorization is empty"})
+			continue
+		}
+
+		err := hasInvalidRequiredScopes(*authorization)
+		if err != nil {
+			attrPath := fmt.Sprintf("%s[%d]%s", authorizationsAttrPath, i, ".requiredScopes")
+			failures = append(failures, validation.Failure{AttributePath: attrPath, Message: err.Error()})
+		}
+
+		err = hasInvalidAudiences(*authorization)
+		if err != nil {
+			attrPath := fmt.Sprintf("%s[%d]%s", authorizationsAttrPath, i, ".audiences")
+			failures = append(failures, validation.Failure{AttributePath: attrPath, Message: err.Error()})
+		}
+	}
+
+	return
+}
+
+// validateJwtAuthenticationEquality validates that all JWT authorizations with the same issuer and JWKS URI have the same configuration
+func validateJwtAuthenticationEquality(parentAttributePath string, rules []gatewayv2alpha1.Rule) []validation.Failure {
+	var failures []validation.Failure
+	jwtAuths := map[string]*gatewayv2alpha1.JwtAuthentication{}
+
+	for ruleIndex, rule := range rules {
+
+		if rule.Jwt == nil {
+			continue
+		}
+
+		for authenticationIndex, authentication := range rule.Jwt.Authentications {
+			authAttributePath := fmt.Sprintf("%s[%d].jwt.authentications[%d]", parentAttributePath, ruleIndex, authenticationIndex)
+
+			jwtAuthKey := authentication.Issuer + authentication.JwksUri
+			if jwtAuths[jwtAuthKey] != nil && !jwtAuthenticationsEqual(authentication, jwtAuths[jwtAuthKey]) {
+				failures = append(failures, validation.Failure{AttributePath: authAttributePath, Message: "multiple jwt configurations that differ for the same issuer"})
+			} else {
+				jwtAuths[jwtAuthKey] = authentication
+			}
+		}
+	}
+	return failures
+}
+
+func jwtAuthenticationsEqual(auth1 *gatewayv2alpha1.JwtAuthentication, auth2 *gatewayv2alpha1.JwtAuthentication) bool {
+	if auth1.Issuer != auth2.Issuer || auth1.JwksUri != auth2.JwksUri {
+		return false
+	}
+	if len(auth1.FromHeaders) != len(auth2.FromHeaders) {
+		return false
+	}
+	for i, auth1FromHeader := range auth1.FromHeaders {
+		if auth1FromHeader.Name != auth2.FromHeaders[i].Name || auth1FromHeader.Prefix != auth2.FromHeaders[i].Prefix {
+			return false
+		}
+	}
+	if len(auth1.FromParams) != len(auth2.FromParams) {
+		return false
+	}
+	for i, auth1FromParam := range auth1.FromParams {
+		if auth1FromParam != auth2.FromParams[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func validateJwtIssuer(issuer string) error {
+	if issuer == "" {
+		return errors.New("value is empty")
+	}
+
+	// If issuer contains ':' it must be a valid URI, see https://datatracker.ietf.org/doc/html/rfc7519#section-4.1.1
+	if strings.Contains(issuer, ":") {
+		if isInvalid, err := validation.IsInvalidURL(issuer); isInvalid {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/validation/v2alpha1/jwt_authentications_test.go
+++ b/internal/validation/v2alpha1/jwt_authentications_test.go
@@ -1,0 +1,252 @@
+package v2alpha1
+
+import (
+	gatewayv2alpha1 "github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("JWT authentications validation", func() {
+
+	It("should fail validation when jwksUri is not a URI", func() {
+		//given
+		rule := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:  "the_issuer/",
+						JwksUri: "no_url",
+					},
+				},
+			},
+		}
+
+		//when
+		problems := validateJwt("rule", &rule)
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications[0].jwksUri"))
+		Expect(problems[0].Message).To(ContainSubstring("value is empty or not a valid uri"))
+	})
+
+	It("should fail validation when issuer and jwksUri are empty", func() {
+		//given
+		rule := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:  "",
+						JwksUri: "",
+					},
+				},
+			},
+		}
+
+		//when
+		problems := validateJwt("rule", &rule)
+
+		//then
+		Expect(problems).To(HaveLen(2))
+		Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications[0].issuer"))
+		Expect(problems[0].Message).To(ContainSubstring("value is empty or not a valid uri"))
+		Expect(problems[1].AttributePath).To(Equal("rule.jwt.authentications[0].jwksUri"))
+		Expect(problems[1].Message).To(ContainSubstring("value is empty or not a valid uri"))
+	})
+
+	It("should fail validation when issuer contains ':' but is not a URI", func() {
+		//given
+		rule := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:  "://example",
+						JwksUri: "http://issuer.test/.well-known/jwks.json",
+					},
+				},
+			},
+		}
+
+		//when
+		problems := validateJwt("rule", &rule)
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications[0].issuer"))
+		Expect(problems[0].Message).To(ContainSubstring("value is empty or not a valid uri"))
+	})
+
+	It("should pass validation when issuer contains ':' and is a URI", func() {
+		//given
+		rule := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:  "https://issuer.example.com",
+						JwksUri: "http://issuer.test/.well-known/jwks.json",
+					},
+				},
+			},
+		}
+
+		//when
+		problems := validateJwt("rule", &rule)
+
+		//then
+		Expect(problems).To(HaveLen(0))
+	})
+
+	It("should pass validation when issuer is not empty has contains no ':'", func() {
+		//given
+		rule := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:  "testing@secure.istio.io",
+						JwksUri: "http://issuer.test/.well-known/jwks.json",
+					},
+				},
+			},
+		}
+
+		//when
+		problems := validateJwt("rule", &rule)
+
+		//then
+		Expect(problems).To(HaveLen(0))
+	})
+
+	It("should succeed for config with plain HTTP JWKSUrls and trustedIssuers", func() {
+		//given
+		rule := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:  "http://issuer.test",
+						JwksUri: "http://issuer.test/.well-known/jwks.json",
+					},
+				},
+			},
+		}
+
+		//when
+		problems := validateJwt("rule", &rule)
+
+		//then
+		Expect(problems).To(HaveLen(0))
+	})
+
+	It("should succeed for config with file JWKSUrls and HTTPS trustedIssuers", func() {
+		//given
+		rule := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:  "https://issuer.test/",
+						JwksUri: "file://.well-known/jwks.json",
+					},
+				},
+			},
+		}
+
+		//when
+		problems := validateJwt("rule", &rule)
+
+		//then
+		Expect(problems).To(HaveLen(0))
+	})
+
+	It("should succeed for config with HTTPS JWKSUrls and trustedIssuers", func() {
+		//given
+		rule := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:  "https://issuer.test//",
+						JwksUri: "https://issuer.test/.well-known/jwks.json",
+					},
+				},
+			},
+		}
+
+		//when
+		problems := validateJwt("rule", &rule)
+
+		//then
+		Expect(problems).To(HaveLen(0))
+	})
+
+	It("Should fail validation when authentication has more than one fromHeaders", func() {
+		//given
+		rule := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:      "https://issuer.test//",
+						JwksUri:     "https://issuer.test/.well-known/jwks.json",
+						FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}, {Name: "header2"}},
+					},
+				},
+			},
+		}
+
+		//when
+		problems := validateJwt("rule", &rule)
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications[0].fromHeaders"))
+		Expect(problems[0].Message).To(Equal("multiple fromHeaders are not supported"))
+	})
+
+	It("should fail validation when authentication has more than one fromParams", func() {
+		//given
+		rule := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:     "https://issuer.test//",
+						JwksUri:    "https://issuer.test/.well-known/jwks.json",
+						FromParams: []string{"param1", "param2"},
+					},
+				},
+			},
+		}
+
+		//when
+		problems := validateJwt("rule", &rule)
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications[0].fromParams"))
+		Expect(problems[0].Message).To(Equal("multiple fromParams are not supported"))
+	})
+
+	It("should fail validation when multiple authentications have mixture of fromHeaders and fromParams", func() {
+		//given
+		rule := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:     "https://issuer.test//",
+						JwksUri:    "file://.well-known/jwks.json",
+						FromParams: []string{"param1"},
+					},
+					{
+						Issuer:      "https://issuer.test/",
+						JwksUri:     "file://.well-known/jwks.json",
+						FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}},
+					},
+				},
+			},
+		}
+
+		//when
+		problems := validateJwt("rule", &rule)
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications[1].fromHeaders"))
+		Expect(problems[0].Message).To(Equal("mixture of multiple fromHeaders and fromParams is not supported"))
+	})
+})

--- a/internal/validation/v2alpha1/jwt_authorizations_test.go
+++ b/internal/validation/v2alpha1/jwt_authorizations_test.go
@@ -1,0 +1,272 @@
+package v2alpha1
+
+import (
+	gatewayv2alpha1 "github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("JWT authorizations validation", func() {
+
+	It("should fail validation when authorizations is defined, but empty", func() {
+		//given
+		rule := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:  "https://issuer.test/",
+						JwksUri: "file://.well-known/jwks.json",
+					},
+				},
+				Authorizations: []*gatewayv2alpha1.JwtAuthorization{},
+			},
+		}
+
+		//when
+		problems := validateJwt("rule", &rule)
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal("rule.jwt.authorizations"))
+		Expect(problems[0].Message).To(Equal("authorizations defined, but no configuration exists"))
+	})
+
+	It("should fail validation when authorization is empty", func() {
+		//given
+		var auth *gatewayv2alpha1.JwtAuthorization
+		rule := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:  "https://issuer.test/",
+						JwksUri: "file://.well-known/jwks.json",
+					},
+				},
+				Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+					auth,
+				},
+			},
+		}
+
+		//when
+		problems := validateJwt("rule", &rule)
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal("rule.jwt.authorizations[0]"))
+		Expect(problems[0].Message).To(Equal("authorization is empty"))
+	})
+
+	Context("required scopes", func() {
+		It("should fail for config with empty required scopes", func() {
+			//given
+			rule := gatewayv2alpha1.Rule{
+				Jwt: &gatewayv2alpha1.JwtConfig{
+					Authentications: []*gatewayv2alpha1.JwtAuthentication{
+						{
+							Issuer:  "https://issuer.test/",
+							JwksUri: "file://.well-known/jwks.json",
+						},
+					},
+					Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+						{
+							RequiredScopes: []string{},
+						},
+					},
+				},
+			}
+
+			//when
+			problems := validateJwt("rule", &rule)
+
+			//then
+			Expect(problems).To(HaveLen(1))
+			Expect(problems[0].AttributePath).To(Equal("rule.jwt.authorizations[0].requiredScopes"))
+			Expect(problems[0].Message).To(Equal("value is empty"))
+		})
+
+		It("should fail for config with empty string in required scopes", func() {
+			//given
+			rule := gatewayv2alpha1.Rule{
+				Jwt: &gatewayv2alpha1.JwtConfig{
+					Authentications: []*gatewayv2alpha1.JwtAuthentication{
+						{
+							Issuer:  "https://issuer.test/",
+							JwksUri: "file://.well-known/jwks.json",
+						},
+					},
+					Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+						{
+							RequiredScopes: []string{"scope-a", ""},
+						},
+					},
+				},
+			}
+
+			//when
+			problems := validateJwt("rule", &rule)
+
+			//then
+			Expect(problems).To(HaveLen(1))
+			Expect(problems[0].AttributePath).To(Equal("rule.jwt.authorizations[0].requiredScopes"))
+			Expect(problems[0].Message).To(Equal("scope value is empty"))
+		})
+
+		It("should succeed for config with two required scopes", func() {
+			//given
+			rule := gatewayv2alpha1.Rule{
+				Jwt: &gatewayv2alpha1.JwtConfig{
+					Authentications: []*gatewayv2alpha1.JwtAuthentication{
+						{
+							Issuer:  "https://issuer.test/",
+							JwksUri: "file://.well-known/jwks.json",
+						},
+					},
+					Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+						{
+							RequiredScopes: []string{"scope-a", "scope-b"},
+						},
+					},
+				},
+			}
+
+			//when
+			problems := validateJwt("rule", &rule)
+
+			//then
+			Expect(problems).To(HaveLen(0))
+		})
+
+		It("should successful validate config without a required scope", func() {
+			//given
+			rule := gatewayv2alpha1.Rule{
+				Jwt: &gatewayv2alpha1.JwtConfig{
+					Authentications: []*gatewayv2alpha1.JwtAuthentication{
+						{
+							Issuer:  "https://issuer.test/",
+							JwksUri: "file://.well-known/jwks.json",
+						},
+					},
+					Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+						{
+							Audiences: []string{"www.example.com"},
+						},
+					},
+				},
+			}
+
+			//when
+			problems := validateJwt("rule", &rule)
+
+			//then
+			Expect(problems).To(HaveLen(0))
+		})
+	})
+
+	Context("audiences", func() {
+
+		It("should fail validation for config with empty audiences", func() {
+			//given
+			rule := gatewayv2alpha1.Rule{
+				Jwt: &gatewayv2alpha1.JwtConfig{
+					Authentications: []*gatewayv2alpha1.JwtAuthentication{
+						{
+							Issuer:  "https://issuer.test/",
+							JwksUri: "file://.well-known/jwks.json",
+						},
+					},
+					Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+						{
+							Audiences: []string{},
+						},
+					},
+				},
+			}
+
+			//when
+			problems := validateJwt("rule", &rule)
+
+			//then
+			Expect(problems).To(HaveLen(1))
+			Expect(problems[0].AttributePath).To(Equal("rule.jwt.authorizations[0].audiences"))
+			Expect(problems[0].Message).To(Equal("value is empty"))
+		})
+
+		It("should fail validation for config with empty string in audiences", func() {
+			//given
+			rule := gatewayv2alpha1.Rule{
+				Jwt: &gatewayv2alpha1.JwtConfig{
+					Authentications: []*gatewayv2alpha1.JwtAuthentication{
+						{
+							Issuer:  "https://issuer.test/",
+							JwksUri: "file://.well-known/jwks.json",
+						},
+					},
+					Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+						{
+							Audiences: []string{"www.example.com", ""},
+						},
+					},
+				},
+			}
+
+			//when
+			problems := validateJwt("rule", &rule)
+
+			//then
+			Expect(problems).To(HaveLen(1))
+			Expect(problems[0].AttributePath).To(Equal("rule.jwt.authorizations[0].audiences"))
+			Expect(problems[0].Message).To(Equal("audience value is empty"))
+		})
+
+		It("should successful validate config with an audience", func() {
+			//given
+			rule := gatewayv2alpha1.Rule{
+				Jwt: &gatewayv2alpha1.JwtConfig{
+					Authentications: []*gatewayv2alpha1.JwtAuthentication{
+						{
+							Issuer:  "https://issuer.test/",
+							JwksUri: "file://.well-known/jwks.json",
+						},
+					},
+					Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+						{
+							Audiences: []string{"www.example.com"},
+						},
+					},
+				},
+			}
+
+			//when
+			problems := validateJwt("rule", &rule)
+
+			//then
+			Expect(problems).To(HaveLen(0))
+		})
+
+		It("should successful validate config without audiences", func() {
+			//given
+			rule := gatewayv2alpha1.Rule{
+				Jwt: &gatewayv2alpha1.JwtConfig{
+					Authentications: []*gatewayv2alpha1.JwtAuthentication{
+						{
+							Issuer:  "https://issuer.test/",
+							JwksUri: "file://.well-known/jwks.json",
+						},
+					},
+					Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+						{
+							RequiredScopes: []string{"www.example.com"},
+						},
+					},
+				},
+			}
+
+			//when
+			problems := validateJwt("rule", &rule)
+
+			//then
+			Expect(problems).To(HaveLen(0))
+		})
+	})
+})

--- a/internal/validation/v2alpha1/jwt_test.go
+++ b/internal/validation/v2alpha1/jwt_test.go
@@ -1,0 +1,722 @@
+package v2alpha1
+
+import (
+	gatewayv2alpha1 "github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("JWT validation", func() {
+
+	Context("validateJwt", func() {
+
+		It("should fail with empty JWT config", func() {
+			//given
+			rule := gatewayv2alpha1.Rule{
+				Jwt: &gatewayv2alpha1.JwtConfig{},
+			}
+
+			//when
+			problems := validateJwt("rule", &rule)
+
+			//then
+			Expect(problems).To(HaveLen(1))
+			Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications"))
+			Expect(problems[0].Message).To(Equal("A JWT config must have at least one authentication"))
+		})
+
+		It("should fail when Authorizations are configured, but empty Authentications", func() {
+			//given
+			rule := gatewayv2alpha1.Rule{
+				Jwt: &gatewayv2alpha1.JwtConfig{
+					Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+						{
+							RequiredScopes: []string{"scope-a", "scope-b"},
+						},
+					},
+				},
+			}
+
+			//when
+			problems := validateJwt("rule", &rule)
+
+			//then
+			Expect(problems).To(HaveLen(1))
+			Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications"))
+			Expect(problems[0].Message).To(Equal("A JWT config must have at least one authentication"))
+		})
+
+		Context("for authentications", func() {
+
+			It("should fail validation when jwksUri is not a URI", func() {
+				//given
+				rule := gatewayv2alpha1.Rule{
+					Jwt: &gatewayv2alpha1.JwtConfig{
+						Authentications: []*gatewayv2alpha1.JwtAuthentication{
+							{
+								Issuer:  "the_issuer/",
+								JwksUri: "no_url",
+							},
+						},
+					},
+				}
+
+				//when
+				problems := validateJwt("rule", &rule)
+
+				//then
+				Expect(problems).To(HaveLen(1))
+				Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications[0].jwksUri"))
+				Expect(problems[0].Message).To(ContainSubstring("value is empty or not a valid uri"))
+			})
+
+			It("should fail validation when issuer and jwksUri are empty", func() {
+				//given
+				rule := gatewayv2alpha1.Rule{
+					Jwt: &gatewayv2alpha1.JwtConfig{
+						Authentications: []*gatewayv2alpha1.JwtAuthentication{
+							{
+								Issuer:  "",
+								JwksUri: "",
+							},
+						},
+					},
+				}
+
+				//when
+				problems := validateJwt("rule", &rule)
+
+				//then
+				Expect(problems).To(HaveLen(2))
+				Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications[0].issuer"))
+				Expect(problems[0].Message).To(ContainSubstring("value is empty or not a valid uri"))
+				Expect(problems[1].AttributePath).To(Equal("rule.jwt.authentications[0].jwksUri"))
+				Expect(problems[1].Message).To(ContainSubstring("value is empty or not a valid uri"))
+			})
+
+			It("should fail validation when issuer contains ':' but is not a URI", func() {
+				//given
+				rule := gatewayv2alpha1.Rule{
+					Jwt: &gatewayv2alpha1.JwtConfig{
+						Authentications: []*gatewayv2alpha1.JwtAuthentication{
+							{
+								Issuer:  "://example",
+								JwksUri: "http://issuer.test/.well-known/jwks.json",
+							},
+						},
+					},
+				}
+
+				//when
+				problems := validateJwt("rule", &rule)
+
+				//then
+				Expect(problems).To(HaveLen(1))
+				Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications[0].issuer"))
+				Expect(problems[0].Message).To(ContainSubstring("value is empty or not a valid uri"))
+			})
+
+			It("should pass validation when issuer contains ':' and is a URI", func() {
+				//given
+				rule := gatewayv2alpha1.Rule{
+					Jwt: &gatewayv2alpha1.JwtConfig{
+						Authentications: []*gatewayv2alpha1.JwtAuthentication{
+							{
+								Issuer:  "https://issuer.example.com",
+								JwksUri: "http://issuer.test/.well-known/jwks.json",
+							},
+						},
+					},
+				}
+
+				//when
+				problems := validateJwt("rule", &rule)
+
+				//then
+				Expect(problems).To(HaveLen(0))
+			})
+
+			It("should pass validation when issuer is not empty has contains no ':'", func() {
+				//given
+				rule := gatewayv2alpha1.Rule{
+					Jwt: &gatewayv2alpha1.JwtConfig{
+						Authentications: []*gatewayv2alpha1.JwtAuthentication{
+							{
+								Issuer:  "testing@secure.istio.io",
+								JwksUri: "http://issuer.test/.well-known/jwks.json",
+							},
+						},
+					},
+				}
+
+				//when
+				problems := validateJwt("rule", &rule)
+
+				//then
+				Expect(problems).To(HaveLen(0))
+			})
+
+			It("should succeed for config with plain HTTP JWKSUrls and trustedIssuers", func() {
+				//given
+				rule := gatewayv2alpha1.Rule{
+					Jwt: &gatewayv2alpha1.JwtConfig{
+						Authentications: []*gatewayv2alpha1.JwtAuthentication{
+							{
+								Issuer:  "http://issuer.test",
+								JwksUri: "http://issuer.test/.well-known/jwks.json",
+							},
+						},
+					},
+				}
+
+				//when
+				problems := validateJwt("rule", &rule)
+
+				//then
+				Expect(problems).To(HaveLen(0))
+			})
+
+			It("should succeed for config with file JWKSUrls and HTTPS trustedIssuers", func() {
+				//given
+				rule := gatewayv2alpha1.Rule{
+					Jwt: &gatewayv2alpha1.JwtConfig{
+						Authentications: []*gatewayv2alpha1.JwtAuthentication{
+							{
+								Issuer:  "https://issuer.test/",
+								JwksUri: "file://.well-known/jwks.json",
+							},
+						},
+					},
+				}
+
+				//when
+				problems := validateJwt("rule", &rule)
+
+				//then
+				Expect(problems).To(HaveLen(0))
+			})
+
+			It("should succeed for config with HTTPS JWKSUrls and trustedIssuers", func() {
+				//given
+				rule := gatewayv2alpha1.Rule{
+					Jwt: &gatewayv2alpha1.JwtConfig{
+						Authentications: []*gatewayv2alpha1.JwtAuthentication{
+							{
+								Issuer:  "https://issuer.test//",
+								JwksUri: "https://issuer.test/.well-known/jwks.json",
+							},
+						},
+					},
+				}
+
+				//when
+				problems := validateJwt("rule", &rule)
+
+				//then
+				Expect(problems).To(HaveLen(0))
+			})
+
+			It("Should fail validation when authentication has more than one fromHeaders", func() {
+				//given
+				rule := gatewayv2alpha1.Rule{
+					Jwt: &gatewayv2alpha1.JwtConfig{
+						Authentications: []*gatewayv2alpha1.JwtAuthentication{
+							{
+								Issuer:      "https://issuer.test//",
+								JwksUri:     "https://issuer.test/.well-known/jwks.json",
+								FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}, {Name: "header2"}},
+							},
+						},
+					},
+				}
+
+				//when
+				problems := validateJwt("rule", &rule)
+
+				//then
+				Expect(problems).To(HaveLen(1))
+				Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications[0].fromHeaders"))
+				Expect(problems[0].Message).To(Equal("multiple fromHeaders are not supported"))
+			})
+
+			It("should fail validation when authentication has more than one fromParams", func() {
+				//given
+				rule := gatewayv2alpha1.Rule{
+					Jwt: &gatewayv2alpha1.JwtConfig{
+						Authentications: []*gatewayv2alpha1.JwtAuthentication{
+							{
+								Issuer:     "https://issuer.test//",
+								JwksUri:    "https://issuer.test/.well-known/jwks.json",
+								FromParams: []string{"param1", "param2"},
+							},
+						},
+					},
+				}
+
+				//when
+				problems := validateJwt("rule", &rule)
+
+				//then
+				Expect(problems).To(HaveLen(1))
+				Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications[0].fromParams"))
+				Expect(problems[0].Message).To(Equal("multiple fromParams are not supported"))
+			})
+
+			It("should fail validation when multiple authentications have mixture of fromHeaders and fromParams", func() {
+				//given
+				rule := gatewayv2alpha1.Rule{
+					Jwt: &gatewayv2alpha1.JwtConfig{
+						Authentications: []*gatewayv2alpha1.JwtAuthentication{
+							{
+								Issuer:     "https://issuer.test//",
+								JwksUri:    "file://.well-known/jwks.json",
+								FromParams: []string{"param1"},
+							},
+							{
+								Issuer:      "https://issuer.test/",
+								JwksUri:     "file://.well-known/jwks.json",
+								FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}},
+							},
+						},
+					},
+				}
+
+				//when
+				problems := validateJwt("rule", &rule)
+
+				//then
+				Expect(problems).To(HaveLen(1))
+				Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications[1].fromHeaders"))
+				Expect(problems[0].Message).To(Equal("mixture of multiple fromHeaders and fromParams is not supported"))
+			})
+		})
+
+		Context("for authorizations", func() {
+
+			It("should fail validation when authorizations is defined, but empty", func() {
+				//given
+				rule := gatewayv2alpha1.Rule{
+					Jwt: &gatewayv2alpha1.JwtConfig{
+						Authentications: []*gatewayv2alpha1.JwtAuthentication{
+							{
+								Issuer:  "https://issuer.test/",
+								JwksUri: "file://.well-known/jwks.json",
+							},
+						},
+						Authorizations: []*gatewayv2alpha1.JwtAuthorization{},
+					},
+				}
+
+				//when
+				problems := validateJwt("rule", &rule)
+
+				//then
+				Expect(problems).To(HaveLen(1))
+				Expect(problems[0].AttributePath).To(Equal("rule.jwt.authorizations"))
+				Expect(problems[0].Message).To(Equal("authorizations defined, but no configuration exists"))
+			})
+
+			It("should fail validation when authorization is empty", func() {
+				//given
+				var auth *gatewayv2alpha1.JwtAuthorization
+				rule := gatewayv2alpha1.Rule{
+					Jwt: &gatewayv2alpha1.JwtConfig{
+						Authentications: []*gatewayv2alpha1.JwtAuthentication{
+							{
+								Issuer:  "https://issuer.test/",
+								JwksUri: "file://.well-known/jwks.json",
+							},
+						},
+						Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+							auth,
+						},
+					},
+				}
+
+				//when
+				problems := validateJwt("rule", &rule)
+
+				//then
+				Expect(problems).To(HaveLen(1))
+				Expect(problems[0].AttributePath).To(Equal("rule.jwt.authorizations[0]"))
+				Expect(problems[0].Message).To(Equal("authorization is empty"))
+			})
+
+			Context("required scopes", func() {
+				It("should fail for config with empty required scopes", func() {
+					//given
+					rule := gatewayv2alpha1.Rule{
+						Jwt: &gatewayv2alpha1.JwtConfig{
+							Authentications: []*gatewayv2alpha1.JwtAuthentication{
+								{
+									Issuer:  "https://issuer.test/",
+									JwksUri: "file://.well-known/jwks.json",
+								},
+							},
+							Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+								{
+									RequiredScopes: []string{},
+								},
+							},
+						},
+					}
+
+					//when
+					problems := validateJwt("rule", &rule)
+
+					//then
+					Expect(problems).To(HaveLen(1))
+					Expect(problems[0].AttributePath).To(Equal("rule.jwt.authorizations[0].requiredScopes"))
+					Expect(problems[0].Message).To(Equal("value is empty"))
+				})
+
+				It("should fail for config with empty string in required scopes", func() {
+					//given
+					rule := gatewayv2alpha1.Rule{
+						Jwt: &gatewayv2alpha1.JwtConfig{
+							Authentications: []*gatewayv2alpha1.JwtAuthentication{
+								{
+									Issuer:  "https://issuer.test/",
+									JwksUri: "file://.well-known/jwks.json",
+								},
+							},
+							Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+								{
+									RequiredScopes: []string{"scope-a", ""},
+								},
+							},
+						},
+					}
+
+					//when
+					problems := validateJwt("rule", &rule)
+
+					//then
+					Expect(problems).To(HaveLen(1))
+					Expect(problems[0].AttributePath).To(Equal("rule.jwt.authorizations[0].requiredScopes"))
+					Expect(problems[0].Message).To(Equal("scope value is empty"))
+				})
+
+				It("should succeed for config with two required scopes", func() {
+					//given
+					rule := gatewayv2alpha1.Rule{
+						Jwt: &gatewayv2alpha1.JwtConfig{
+							Authentications: []*gatewayv2alpha1.JwtAuthentication{
+								{
+									Issuer:  "https://issuer.test/",
+									JwksUri: "file://.well-known/jwks.json",
+								},
+							},
+							Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+								{
+									RequiredScopes: []string{"scope-a", "scope-b"},
+								},
+							},
+						},
+					}
+
+					//when
+					problems := validateJwt("rule", &rule)
+
+					//then
+					Expect(problems).To(HaveLen(0))
+				})
+
+				It("should successful validate config without a required scope", func() {
+					//given
+					rule := gatewayv2alpha1.Rule{
+						Jwt: &gatewayv2alpha1.JwtConfig{
+							Authentications: []*gatewayv2alpha1.JwtAuthentication{
+								{
+									Issuer:  "https://issuer.test/",
+									JwksUri: "file://.well-known/jwks.json",
+								},
+							},
+							Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+								{
+									Audiences: []string{"www.example.com"},
+								},
+							},
+						},
+					}
+
+					//when
+					problems := validateJwt("rule", &rule)
+
+					//then
+					Expect(problems).To(HaveLen(0))
+				})
+			})
+
+			Context("audiences", func() {
+
+				It("should fail validation for config with empty audiences", func() {
+					//given
+					rule := gatewayv2alpha1.Rule{
+						Jwt: &gatewayv2alpha1.JwtConfig{
+							Authentications: []*gatewayv2alpha1.JwtAuthentication{
+								{
+									Issuer:  "https://issuer.test/",
+									JwksUri: "file://.well-known/jwks.json",
+								},
+							},
+							Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+								{
+									Audiences: []string{},
+								},
+							},
+						},
+					}
+
+					//when
+					problems := validateJwt("rule", &rule)
+
+					//then
+					Expect(problems).To(HaveLen(1))
+					Expect(problems[0].AttributePath).To(Equal("rule.jwt.authorizations[0].audiences"))
+					Expect(problems[0].Message).To(Equal("value is empty"))
+				})
+
+				It("should fail validation for config with empty string in audiences", func() {
+					//given
+					rule := gatewayv2alpha1.Rule{
+						Jwt: &gatewayv2alpha1.JwtConfig{
+							Authentications: []*gatewayv2alpha1.JwtAuthentication{
+								{
+									Issuer:  "https://issuer.test/",
+									JwksUri: "file://.well-known/jwks.json",
+								},
+							},
+							Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+								{
+									Audiences: []string{"www.example.com", ""},
+								},
+							},
+						},
+					}
+
+					//when
+					problems := validateJwt("rule", &rule)
+
+					//then
+					Expect(problems).To(HaveLen(1))
+					Expect(problems[0].AttributePath).To(Equal("rule.jwt.authorizations[0].audiences"))
+					Expect(problems[0].Message).To(Equal("audience value is empty"))
+				})
+
+				It("should successful validate config with an audience", func() {
+					//given
+					rule := gatewayv2alpha1.Rule{
+						Jwt: &gatewayv2alpha1.JwtConfig{
+							Authentications: []*gatewayv2alpha1.JwtAuthentication{
+								{
+									Issuer:  "https://issuer.test/",
+									JwksUri: "file://.well-known/jwks.json",
+								},
+							},
+							Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+								{
+									Audiences: []string{"www.example.com"},
+								},
+							},
+						},
+					}
+
+					//when
+					problems := validateJwt("rule", &rule)
+
+					//then
+					Expect(problems).To(HaveLen(0))
+				})
+
+				It("should successful validate config without audiences", func() {
+					//given
+					rule := gatewayv2alpha1.Rule{
+						Jwt: &gatewayv2alpha1.JwtConfig{
+							Authentications: []*gatewayv2alpha1.JwtAuthentication{
+								{
+									Issuer:  "https://issuer.test/",
+									JwksUri: "file://.well-known/jwks.json",
+								},
+							},
+							Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+								{
+									RequiredScopes: []string{"www.example.com"},
+								},
+							},
+						},
+					}
+
+					//when
+					problems := validateJwt("rule", &rule)
+
+					//then
+					Expect(problems).To(HaveLen(0))
+				})
+			})
+		})
+	})
+
+	Context("validateJwtAuthenticationEquality", func() {
+
+		It("should fail validation when multiple authentications fromHeaders configuration", func() {
+			//given
+			rule := gatewayv2alpha1.Rule{
+				Jwt: &gatewayv2alpha1.JwtConfig{
+					Authentications: []*gatewayv2alpha1.JwtAuthentication{
+						{
+							Issuer:      "https://issuer.test/",
+							JwksUri:     "file://.well-known/jwks.json",
+							FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}},
+						},
+						{
+							Issuer:      "https://issuer.test/",
+							JwksUri:     "file://.well-known/jwks.json",
+							FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header2"}},
+						},
+					},
+				},
+			}
+
+			//when
+			problems := validateJwtAuthenticationEquality(".spec.rules", []gatewayv2alpha1.Rule{rule})
+
+			//then
+			Expect(problems).To(HaveLen(1))
+			Expect(problems[0].AttributePath).To(Equal(".spec.rules[0].jwt.authentications[1]"))
+			Expect(problems[0].Message).To(Equal("multiple jwt configurations that differ for the same issuer"))
+		})
+
+		It("should fail validation when multiple authentications fromParams configuration", func() {
+			//given
+			rule := gatewayv2alpha1.Rule{
+				Jwt: &gatewayv2alpha1.JwtConfig{
+					Authentications: []*gatewayv2alpha1.JwtAuthentication{
+						{
+							Issuer:     "https://issuer.test/",
+							JwksUri:    "file://.well-known/jwks.json",
+							FromParams: []string{"param1"},
+						},
+						{
+							Issuer:     "https://issuer.test/",
+							JwksUri:    "file://.well-known/jwks.json",
+							FromParams: []string{"param2"},
+						},
+					},
+				},
+			}
+
+			//when
+			problems := validateJwtAuthenticationEquality(".spec.rules", []gatewayv2alpha1.Rule{rule})
+
+			//then
+			Expect(problems).To(HaveLen(1))
+			Expect(problems[0].AttributePath).To(Equal(".spec.rules[0].jwt.authentications[1]"))
+			Expect(problems[0].Message).To(Equal("multiple jwt configurations that differ for the same issuer"))
+		})
+
+		It("should fail when multiple jwt handlers specify different token from types of configurations", func() {
+			//given
+			ruleFromHeaders := gatewayv2alpha1.Rule{
+				Jwt: &gatewayv2alpha1.JwtConfig{
+					Authentications: []*gatewayv2alpha1.JwtAuthentication{
+						{
+							Issuer:      "https://issuer.test/",
+							JwksUri:     "file://.well-known/jwks.json",
+							FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}},
+						},
+					},
+				},
+			}
+
+			ruleFromParams := gatewayv2alpha1.Rule{
+				Jwt: &gatewayv2alpha1.JwtConfig{
+					Authentications: []*gatewayv2alpha1.JwtAuthentication{
+						{
+							Issuer:     "https://issuer.test/",
+							JwksUri:    "file://.well-known/jwks.json",
+							FromParams: []string{"param1"},
+						},
+					},
+				},
+			}
+
+			//when
+			problems := validateJwtAuthenticationEquality(".spec.rules", []gatewayv2alpha1.Rule{ruleFromHeaders, ruleFromParams})
+
+			//then
+			Expect(problems).To(HaveLen(1))
+			Expect(problems[0].AttributePath).To(Equal(".spec.rules[1].jwt.authentications[0]"))
+			Expect(problems[0].Message).To(Equal("multiple jwt configurations that differ for the same issuer"))
+		})
+
+		It("should fail when multiple jwt handlers specify different token from headers configuration", func() {
+			//given
+			ruleFromHeaders := gatewayv2alpha1.Rule{
+				Jwt: &gatewayv2alpha1.JwtConfig{
+					Authentications: []*gatewayv2alpha1.JwtAuthentication{
+						{
+							Issuer:      "https://issuer.test/",
+							JwksUri:     "file://.well-known/jwks.json",
+							FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}},
+						},
+					},
+				},
+			}
+
+			ruleFromHeadersDifferent := gatewayv2alpha1.Rule{
+				Jwt: &gatewayv2alpha1.JwtConfig{
+					Authentications: []*gatewayv2alpha1.JwtAuthentication{
+						{
+							Issuer:      "https://issuer.test/",
+							JwksUri:     "file://.well-known/jwks.json",
+							FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header2"}},
+						},
+					},
+				},
+			}
+
+			//when
+			problems := validateJwtAuthenticationEquality(".spec.rules", []gatewayv2alpha1.Rule{ruleFromHeaders, ruleFromHeadersDifferent})
+
+			//then
+			Expect(problems).To(HaveLen(1))
+			Expect(problems[0].AttributePath).To(Equal(".spec.rules[1].jwt.authentications[0]"))
+			Expect(problems[0].Message).To(Equal("multiple jwt configurations that differ for the same issuer"))
+		})
+
+		It("should succeed when multiple jwt handlers specify same token from headers configuration", func() {
+			//given
+			ruleFromHeaders := gatewayv2alpha1.Rule{
+				Jwt: &gatewayv2alpha1.JwtConfig{
+					Authentications: []*gatewayv2alpha1.JwtAuthentication{
+						{
+							Issuer:      "https://issuer.test/",
+							JwksUri:     "file://.well-known/jwks.json",
+							FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}},
+						},
+					},
+				},
+			}
+
+			ruleFromHeadersEqual := gatewayv2alpha1.Rule{
+				Jwt: &gatewayv2alpha1.JwtConfig{
+					Authentications: []*gatewayv2alpha1.JwtAuthentication{
+						{
+							Issuer:      "https://issuer.test/",
+							JwksUri:     "file://.well-known/jwks.json",
+							FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}},
+						},
+					},
+				},
+			}
+
+			//when
+			problems := validateJwtAuthenticationEquality(".spec.rules", []gatewayv2alpha1.Rule{ruleFromHeaders, ruleFromHeadersEqual})
+
+			//then
+			Expect(problems).To(HaveLen(0))
+		})
+	})
+
+})

--- a/internal/validation/v2alpha1/jwt_test.go
+++ b/internal/validation/v2alpha1/jwt_test.go
@@ -6,717 +6,202 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = Describe("JWT validation", func() {
-
-	Context("validateJwt", func() {
-
-		It("should fail with empty JWT config", func() {
-			//given
-			rule := gatewayv2alpha1.Rule{
-				Jwt: &gatewayv2alpha1.JwtConfig{},
-			}
-
-			//when
-			problems := validateJwt("rule", &rule)
-
-			//then
-			Expect(problems).To(HaveLen(1))
-			Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications"))
-			Expect(problems[0].Message).To(Equal("A JWT config must have at least one authentication"))
-		})
-
-		It("should fail when Authorizations are configured, but empty Authentications", func() {
-			//given
-			rule := gatewayv2alpha1.Rule{
-				Jwt: &gatewayv2alpha1.JwtConfig{
-					Authorizations: []*gatewayv2alpha1.JwtAuthorization{
-						{
-							RequiredScopes: []string{"scope-a", "scope-b"},
-						},
-					},
-				},
-			}
-
-			//when
-			problems := validateJwt("rule", &rule)
-
-			//then
-			Expect(problems).To(HaveLen(1))
-			Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications"))
-			Expect(problems[0].Message).To(Equal("A JWT config must have at least one authentication"))
-		})
-
-		Context("for authentications", func() {
-
-			It("should fail validation when jwksUri is not a URI", func() {
-				//given
-				rule := gatewayv2alpha1.Rule{
-					Jwt: &gatewayv2alpha1.JwtConfig{
-						Authentications: []*gatewayv2alpha1.JwtAuthentication{
-							{
-								Issuer:  "the_issuer/",
-								JwksUri: "no_url",
-							},
-						},
-					},
-				}
-
-				//when
-				problems := validateJwt("rule", &rule)
-
-				//then
-				Expect(problems).To(HaveLen(1))
-				Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications[0].jwksUri"))
-				Expect(problems[0].Message).To(ContainSubstring("value is empty or not a valid uri"))
-			})
-
-			It("should fail validation when issuer and jwksUri are empty", func() {
-				//given
-				rule := gatewayv2alpha1.Rule{
-					Jwt: &gatewayv2alpha1.JwtConfig{
-						Authentications: []*gatewayv2alpha1.JwtAuthentication{
-							{
-								Issuer:  "",
-								JwksUri: "",
-							},
-						},
-					},
-				}
-
-				//when
-				problems := validateJwt("rule", &rule)
-
-				//then
-				Expect(problems).To(HaveLen(2))
-				Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications[0].issuer"))
-				Expect(problems[0].Message).To(ContainSubstring("value is empty or not a valid uri"))
-				Expect(problems[1].AttributePath).To(Equal("rule.jwt.authentications[0].jwksUri"))
-				Expect(problems[1].Message).To(ContainSubstring("value is empty or not a valid uri"))
-			})
-
-			It("should fail validation when issuer contains ':' but is not a URI", func() {
-				//given
-				rule := gatewayv2alpha1.Rule{
-					Jwt: &gatewayv2alpha1.JwtConfig{
-						Authentications: []*gatewayv2alpha1.JwtAuthentication{
-							{
-								Issuer:  "://example",
-								JwksUri: "http://issuer.test/.well-known/jwks.json",
-							},
-						},
-					},
-				}
-
-				//when
-				problems := validateJwt("rule", &rule)
-
-				//then
-				Expect(problems).To(HaveLen(1))
-				Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications[0].issuer"))
-				Expect(problems[0].Message).To(ContainSubstring("value is empty or not a valid uri"))
-			})
-
-			It("should pass validation when issuer contains ':' and is a URI", func() {
-				//given
-				rule := gatewayv2alpha1.Rule{
-					Jwt: &gatewayv2alpha1.JwtConfig{
-						Authentications: []*gatewayv2alpha1.JwtAuthentication{
-							{
-								Issuer:  "https://issuer.example.com",
-								JwksUri: "http://issuer.test/.well-known/jwks.json",
-							},
-						},
-					},
-				}
-
-				//when
-				problems := validateJwt("rule", &rule)
-
-				//then
-				Expect(problems).To(HaveLen(0))
-			})
-
-			It("should pass validation when issuer is not empty has contains no ':'", func() {
-				//given
-				rule := gatewayv2alpha1.Rule{
-					Jwt: &gatewayv2alpha1.JwtConfig{
-						Authentications: []*gatewayv2alpha1.JwtAuthentication{
-							{
-								Issuer:  "testing@secure.istio.io",
-								JwksUri: "http://issuer.test/.well-known/jwks.json",
-							},
-						},
-					},
-				}
-
-				//when
-				problems := validateJwt("rule", &rule)
-
-				//then
-				Expect(problems).To(HaveLen(0))
-			})
-
-			It("should succeed for config with plain HTTP JWKSUrls and trustedIssuers", func() {
-				//given
-				rule := gatewayv2alpha1.Rule{
-					Jwt: &gatewayv2alpha1.JwtConfig{
-						Authentications: []*gatewayv2alpha1.JwtAuthentication{
-							{
-								Issuer:  "http://issuer.test",
-								JwksUri: "http://issuer.test/.well-known/jwks.json",
-							},
-						},
-					},
-				}
-
-				//when
-				problems := validateJwt("rule", &rule)
-
-				//then
-				Expect(problems).To(HaveLen(0))
-			})
-
-			It("should succeed for config with file JWKSUrls and HTTPS trustedIssuers", func() {
-				//given
-				rule := gatewayv2alpha1.Rule{
-					Jwt: &gatewayv2alpha1.JwtConfig{
-						Authentications: []*gatewayv2alpha1.JwtAuthentication{
-							{
-								Issuer:  "https://issuer.test/",
-								JwksUri: "file://.well-known/jwks.json",
-							},
-						},
-					},
-				}
-
-				//when
-				problems := validateJwt("rule", &rule)
-
-				//then
-				Expect(problems).To(HaveLen(0))
-			})
-
-			It("should succeed for config with HTTPS JWKSUrls and trustedIssuers", func() {
-				//given
-				rule := gatewayv2alpha1.Rule{
-					Jwt: &gatewayv2alpha1.JwtConfig{
-						Authentications: []*gatewayv2alpha1.JwtAuthentication{
-							{
-								Issuer:  "https://issuer.test//",
-								JwksUri: "https://issuer.test/.well-known/jwks.json",
-							},
-						},
-					},
-				}
-
-				//when
-				problems := validateJwt("rule", &rule)
-
-				//then
-				Expect(problems).To(HaveLen(0))
-			})
-
-			It("Should fail validation when authentication has more than one fromHeaders", func() {
-				//given
-				rule := gatewayv2alpha1.Rule{
-					Jwt: &gatewayv2alpha1.JwtConfig{
-						Authentications: []*gatewayv2alpha1.JwtAuthentication{
-							{
-								Issuer:      "https://issuer.test//",
-								JwksUri:     "https://issuer.test/.well-known/jwks.json",
-								FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}, {Name: "header2"}},
-							},
-						},
-					},
-				}
-
-				//when
-				problems := validateJwt("rule", &rule)
-
-				//then
-				Expect(problems).To(HaveLen(1))
-				Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications[0].fromHeaders"))
-				Expect(problems[0].Message).To(Equal("multiple fromHeaders are not supported"))
-			})
-
-			It("should fail validation when authentication has more than one fromParams", func() {
-				//given
-				rule := gatewayv2alpha1.Rule{
-					Jwt: &gatewayv2alpha1.JwtConfig{
-						Authentications: []*gatewayv2alpha1.JwtAuthentication{
-							{
-								Issuer:     "https://issuer.test//",
-								JwksUri:    "https://issuer.test/.well-known/jwks.json",
-								FromParams: []string{"param1", "param2"},
-							},
-						},
-					},
-				}
-
-				//when
-				problems := validateJwt("rule", &rule)
-
-				//then
-				Expect(problems).To(HaveLen(1))
-				Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications[0].fromParams"))
-				Expect(problems[0].Message).To(Equal("multiple fromParams are not supported"))
-			})
-
-			It("should fail validation when multiple authentications have mixture of fromHeaders and fromParams", func() {
-				//given
-				rule := gatewayv2alpha1.Rule{
-					Jwt: &gatewayv2alpha1.JwtConfig{
-						Authentications: []*gatewayv2alpha1.JwtAuthentication{
-							{
-								Issuer:     "https://issuer.test//",
-								JwksUri:    "file://.well-known/jwks.json",
-								FromParams: []string{"param1"},
-							},
-							{
-								Issuer:      "https://issuer.test/",
-								JwksUri:     "file://.well-known/jwks.json",
-								FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}},
-							},
-						},
-					},
-				}
-
-				//when
-				problems := validateJwt("rule", &rule)
-
-				//then
-				Expect(problems).To(HaveLen(1))
-				Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications[1].fromHeaders"))
-				Expect(problems[0].Message).To(Equal("mixture of multiple fromHeaders and fromParams is not supported"))
-			})
-		})
-
-		Context("for authorizations", func() {
-
-			It("should fail validation when authorizations is defined, but empty", func() {
-				//given
-				rule := gatewayv2alpha1.Rule{
-					Jwt: &gatewayv2alpha1.JwtConfig{
-						Authentications: []*gatewayv2alpha1.JwtAuthentication{
-							{
-								Issuer:  "https://issuer.test/",
-								JwksUri: "file://.well-known/jwks.json",
-							},
-						},
-						Authorizations: []*gatewayv2alpha1.JwtAuthorization{},
-					},
-				}
-
-				//when
-				problems := validateJwt("rule", &rule)
-
-				//then
-				Expect(problems).To(HaveLen(1))
-				Expect(problems[0].AttributePath).To(Equal("rule.jwt.authorizations"))
-				Expect(problems[0].Message).To(Equal("authorizations defined, but no configuration exists"))
-			})
-
-			It("should fail validation when authorization is empty", func() {
-				//given
-				var auth *gatewayv2alpha1.JwtAuthorization
-				rule := gatewayv2alpha1.Rule{
-					Jwt: &gatewayv2alpha1.JwtConfig{
-						Authentications: []*gatewayv2alpha1.JwtAuthentication{
-							{
-								Issuer:  "https://issuer.test/",
-								JwksUri: "file://.well-known/jwks.json",
-							},
-						},
-						Authorizations: []*gatewayv2alpha1.JwtAuthorization{
-							auth,
-						},
-					},
-				}
-
-				//when
-				problems := validateJwt("rule", &rule)
-
-				//then
-				Expect(problems).To(HaveLen(1))
-				Expect(problems[0].AttributePath).To(Equal("rule.jwt.authorizations[0]"))
-				Expect(problems[0].Message).To(Equal("authorization is empty"))
-			})
-
-			Context("required scopes", func() {
-				It("should fail for config with empty required scopes", func() {
-					//given
-					rule := gatewayv2alpha1.Rule{
-						Jwt: &gatewayv2alpha1.JwtConfig{
-							Authentications: []*gatewayv2alpha1.JwtAuthentication{
-								{
-									Issuer:  "https://issuer.test/",
-									JwksUri: "file://.well-known/jwks.json",
-								},
-							},
-							Authorizations: []*gatewayv2alpha1.JwtAuthorization{
-								{
-									RequiredScopes: []string{},
-								},
-							},
-						},
-					}
-
-					//when
-					problems := validateJwt("rule", &rule)
-
-					//then
-					Expect(problems).To(HaveLen(1))
-					Expect(problems[0].AttributePath).To(Equal("rule.jwt.authorizations[0].requiredScopes"))
-					Expect(problems[0].Message).To(Equal("value is empty"))
-				})
-
-				It("should fail for config with empty string in required scopes", func() {
-					//given
-					rule := gatewayv2alpha1.Rule{
-						Jwt: &gatewayv2alpha1.JwtConfig{
-							Authentications: []*gatewayv2alpha1.JwtAuthentication{
-								{
-									Issuer:  "https://issuer.test/",
-									JwksUri: "file://.well-known/jwks.json",
-								},
-							},
-							Authorizations: []*gatewayv2alpha1.JwtAuthorization{
-								{
-									RequiredScopes: []string{"scope-a", ""},
-								},
-							},
-						},
-					}
-
-					//when
-					problems := validateJwt("rule", &rule)
-
-					//then
-					Expect(problems).To(HaveLen(1))
-					Expect(problems[0].AttributePath).To(Equal("rule.jwt.authorizations[0].requiredScopes"))
-					Expect(problems[0].Message).To(Equal("scope value is empty"))
-				})
-
-				It("should succeed for config with two required scopes", func() {
-					//given
-					rule := gatewayv2alpha1.Rule{
-						Jwt: &gatewayv2alpha1.JwtConfig{
-							Authentications: []*gatewayv2alpha1.JwtAuthentication{
-								{
-									Issuer:  "https://issuer.test/",
-									JwksUri: "file://.well-known/jwks.json",
-								},
-							},
-							Authorizations: []*gatewayv2alpha1.JwtAuthorization{
-								{
-									RequiredScopes: []string{"scope-a", "scope-b"},
-								},
-							},
-						},
-					}
-
-					//when
-					problems := validateJwt("rule", &rule)
-
-					//then
-					Expect(problems).To(HaveLen(0))
-				})
-
-				It("should successful validate config without a required scope", func() {
-					//given
-					rule := gatewayv2alpha1.Rule{
-						Jwt: &gatewayv2alpha1.JwtConfig{
-							Authentications: []*gatewayv2alpha1.JwtAuthentication{
-								{
-									Issuer:  "https://issuer.test/",
-									JwksUri: "file://.well-known/jwks.json",
-								},
-							},
-							Authorizations: []*gatewayv2alpha1.JwtAuthorization{
-								{
-									Audiences: []string{"www.example.com"},
-								},
-							},
-						},
-					}
-
-					//when
-					problems := validateJwt("rule", &rule)
-
-					//then
-					Expect(problems).To(HaveLen(0))
-				})
-			})
-
-			Context("audiences", func() {
-
-				It("should fail validation for config with empty audiences", func() {
-					//given
-					rule := gatewayv2alpha1.Rule{
-						Jwt: &gatewayv2alpha1.JwtConfig{
-							Authentications: []*gatewayv2alpha1.JwtAuthentication{
-								{
-									Issuer:  "https://issuer.test/",
-									JwksUri: "file://.well-known/jwks.json",
-								},
-							},
-							Authorizations: []*gatewayv2alpha1.JwtAuthorization{
-								{
-									Audiences: []string{},
-								},
-							},
-						},
-					}
-
-					//when
-					problems := validateJwt("rule", &rule)
-
-					//then
-					Expect(problems).To(HaveLen(1))
-					Expect(problems[0].AttributePath).To(Equal("rule.jwt.authorizations[0].audiences"))
-					Expect(problems[0].Message).To(Equal("value is empty"))
-				})
-
-				It("should fail validation for config with empty string in audiences", func() {
-					//given
-					rule := gatewayv2alpha1.Rule{
-						Jwt: &gatewayv2alpha1.JwtConfig{
-							Authentications: []*gatewayv2alpha1.JwtAuthentication{
-								{
-									Issuer:  "https://issuer.test/",
-									JwksUri: "file://.well-known/jwks.json",
-								},
-							},
-							Authorizations: []*gatewayv2alpha1.JwtAuthorization{
-								{
-									Audiences: []string{"www.example.com", ""},
-								},
-							},
-						},
-					}
-
-					//when
-					problems := validateJwt("rule", &rule)
-
-					//then
-					Expect(problems).To(HaveLen(1))
-					Expect(problems[0].AttributePath).To(Equal("rule.jwt.authorizations[0].audiences"))
-					Expect(problems[0].Message).To(Equal("audience value is empty"))
-				})
-
-				It("should successful validate config with an audience", func() {
-					//given
-					rule := gatewayv2alpha1.Rule{
-						Jwt: &gatewayv2alpha1.JwtConfig{
-							Authentications: []*gatewayv2alpha1.JwtAuthentication{
-								{
-									Issuer:  "https://issuer.test/",
-									JwksUri: "file://.well-known/jwks.json",
-								},
-							},
-							Authorizations: []*gatewayv2alpha1.JwtAuthorization{
-								{
-									Audiences: []string{"www.example.com"},
-								},
-							},
-						},
-					}
-
-					//when
-					problems := validateJwt("rule", &rule)
-
-					//then
-					Expect(problems).To(HaveLen(0))
-				})
-
-				It("should successful validate config without audiences", func() {
-					//given
-					rule := gatewayv2alpha1.Rule{
-						Jwt: &gatewayv2alpha1.JwtConfig{
-							Authentications: []*gatewayv2alpha1.JwtAuthentication{
-								{
-									Issuer:  "https://issuer.test/",
-									JwksUri: "file://.well-known/jwks.json",
-								},
-							},
-							Authorizations: []*gatewayv2alpha1.JwtAuthorization{
-								{
-									RequiredScopes: []string{"www.example.com"},
-								},
-							},
-						},
-					}
-
-					//when
-					problems := validateJwt("rule", &rule)
-
-					//then
-					Expect(problems).To(HaveLen(0))
-				})
-			})
-		})
+var _ = Describe("validateJwt", func() {
+
+	It("should fail with empty JWT config", func() {
+		//given
+		rule := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{},
+		}
+
+		//when
+		problems := validateJwt("rule", &rule)
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications"))
+		Expect(problems[0].Message).To(Equal("A JWT config must have at least one authentication"))
 	})
 
-	Context("validateJwtAuthenticationEquality", func() {
-
-		It("should fail validation when multiple authentications fromHeaders configuration", func() {
-			//given
-			rule := gatewayv2alpha1.Rule{
-				Jwt: &gatewayv2alpha1.JwtConfig{
-					Authentications: []*gatewayv2alpha1.JwtAuthentication{
-						{
-							Issuer:      "https://issuer.test/",
-							JwksUri:     "file://.well-known/jwks.json",
-							FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}},
-						},
-						{
-							Issuer:      "https://issuer.test/",
-							JwksUri:     "file://.well-known/jwks.json",
-							FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header2"}},
-						},
+	It("should fail when Authorizations are configured, but empty Authentications", func() {
+		//given
+		rule := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authorizations: []*gatewayv2alpha1.JwtAuthorization{
+					{
+						RequiredScopes: []string{"scope-a", "scope-b"},
 					},
 				},
-			}
+			},
+		}
 
-			//when
-			problems := validateJwtAuthenticationEquality(".spec.rules", []gatewayv2alpha1.Rule{rule})
+		//when
+		problems := validateJwt("rule", &rule)
 
-			//then
-			Expect(problems).To(HaveLen(1))
-			Expect(problems[0].AttributePath).To(Equal(".spec.rules[0].jwt.authentications[1]"))
-			Expect(problems[0].Message).To(Equal("multiple jwt configurations that differ for the same issuer"))
-		})
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal("rule.jwt.authentications"))
+		Expect(problems[0].Message).To(Equal("A JWT config must have at least one authentication"))
+	})
+})
 
-		It("should fail validation when multiple authentications fromParams configuration", func() {
-			//given
-			rule := gatewayv2alpha1.Rule{
-				Jwt: &gatewayv2alpha1.JwtConfig{
-					Authentications: []*gatewayv2alpha1.JwtAuthentication{
-						{
-							Issuer:     "https://issuer.test/",
-							JwksUri:    "file://.well-known/jwks.json",
-							FromParams: []string{"param1"},
-						},
-						{
-							Issuer:     "https://issuer.test/",
-							JwksUri:    "file://.well-known/jwks.json",
-							FromParams: []string{"param2"},
-						},
+var _ = Describe("validateJwtAuthenticationEquality", func() {
+	It("should fail validation when multiple authentications fromHeaders configuration", func() {
+		//given
+		rule := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:      "https://issuer.test/",
+						JwksUri:     "file://.well-known/jwks.json",
+						FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}},
+					},
+					{
+						Issuer:      "https://issuer.test/",
+						JwksUri:     "file://.well-known/jwks.json",
+						FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header2"}},
 					},
 				},
-			}
+			},
+		}
 
-			//when
-			problems := validateJwtAuthenticationEquality(".spec.rules", []gatewayv2alpha1.Rule{rule})
+		//when
+		problems := validateJwtAuthenticationEquality(".spec.rules", []gatewayv2alpha1.Rule{rule})
 
-			//then
-			Expect(problems).To(HaveLen(1))
-			Expect(problems[0].AttributePath).To(Equal(".spec.rules[0].jwt.authentications[1]"))
-			Expect(problems[0].Message).To(Equal("multiple jwt configurations that differ for the same issuer"))
-		})
-
-		It("should fail when multiple jwt handlers specify different token from types of configurations", func() {
-			//given
-			ruleFromHeaders := gatewayv2alpha1.Rule{
-				Jwt: &gatewayv2alpha1.JwtConfig{
-					Authentications: []*gatewayv2alpha1.JwtAuthentication{
-						{
-							Issuer:      "https://issuer.test/",
-							JwksUri:     "file://.well-known/jwks.json",
-							FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}},
-						},
-					},
-				},
-			}
-
-			ruleFromParams := gatewayv2alpha1.Rule{
-				Jwt: &gatewayv2alpha1.JwtConfig{
-					Authentications: []*gatewayv2alpha1.JwtAuthentication{
-						{
-							Issuer:     "https://issuer.test/",
-							JwksUri:    "file://.well-known/jwks.json",
-							FromParams: []string{"param1"},
-						},
-					},
-				},
-			}
-
-			//when
-			problems := validateJwtAuthenticationEquality(".spec.rules", []gatewayv2alpha1.Rule{ruleFromHeaders, ruleFromParams})
-
-			//then
-			Expect(problems).To(HaveLen(1))
-			Expect(problems[0].AttributePath).To(Equal(".spec.rules[1].jwt.authentications[0]"))
-			Expect(problems[0].Message).To(Equal("multiple jwt configurations that differ for the same issuer"))
-		})
-
-		It("should fail when multiple jwt handlers specify different token from headers configuration", func() {
-			//given
-			ruleFromHeaders := gatewayv2alpha1.Rule{
-				Jwt: &gatewayv2alpha1.JwtConfig{
-					Authentications: []*gatewayv2alpha1.JwtAuthentication{
-						{
-							Issuer:      "https://issuer.test/",
-							JwksUri:     "file://.well-known/jwks.json",
-							FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}},
-						},
-					},
-				},
-			}
-
-			ruleFromHeadersDifferent := gatewayv2alpha1.Rule{
-				Jwt: &gatewayv2alpha1.JwtConfig{
-					Authentications: []*gatewayv2alpha1.JwtAuthentication{
-						{
-							Issuer:      "https://issuer.test/",
-							JwksUri:     "file://.well-known/jwks.json",
-							FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header2"}},
-						},
-					},
-				},
-			}
-
-			//when
-			problems := validateJwtAuthenticationEquality(".spec.rules", []gatewayv2alpha1.Rule{ruleFromHeaders, ruleFromHeadersDifferent})
-
-			//then
-			Expect(problems).To(HaveLen(1))
-			Expect(problems[0].AttributePath).To(Equal(".spec.rules[1].jwt.authentications[0]"))
-			Expect(problems[0].Message).To(Equal("multiple jwt configurations that differ for the same issuer"))
-		})
-
-		It("should succeed when multiple jwt handlers specify same token from headers configuration", func() {
-			//given
-			ruleFromHeaders := gatewayv2alpha1.Rule{
-				Jwt: &gatewayv2alpha1.JwtConfig{
-					Authentications: []*gatewayv2alpha1.JwtAuthentication{
-						{
-							Issuer:      "https://issuer.test/",
-							JwksUri:     "file://.well-known/jwks.json",
-							FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}},
-						},
-					},
-				},
-			}
-
-			ruleFromHeadersEqual := gatewayv2alpha1.Rule{
-				Jwt: &gatewayv2alpha1.JwtConfig{
-					Authentications: []*gatewayv2alpha1.JwtAuthentication{
-						{
-							Issuer:      "https://issuer.test/",
-							JwksUri:     "file://.well-known/jwks.json",
-							FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}},
-						},
-					},
-				},
-			}
-
-			//when
-			problems := validateJwtAuthenticationEquality(".spec.rules", []gatewayv2alpha1.Rule{ruleFromHeaders, ruleFromHeadersEqual})
-
-			//then
-			Expect(problems).To(HaveLen(0))
-		})
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal(".spec.rules[0].jwt.authentications[1]"))
+		Expect(problems[0].Message).To(Equal("multiple jwt configurations that differ for the same issuer"))
 	})
 
+	It("should fail validation when multiple authentications fromParams configuration", func() {
+		//given
+		rule := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:     "https://issuer.test/",
+						JwksUri:    "file://.well-known/jwks.json",
+						FromParams: []string{"param1"},
+					},
+					{
+						Issuer:     "https://issuer.test/",
+						JwksUri:    "file://.well-known/jwks.json",
+						FromParams: []string{"param2"},
+					},
+				},
+			},
+		}
+
+		//when
+		problems := validateJwtAuthenticationEquality(".spec.rules", []gatewayv2alpha1.Rule{rule})
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal(".spec.rules[0].jwt.authentications[1]"))
+		Expect(problems[0].Message).To(Equal("multiple jwt configurations that differ for the same issuer"))
+	})
+
+	It("should fail when multiple jwt handlers specify different token from types of configurations", func() {
+		//given
+		ruleFromHeaders := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:      "https://issuer.test/",
+						JwksUri:     "file://.well-known/jwks.json",
+						FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}},
+					},
+				},
+			},
+		}
+
+		ruleFromParams := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:     "https://issuer.test/",
+						JwksUri:    "file://.well-known/jwks.json",
+						FromParams: []string{"param1"},
+					},
+				},
+			},
+		}
+
+		//when
+		problems := validateJwtAuthenticationEquality(".spec.rules", []gatewayv2alpha1.Rule{ruleFromHeaders, ruleFromParams})
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal(".spec.rules[1].jwt.authentications[0]"))
+		Expect(problems[0].Message).To(Equal("multiple jwt configurations that differ for the same issuer"))
+	})
+
+	It("should fail when multiple jwt handlers specify different token from headers configuration", func() {
+		//given
+		ruleFromHeaders := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:      "https://issuer.test/",
+						JwksUri:     "file://.well-known/jwks.json",
+						FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}},
+					},
+				},
+			},
+		}
+
+		ruleFromHeadersDifferent := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:      "https://issuer.test/",
+						JwksUri:     "file://.well-known/jwks.json",
+						FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header2"}},
+					},
+				},
+			},
+		}
+
+		//when
+		problems := validateJwtAuthenticationEquality(".spec.rules", []gatewayv2alpha1.Rule{ruleFromHeaders, ruleFromHeadersDifferent})
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal(".spec.rules[1].jwt.authentications[0]"))
+		Expect(problems[0].Message).To(Equal("multiple jwt configurations that differ for the same issuer"))
+	})
+
+	It("should succeed when multiple jwt handlers specify same token from headers configuration", func() {
+		//given
+		ruleFromHeaders := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:      "https://issuer.test/",
+						JwksUri:     "file://.well-known/jwks.json",
+						FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}},
+					},
+				},
+			},
+		}
+
+		ruleFromHeadersEqual := gatewayv2alpha1.Rule{
+			Jwt: &gatewayv2alpha1.JwtConfig{
+				Authentications: []*gatewayv2alpha1.JwtAuthentication{
+					{
+						Issuer:      "https://issuer.test/",
+						JwksUri:     "file://.well-known/jwks.json",
+						FromHeaders: []*gatewayv2alpha1.JwtHeader{{Name: "header1"}},
+					},
+				},
+			},
+		}
+
+		//when
+		problems := validateJwtAuthenticationEquality(".spec.rules", []gatewayv2alpha1.Rule{ruleFromHeaders, ruleFromHeadersEqual})
+
+		//then
+		Expect(problems).To(HaveLen(0))
+	})
 })

--- a/internal/validation/v2alpha1/rules.go
+++ b/internal/validation/v2alpha1/rules.go
@@ -1,0 +1,74 @@
+package v2alpha1
+
+import (
+	"context"
+	"fmt"
+	gatewayv2alpha1 "github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
+	"github.com/kyma-project/api-gateway/internal/validation"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func validateRules(ctx context.Context, client client.Client, parentAttributePath string, apiRule *gatewayv2alpha1.APIRule) []validation.Failure {
+	var problems []validation.Failure
+
+	rules := apiRule.Spec.Rules
+	if len(rules) == 0 {
+		problems = append(problems, validation.Failure{AttributePath: parentAttributePath, Message: "No rules defined"})
+		return problems
+	}
+
+	if hasPathAndMethodDuplicates(rules) {
+		problems = append(problems, validation.Failure{AttributePath: parentAttributePath, Message: "multiple rules defined for the same path and method"})
+	}
+
+	for i, rule := range rules {
+		ruleAttributePath := fmt.Sprintf("%s[%d]", parentAttributePath, i)
+
+		if apiRule.Spec.Service == nil && rule.Service == nil {
+			problems = append(problems, validation.Failure{AttributePath: ruleAttributePath + ".service", Message: "The rule must contain a service, because no service set on spec level"})
+		}
+
+		if rule.Jwt != nil {
+			injectionFailures, err := validateSidecarInjection(ctx, client, ruleAttributePath, apiRule, rule)
+			if err != nil {
+				problems = append(problems, validation.Failure{AttributePath: ruleAttributePath, Message: fmt.Sprintf("Failed to execute sidecar injection validation, err: %s", err)})
+			}
+
+			problems = append(problems, injectionFailures...)
+
+			jwtFailures := validateJwt(ruleAttributePath, &rule)
+			problems = append(problems, jwtFailures...)
+		}
+
+	}
+
+	jwtAuthFailures := validateJwtAuthenticationEquality(".spec.rules", rules)
+	problems = append(problems, jwtAuthFailures...)
+
+	return problems
+}
+
+func hasPathAndMethodDuplicates(rules []gatewayv2alpha1.Rule) bool {
+	duplicates := map[string]bool{}
+
+	if len(rules) > 1 {
+		for _, rule := range rules {
+			if len(rule.Methods) > 0 {
+				for _, method := range rule.Methods {
+					tmp := fmt.Sprintf("%s:%s", rule.Path, method)
+					if duplicates[tmp] {
+						return true
+					}
+					duplicates[tmp] = true
+				}
+			} else {
+				if duplicates[rule.Path] {
+					return true
+				}
+				duplicates[rule.Path] = true
+			}
+		}
+	}
+
+	return false
+}

--- a/internal/validation/v2alpha1/rules.go
+++ b/internal/validation/v2alpha1/rules.go
@@ -25,7 +25,7 @@ func validateRules(ctx context.Context, client client.Client, parentAttributePat
 		ruleAttributePath := fmt.Sprintf("%s[%d]", parentAttributePath, i)
 
 		if apiRule.Spec.Service == nil && rule.Service == nil {
-			problems = append(problems, validation.Failure{AttributePath: ruleAttributePath + ".service", Message: "The rule must contain a service, because no service set on spec level"})
+			problems = append(problems, validation.Failure{AttributePath: ruleAttributePath + ".service", Message: "The rule must define a service, because no service is defined on spec level"})
 		}
 
 		if rule.Jwt != nil {

--- a/internal/validation/v2alpha1/rules.go
+++ b/internal/validation/v2alpha1/rules.go
@@ -10,19 +10,20 @@ import (
 
 func validateRules(ctx context.Context, client client.Client, parentAttributePath string, apiRule *gatewayv2alpha1.APIRule) []validation.Failure {
 	var problems []validation.Failure
+	rulesAttributePath := parentAttributePath + ".rules"
 
 	rules := apiRule.Spec.Rules
 	if len(rules) == 0 {
-		problems = append(problems, validation.Failure{AttributePath: parentAttributePath, Message: "No rules defined"})
+		problems = append(problems, validation.Failure{AttributePath: rulesAttributePath, Message: "No rules defined"})
 		return problems
 	}
 
 	if hasPathAndMethodDuplicates(rules) {
-		problems = append(problems, validation.Failure{AttributePath: parentAttributePath, Message: "multiple rules defined for the same path and method"})
+		problems = append(problems, validation.Failure{AttributePath: rulesAttributePath, Message: "multiple rules defined for the same path and method"})
 	}
 
 	for i, rule := range rules {
-		ruleAttributePath := fmt.Sprintf("%s[%d]", parentAttributePath, i)
+		ruleAttributePath := fmt.Sprintf("%s[%d]", rulesAttributePath, i)
 
 		if apiRule.Spec.Service == nil && rule.Service == nil {
 			problems = append(problems, validation.Failure{AttributePath: ruleAttributePath + ".service", Message: "The rule must define a service, because no service is defined on spec level"})
@@ -42,7 +43,7 @@ func validateRules(ctx context.Context, client client.Client, parentAttributePat
 
 	}
 
-	jwtAuthFailures := validateJwtAuthenticationEquality(".spec.rules", rules)
+	jwtAuthFailures := validateJwtAuthenticationEquality(rulesAttributePath, rules)
 	problems = append(problems, jwtAuthFailures...)
 
 	return problems

--- a/internal/validation/v2alpha1/rules_test.go
+++ b/internal/validation/v2alpha1/rules_test.go
@@ -100,11 +100,6 @@ var _ = Describe("Validate rules", func() {
 
 		//then
 		Expect(problems).To(HaveLen(2))
-		Expect(problems[0].AttributePath).To(Equal(".spec.rules"))
-		Expect(problems[0].Message).To(Equal("multiple rules defined for the same path and method"))
-
-		Expect(problems[1].AttributePath).To(Equal(".spec.rules[2].jwt.authentications"))
-		Expect(problems[1].Message).To(Equal("A JWT config must have at least one authentication"))
 	})
 
 	It("should fail for the same path and method", func() {

--- a/internal/validation/v2alpha1/rules_test.go
+++ b/internal/validation/v2alpha1/rules_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
 	"net/http"
@@ -309,7 +308,7 @@ var _ = Describe("Validate rules", func() {
 		fakeClient := createFakeClient(service)
 
 		//when
-		problems := (&APIRuleValidator{ApiRule: apiRule}).Validate(context.Background(), fakeClient, networkingv1beta1.VirtualServiceList{})
+		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
 
 		// then
 		Expect(problems).To(HaveLen(1))

--- a/internal/validation/v2alpha1/rules_test.go
+++ b/internal/validation/v2alpha1/rules_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Validate rules", func() {
 		fakeClient := createFakeClient(service)
 
 		//when
-		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
+		problems := validateRules(context.Background(), fakeClient, ".spec", apiRule)
 
 		//then
 		Expect(problems).To(HaveLen(1))
@@ -54,7 +54,7 @@ var _ = Describe("Validate rules", func() {
 		fakeClient := createFakeClient(service)
 
 		//when
-		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
+		problems := validateRules(context.Background(), fakeClient, ".spec", apiRule)
 
 		//then
 		Expect(problems).To(HaveLen(1))
@@ -96,7 +96,7 @@ var _ = Describe("Validate rules", func() {
 		fakeClient := createFakeClient(service)
 
 		//when
-		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
+		problems := validateRules(context.Background(), fakeClient, ".spec", apiRule)
 
 		//then
 		Expect(problems).To(HaveLen(2))
@@ -132,7 +132,7 @@ var _ = Describe("Validate rules", func() {
 		fakeClient := createFakeClient(service)
 
 		//when
-		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
+		problems := validateRules(context.Background(), fakeClient, ".spec", apiRule)
 
 		//then
 		Expect(problems).To(HaveLen(1))
@@ -168,7 +168,7 @@ var _ = Describe("Validate rules", func() {
 		fakeClient := createFakeClient(service)
 
 		//when
-		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
+		problems := validateRules(context.Background(), fakeClient, ".spec", apiRule)
 
 		//then
 		Expect(problems).To(HaveLen(0))
@@ -195,7 +195,7 @@ var _ = Describe("Validate rules", func() {
 		fakeClient := createFakeClient(service)
 
 		//when
-		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
+		problems := validateRules(context.Background(), fakeClient, ".spec", apiRule)
 
 		//then
 		Expect(problems).To(HaveLen(0))
@@ -222,7 +222,7 @@ var _ = Describe("Validate rules", func() {
 		fakeClient := createFakeClient(service)
 
 		//when
-		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
+		problems := validateRules(context.Background(), fakeClient, ".spec", apiRule)
 
 		//then
 		Expect(problems).To(HaveLen(0))
@@ -248,7 +248,7 @@ var _ = Describe("Validate rules", func() {
 		fakeClient := createFakeClient(service)
 
 		//when
-		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
+		problems := validateRules(context.Background(), fakeClient, ".spec", apiRule)
 
 		//then
 		Expect(problems).To(HaveLen(0))
@@ -274,7 +274,7 @@ var _ = Describe("Validate rules", func() {
 		fakeClient := createFakeClient(service)
 
 		//when
-		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
+		problems := validateRules(context.Background(), fakeClient, ".spec", apiRule)
 
 		//then
 		Expect(problems).To(HaveLen(0))
@@ -308,7 +308,7 @@ var _ = Describe("Validate rules", func() {
 		fakeClient := createFakeClient(service)
 
 		//when
-		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
+		problems := validateRules(context.Background(), fakeClient, ".spec", apiRule)
 
 		// then
 		Expect(problems).To(HaveLen(1))

--- a/internal/validation/v2alpha1/rules_test.go
+++ b/internal/validation/v2alpha1/rules_test.go
@@ -1,0 +1,319 @@
+package v2alpha1
+
+import (
+	"context"
+	"github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/utils/ptr"
+	"net/http"
+)
+
+var _ = Describe("Validate rules", func() {
+	sampleServiceName := "some-service"
+	host := v2alpha1.Host(sampleServiceName + ".test.dev")
+
+	It("should fail for empty rules", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			Spec: v2alpha1.APIRuleSpec{
+				Rules:   nil,
+				Service: getApiRuleService(sampleServiceName, uint32(8080)),
+				Hosts:   []*v2alpha1.Host{&host},
+			},
+		}
+
+		service := getService(sampleServiceName)
+		fakeClient := createFakeClient(service)
+
+		//when
+		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal(".spec.rules"))
+		Expect(problems[0].Message).To(Equal("No rules defined"))
+	})
+
+	It("should return an error when no service is defined for rule with no service on spec level", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			Spec: v2alpha1.APIRuleSpec{
+				Hosts: []*v2alpha1.Host{&host},
+				Rules: []v2alpha1.Rule{
+					{
+						Path:   "/abc",
+						NoAuth: ptr.To(true),
+					},
+				},
+			},
+		}
+
+		service := getService(sampleServiceName, "default")
+		fakeClient := createFakeClient(service)
+
+		//when
+		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal(".spec.rules[0].service"))
+		Expect(problems[0].Message).To(Equal("The rule must define a service, because no service is defined on spec level"))
+	})
+
+	It("should report multiple problem at once", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			Spec: v2alpha1.APIRuleSpec{
+				Service: getApiRuleService(sampleServiceName, uint32(8080)),
+				Hosts:   []*v2alpha1.Host{&host},
+				Rules: []v2alpha1.Rule{
+					{
+						Path: "/abc",
+						Jwt: &v2alpha1.JwtConfig{
+							Authentications: []*v2alpha1.JwtAuthentication{
+								{
+									Issuer:  "https://issuer.example.com",
+									JwksUri: "https://issuer.test/.well-known/jwks.json",
+								},
+							},
+						},
+					},
+					{
+						Path:   "/abc",
+						NoAuth: ptr.To(true),
+					},
+					{
+						Path: "/test",
+						Jwt:  &v2alpha1.JwtConfig{},
+					},
+				},
+			},
+		}
+
+		service := getService(sampleServiceName)
+		fakeClient := createFakeClient(service)
+
+		//when
+		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
+
+		//then
+		Expect(problems).To(HaveLen(2))
+		Expect(problems[0].AttributePath).To(Equal(".spec.rules"))
+		Expect(problems[0].Message).To(Equal("multiple rules defined for the same path and method"))
+
+		Expect(problems[1].AttributePath).To(Equal(".spec.rules[2].jwt.authentications"))
+		Expect(problems[1].Message).To(Equal("A JWT config must have at least one authentication"))
+	})
+
+	It("should fail for the same path and method", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			Spec: v2alpha1.APIRuleSpec{
+				Service: getApiRuleService(sampleServiceName, uint32(8080)),
+				Hosts:   []*v2alpha1.Host{&host},
+				Rules: []v2alpha1.Rule{
+					{
+						Path:    "/abc",
+						NoAuth:  ptr.To(true),
+						Methods: []v2alpha1.HttpMethod{http.MethodGet},
+					},
+					{
+						Path:    "/abc",
+						NoAuth:  ptr.To(true),
+						Methods: []v2alpha1.HttpMethod{http.MethodGet, http.MethodPost},
+					},
+				},
+			},
+		}
+
+		service := getService(sampleServiceName)
+		fakeClient := createFakeClient(service)
+
+		//when
+		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal(".spec.rules"))
+		Expect(problems[0].Message).To(Equal("multiple rules defined for the same path and method"))
+	})
+
+	It("should succeed for the same path but different methods", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			ObjectMeta: metav1.ObjectMeta{
+				UID: "67890",
+			},
+			Spec: v2alpha1.APIRuleSpec{
+				Service: getApiRuleService(sampleServiceName, uint32(8080)),
+				Hosts:   []*v2alpha1.Host{&host},
+				Rules: []v2alpha1.Rule{
+					{
+						Path:    "/abc",
+						NoAuth:  ptr.To(true),
+						Methods: []v2alpha1.HttpMethod{http.MethodPost},
+					},
+					{
+						Path:    "/abc",
+						NoAuth:  ptr.To(true),
+						Methods: []v2alpha1.HttpMethod{http.MethodGet},
+					},
+				},
+			},
+		}
+
+		service := getService(sampleServiceName)
+		fakeClient := createFakeClient(service)
+
+		//when
+		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
+
+		//then
+		Expect(problems).To(HaveLen(0))
+	})
+
+	It("should not fail with service without labels selector by when NoAuth is used", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			Spec: v2alpha1.APIRuleSpec{
+				Rules: []v2alpha1.Rule{
+					{
+						Path:    "/abc",
+						NoAuth:  ptr.To(true),
+						Methods: []v2alpha1.HttpMethod{http.MethodPost},
+					},
+				},
+				Service: getApiRuleService(sampleServiceName, uint32(8080)),
+				Hosts:   []*v2alpha1.Host{&host},
+			},
+		}
+
+		service := getService(sampleServiceName)
+		service.Spec.Selector = map[string]string{}
+		fakeClient := createFakeClient(service)
+
+		//when
+		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
+
+		//then
+		Expect(problems).To(HaveLen(0))
+	})
+
+	It("should not fail with service on path level when NoAuth is used", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			Spec: v2alpha1.APIRuleSpec{
+				Rules: []v2alpha1.Rule{
+					{
+						Path:    "/abc",
+						Service: getApiRuleService(sampleServiceName, uint32(8080)),
+						NoAuth:  ptr.To(true),
+						Methods: []v2alpha1.HttpMethod{http.MethodPost},
+					},
+				},
+				Hosts: []*v2alpha1.Host{&host},
+			},
+		}
+
+		service := getService(sampleServiceName)
+		service.Spec.Selector = map[string]string{}
+		fakeClient := createFakeClient(service)
+
+		//when
+		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
+
+		//then
+		Expect(problems).To(HaveLen(0))
+	})
+
+	It("should succeed with service without namespace", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			Spec: v2alpha1.APIRuleSpec{
+				Rules: []v2alpha1.Rule{
+					{
+						Path:    "/abc",
+						NoAuth:  ptr.To(true),
+						Methods: []v2alpha1.HttpMethod{http.MethodPost},
+					},
+				},
+				Service: getApiRuleService(sampleServiceName, uint32(8080)),
+				Hosts:   []*v2alpha1.Host{&host},
+			},
+		}
+
+		service := getService(sampleServiceName)
+		fakeClient := createFakeClient(service)
+
+		//when
+		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
+
+		//then
+		Expect(problems).To(HaveLen(0))
+	})
+
+	It("should succeed with service on path level without namespace", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			Spec: v2alpha1.APIRuleSpec{
+				Rules: []v2alpha1.Rule{
+					{
+						Path:    "/abc",
+						Service: getApiRuleService(sampleServiceName, uint32(8080)),
+						NoAuth:  ptr.To(true),
+						Methods: []v2alpha1.HttpMethod{http.MethodPost},
+					},
+				},
+				Hosts: []*v2alpha1.Host{&host},
+			},
+		}
+
+		service := getService(sampleServiceName)
+		fakeClient := createFakeClient(service)
+
+		//when
+		problems := validateRules(context.Background(), fakeClient, ".spec.rules", apiRule)
+
+		//then
+		Expect(problems).To(HaveLen(0))
+	})
+
+	It("should invoke sidecar injection validation", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			Spec: v2alpha1.APIRuleSpec{
+				Service: getApiRuleService(sampleServiceName, uint32(8080)),
+				Hosts:   []*v2alpha1.Host{&host},
+				Rules: []v2alpha1.Rule{
+					{
+						Path:   "/abc",
+						NoAuth: ptr.To(true),
+						Jwt: &v2alpha1.JwtConfig{
+							Authentications: []*v2alpha1.JwtAuthentication{
+								{
+									Issuer:  "https://issuer.example.com",
+									JwksUri: "https://issuer.test/.well-known/jwks.json",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		service := getService(sampleServiceName)
+		service.Spec.Selector = map[string]string{}
+		fakeClient := createFakeClient(service)
+
+		//when
+		problems := (&APIRuleValidator{ApiRule: apiRule}).Validate(context.Background(), fakeClient, networkingv1beta1.VirtualServiceList{})
+
+		// then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal(".spec.rules[0].injection"))
+		Expect(problems[0].Message).To(Equal("Service cannot have empty label selectors when the API Rule strategy is JWT"))
+	})
+})

--- a/internal/validation/v2alpha1/sidecar_injection.go
+++ b/internal/validation/v2alpha1/sidecar_injection.go
@@ -1,0 +1,83 @@
+package v2alpha1
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-logr/logr"
+	gatewayv2alpha1 "github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
+	"github.com/kyma-project/api-gateway/internal/validation"
+	apiv1beta1 "istio.io/api/type/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+func validateSidecarInjection(ctx context.Context, k8sClient client.Client, parentAttributePath string, apiRule *gatewayv2alpha1.APIRule, rule gatewayv2alpha1.Rule) (problems []validation.Failure, err error) {
+
+	var ruleForLabelSelector *gatewayv2alpha1.Rule
+	if rule.Service != nil {
+		// We only need to consider the rule's service if it's set, since rule service takes precedence over spec service
+		ruleForLabelSelector = &rule
+	} else if apiRule.Spec.Service != nil {
+		ruleForLabelSelector = nil
+	}
+
+	serviceWorkloadSelector, err := getLabelSelectorFromService(ctx, k8sClient, apiRule.Spec.Service, apiRule, ruleForLabelSelector)
+	if err != nil {
+		l, errorCtx := logr.FromContext(ctx)
+		if errorCtx != nil {
+			ctrl.Log.Error(errorCtx, "No logger in context.", "context", ctx)
+		} else {
+			l.Info("Couldn't get label selectors for service", "error", err)
+		}
+	}
+
+	serviceNamespace := findServiceNamespace(apiRule, &rule)
+
+	return validation.NewInjectionValidator(ctx, k8sClient).Validate(parentAttributePath, serviceWorkloadSelector, serviceNamespace)
+}
+
+func findServiceNamespace(api *gatewayv2alpha1.APIRule, rule *gatewayv2alpha1.Rule) string {
+	// Fallback direction for the upstream service namespace: Rule.Service > Spec.Service > APIRule
+	if rule != nil && rule.Service != nil && rule.Service.Namespace != nil {
+		return *rule.Service.Namespace
+	}
+	if api != nil && api.Spec.Service != nil && api.Spec.Service.Namespace != nil {
+		return *api.Spec.Service.Namespace
+	}
+	return api.Namespace
+}
+
+func getLabelSelectorFromService(ctx context.Context, client client.Client, service *gatewayv2alpha1.Service, api *gatewayv2alpha1.APIRule, rule *gatewayv2alpha1.Rule) (*apiv1beta1.WorkloadSelector, error) {
+	workloadSelector := apiv1beta1.WorkloadSelector{}
+
+	if service == nil || service.Name == nil {
+		return &workloadSelector, fmt.Errorf("service name is required but missing")
+	}
+	nsName := types.NamespacedName{Name: *service.Name}
+	if service.Namespace != nil {
+		nsName.Namespace = *service.Namespace
+	} else {
+		nsName.Namespace = findServiceNamespace(api, rule)
+	}
+
+	if nsName.Namespace == "" {
+		nsName.Namespace = "default"
+	}
+
+	svc := &corev1.Service{}
+	err := client.Get(ctx, nsName, svc)
+	if err != nil {
+		return &workloadSelector, err
+	}
+
+	if len(svc.Spec.Selector) == 0 {
+		return nil, nil
+	}
+	workloadSelector.MatchLabels = map[string]string{}
+	for label, value := range svc.Spec.Selector {
+		workloadSelector.MatchLabels[label] = value
+	}
+	return &workloadSelector, nil
+}

--- a/internal/validation/v2alpha1/sidecar_injection.go
+++ b/internal/validation/v2alpha1/sidecar_injection.go
@@ -3,79 +3,81 @@ package v2alpha1
 import (
 	"context"
 	"fmt"
-	"github.com/go-logr/logr"
 	gatewayv2alpha1 "github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
 	"github.com/kyma-project/api-gateway/internal/validation"
 	apiv1beta1 "istio.io/api/type/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func validateSidecarInjection(ctx context.Context, k8sClient client.Client, parentAttributePath string, apiRule *gatewayv2alpha1.APIRule, rule gatewayv2alpha1.Rule) (problems []validation.Failure, err error) {
 
-	var ruleForLabelSelector *gatewayv2alpha1.Rule
-	if rule.Service != nil {
-		// We only need to consider the rule's service if it's set, since rule service takes precedence over spec service
-		ruleForLabelSelector = &rule
-	}
-
-	serviceWorkloadSelector, err := getLabelSelectorFromService(ctx, k8sClient, apiRule.Spec.Service, apiRule, ruleForLabelSelector)
+	podWorkloadSelector, err := getSelectorFromService(ctx, k8sClient, apiRule, rule)
 	if err != nil {
-		l, errorCtx := logr.FromContext(ctx)
-		if errorCtx != nil {
-			ctrl.Log.Error(errorCtx, "No logger in context.", "context", ctx)
-		} else {
-			l.Info("Couldn't get label selectors for service", "error", err)
-		}
+		return nil, err
 	}
 
-	serviceNamespace := findServiceNamespace(apiRule, &rule)
-
-	return validation.NewInjectionValidator(ctx, k8sClient).Validate(parentAttributePath, serviceWorkloadSelector, serviceNamespace)
+	return validation.NewInjectionValidator(ctx, k8sClient).Validate(parentAttributePath, podWorkloadSelector.selector, podWorkloadSelector.namespace)
 }
 
-func findServiceNamespace(api *gatewayv2alpha1.APIRule, rule *gatewayv2alpha1.Rule) string {
+func findServiceNamespace(apiRule *gatewayv2alpha1.APIRule, rule gatewayv2alpha1.Rule) string {
 	// Fallback direction for the upstream service namespace: Rule.Service > Spec.Service > APIRule
-	if rule != nil && rule.Service != nil && rule.Service.Namespace != nil {
+	if rule.Service != nil && rule.Service.Namespace != nil {
 		return *rule.Service.Namespace
 	}
-	if api != nil && api.Spec.Service != nil && api.Spec.Service.Namespace != nil {
-		return *api.Spec.Service.Namespace
+	if apiRule != nil && apiRule.Spec.Service != nil && apiRule.Spec.Service.Namespace != nil {
+		return *apiRule.Spec.Service.Namespace
 	}
-	return api.Namespace
+	return apiRule.Namespace
 }
 
-func getLabelSelectorFromService(ctx context.Context, client client.Client, service *gatewayv2alpha1.Service, api *gatewayv2alpha1.APIRule, rule *gatewayv2alpha1.Rule) (*apiv1beta1.WorkloadSelector, error) {
-	workloadSelector := apiv1beta1.WorkloadSelector{}
+type podSelector struct {
+	selector  *apiv1beta1.WorkloadSelector
+	namespace string
+}
+
+func getSelectorFromService(ctx context.Context, client client.Client, apiRule *gatewayv2alpha1.APIRule, rule gatewayv2alpha1.Rule) (podSelector, error) {
+
+	var service *gatewayv2alpha1.Service
+	if rule.Service != nil {
+		service = rule.Service
+	} else {
+		service = apiRule.Spec.Service
+	}
 
 	if service == nil || service.Name == nil {
-		return &workloadSelector, fmt.Errorf("service name is required but missing")
+		return podSelector{}, fmt.Errorf("service name is required but missing")
 	}
-	nsName := types.NamespacedName{Name: *service.Name}
+	serviceNamespacedName := types.NamespacedName{Name: *service.Name}
 	if service.Namespace != nil {
-		nsName.Namespace = *service.Namespace
+		serviceNamespacedName.Namespace = *service.Namespace
 	} else {
-		nsName.Namespace = findServiceNamespace(api, rule)
+		serviceNamespacedName.Namespace = findServiceNamespace(apiRule, rule)
 	}
 
-	if nsName.Namespace == "" {
-		nsName.Namespace = "default"
+	if serviceNamespacedName.Namespace == "" {
+		serviceNamespacedName.Namespace = "default"
 	}
 
 	svc := &corev1.Service{}
-	err := client.Get(ctx, nsName, svc)
+	err := client.Get(ctx, serviceNamespacedName, svc)
 	if err != nil {
-		return &workloadSelector, err
+		return podSelector{}, err
 	}
 
 	if len(svc.Spec.Selector) == 0 {
-		return nil, nil
+		return podSelector{}, nil
 	}
+
+	workloadSelector := apiv1beta1.WorkloadSelector{}
 	workloadSelector.MatchLabels = map[string]string{}
 	for label, value := range svc.Spec.Selector {
 		workloadSelector.MatchLabels[label] = value
 	}
-	return &workloadSelector, nil
+
+	return podSelector{
+		selector:  &workloadSelector,
+		namespace: serviceNamespacedName.Namespace,
+	}, nil
 }

--- a/internal/validation/v2alpha1/sidecar_injection.go
+++ b/internal/validation/v2alpha1/sidecar_injection.go
@@ -19,8 +19,6 @@ func validateSidecarInjection(ctx context.Context, k8sClient client.Client, pare
 	if rule.Service != nil {
 		// We only need to consider the rule's service if it's set, since rule service takes precedence over spec service
 		ruleForLabelSelector = &rule
-	} else if apiRule.Spec.Service != nil {
-		ruleForLabelSelector = nil
 	}
 
 	serviceWorkloadSelector, err := getLabelSelectorFromService(ctx, k8sClient, apiRule.Spec.Service, apiRule, ruleForLabelSelector)

--- a/internal/validation/v2alpha1/sidecar_injection_test.go
+++ b/internal/validation/v2alpha1/sidecar_injection_test.go
@@ -1,0 +1,408 @@
+package v2alpha1
+
+import (
+	"context"
+	"github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
+	"k8s.io/utils/ptr"
+	"net/http"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+var _ = Describe("Sidecar injection validation", func() {
+	It("should use service namespace and name from rule for pod selection when it's defined", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "api-rule",
+				Namespace: "api-rule-ns",
+			},
+			Spec: v2alpha1.APIRuleSpec{
+				Service: getApiRuleService("spec-level", uint32(8080), ptr.To("spec-level-ns")),
+				Rules: []v2alpha1.Rule{
+					{
+						Path:    "/abc",
+						Service: getApiRuleService("rule-level", uint32(8080), ptr.To("rule-level-ns")),
+						NoAuth:  ptr.To(true),
+						Methods: []v2alpha1.HttpMethod{http.MethodPost},
+					},
+				},
+				Hosts: getHosts("test.dev"),
+			},
+		}
+
+		ruleService := getService("rule-level", "rule-level-ns")
+		specService := getService("spec-level", "spec-level-ns")
+		ruleLevelNs := getNamespace("rule-level-ns")
+		specLevelNs := getNamespace("spec-level-ns")
+
+		fakeClient := createFakeClient(ruleService, specService, ruleLevelNs, specLevelNs)
+
+		err := fakeClient.Create(context.Background(), &corev1.Pod{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test",
+				Namespace: "rule-level-ns",
+				Labels: map[string]string{
+					"app": "rule-level",
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		//when
+		problems, err := validateSidecarInjection(context.Background(), fakeClient, "some.attribute", apiRule, apiRule.Spec.Rules[0])
+		Expect(err).NotTo(HaveOccurred())
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].Message).To(Equal("Pod rule-level-ns/test does not have an injected istio sidecar"))
+	})
+
+	It("should use service namespace from spec and service name from rule for pod selection when no service namespace is defined on rule-level", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "api-rule",
+				Namespace: "api-rule-ns",
+			},
+			Spec: v2alpha1.APIRuleSpec{
+				Service: getApiRuleService("spec-level", uint32(8080), ptr.To("spec-level-ns")),
+				Rules: []v2alpha1.Rule{
+					{
+						Path:    "/abc",
+						Service: getApiRuleService("rule-level", uint32(8080)),
+						NoAuth:  ptr.To(true),
+						Methods: []v2alpha1.HttpMethod{http.MethodPost},
+					},
+				},
+				Hosts: getHosts("test.dev"),
+			},
+		}
+
+		ruleService := getService("rule-level", "spec-level-ns")
+		specService := getService("spec-level", "spec-level-ns")
+		specLevelNs := getNamespace("spec-level-ns")
+		fakeClient := createFakeClient(ruleService, specService, specLevelNs)
+
+		err := fakeClient.Create(context.Background(), &corev1.Pod{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test",
+				Namespace: "spec-level-ns",
+				Labels: map[string]string{
+					"app": "rule-level",
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		//when
+		problems, err := validateSidecarInjection(context.Background(), fakeClient, "some.attribute", apiRule, apiRule.Spec.Rules[0])
+		Expect(err).NotTo(HaveOccurred())
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].Message).To(Equal("Pod spec-level-ns/test does not have an injected istio sidecar"))
+	})
+
+	It("should use service namespace and name from spec for pod selection when no service is defined on rule-level", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "api-rule",
+				Namespace: "api-rule-ns",
+			},
+			Spec: v2alpha1.APIRuleSpec{
+				Service: getApiRuleService("spec-level", uint32(8080), ptr.To("spec-level-ns")),
+				Rules: []v2alpha1.Rule{
+					{
+						Path:    "/abc",
+						NoAuth:  ptr.To(true),
+						Methods: []v2alpha1.HttpMethod{http.MethodPost},
+					},
+				},
+				Hosts: getHosts("test.dev"),
+			},
+		}
+
+		specService := getService("spec-level", "spec-level-ns")
+		specLevelNs := getNamespace("spec-level-ns")
+		fakeClient := createFakeClient(specService, specLevelNs)
+
+		err := fakeClient.Create(context.Background(), &corev1.Pod{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test",
+				Namespace: "spec-level-ns",
+				Labels: map[string]string{
+					"app": "spec-level",
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		//when
+		problems, err := validateSidecarInjection(context.Background(), fakeClient, "some.attribute", apiRule, apiRule.Spec.Rules[0])
+		Expect(err).NotTo(HaveOccurred())
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].Message).To(Equal("Pod spec-level-ns/test does not have an injected istio sidecar"))
+	})
+
+	It("should use service namespace from APIRule and service name from rule for pod selection when no service namespace is defined on spec or rule", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "api-rule",
+				Namespace: "api-rule-ns",
+			},
+			Spec: v2alpha1.APIRuleSpec{
+				Service: getApiRuleService("spec-level", uint32(8080)),
+				Rules: []v2alpha1.Rule{
+					{
+						Path:    "/abc",
+						Service: getApiRuleService("rule-level", uint32(8080)),
+						NoAuth:  ptr.To(true),
+						Methods: []v2alpha1.HttpMethod{http.MethodPost},
+					},
+				},
+				Hosts: getHosts("test.dev"),
+			},
+		}
+
+		ruleService := getService("rule-level", "api-rule-ns")
+		specService := getService("spec-level", "api-rule-ns")
+		apiRuleNs := getNamespace("api-rule-ns")
+
+		fakeClient := createFakeClient(ruleService, specService, apiRuleNs)
+
+		err := fakeClient.Create(context.Background(), &corev1.Pod{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test",
+				Namespace: "api-rule-ns",
+				Labels: map[string]string{
+					"app": "rule-level",
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		//when
+		problems, err := validateSidecarInjection(context.Background(), fakeClient, "some.attribute", apiRule, apiRule.Spec.Rules[0])
+		Expect(err).NotTo(HaveOccurred())
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].Message).To(Equal("Pod api-rule-ns/test does not have an injected istio sidecar"))
+	})
+
+	It("should use service namespace from APIRule and service name from spec for pod selection when no service namespace is defined on spec or rule", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "api-rule",
+				Namespace: "api-rule-ns",
+			},
+			Spec: v2alpha1.APIRuleSpec{
+				Service: getApiRuleService("spec-level", uint32(8080)),
+				Rules: []v2alpha1.Rule{
+					{
+						Path:    "/abc",
+						NoAuth:  ptr.To(true),
+						Methods: []v2alpha1.HttpMethod{http.MethodPost},
+					},
+				},
+				Hosts: getHosts("test.dev"),
+			},
+		}
+
+		specService := getService("spec-level", "api-rule-ns")
+		apiRuleNs := getNamespace("api-rule-ns")
+
+		fakeClient := createFakeClient(specService, apiRuleNs)
+
+		err := fakeClient.Create(context.Background(), &corev1.Pod{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test",
+				Namespace: "api-rule-ns",
+				Labels: map[string]string{
+					"app": "spec-level",
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		//when
+		problems, err := validateSidecarInjection(context.Background(), fakeClient, "some.attribute", apiRule, apiRule.Spec.Rules[0])
+		Expect(err).NotTo(HaveOccurred())
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].Message).To(Equal("Pod api-rule-ns/test does not have an injected istio sidecar"))
+	})
+
+	It("should use 'default' as service namespace for pod selection and service name from rule when service namespace contains an empty string", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "api-rule",
+				Namespace: "api-rule-ns",
+			},
+			Spec: v2alpha1.APIRuleSpec{
+				Service: getApiRuleService("spec-level", uint32(8080), ptr.To("")),
+				Rules: []v2alpha1.Rule{
+					{
+						Path:    "/abc",
+						Service: getApiRuleService("rule-level", uint32(8080)),
+						NoAuth:  ptr.To(true),
+						Methods: []v2alpha1.HttpMethod{http.MethodPost},
+					},
+				},
+				Hosts: getHosts("test.dev"),
+			},
+		}
+
+		ruleService := getService("rule-level", "default")
+		specService := getService("spec-level", "default")
+		ruleLevelNs := getNamespace("rule-level-ns")
+		specLevelNs := getNamespace("spec-level-ns")
+		defaultNs := getNamespace("default")
+		fakeClient := createFakeClient(ruleService, specService, ruleLevelNs, specLevelNs, defaultNs)
+
+		err := fakeClient.Create(context.Background(), &corev1.Pod{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+				Labels: map[string]string{
+					"app": "rule-level",
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		//when
+		problems, err := validateSidecarInjection(context.Background(), fakeClient, "some.attribute", apiRule, apiRule.Spec.Rules[0])
+		Expect(err).NotTo(HaveOccurred())
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].Message).To(Equal("Pod default/test does not have an injected istio sidecar"))
+	})
+
+	It("should use 'default' as service namespace for pod selection and service name from spec when service namespace contains an empty string", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "api-rule",
+				Namespace: "api-rule-ns",
+			},
+			Spec: v2alpha1.APIRuleSpec{
+				Service: getApiRuleService("spec-level", uint32(8080), ptr.To("")),
+				Rules: []v2alpha1.Rule{
+					{
+						Path:    "/abc",
+						NoAuth:  ptr.To(true),
+						Methods: []v2alpha1.HttpMethod{http.MethodPost},
+					},
+				},
+				Hosts: getHosts("test.dev"),
+			},
+		}
+
+		specService := getService("spec-level", "default")
+		specLevelNs := getNamespace("spec-level-ns")
+		defaultNs := getNamespace("default")
+		fakeClient := createFakeClient(specService, specLevelNs, defaultNs)
+
+		err := fakeClient.Create(context.Background(), &corev1.Pod{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "test",
+				Namespace: "default",
+				Labels: map[string]string{
+					"app": "spec-level",
+				},
+			},
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		//when
+		problems, err := validateSidecarInjection(context.Background(), fakeClient, "some.attribute", apiRule, apiRule.Spec.Rules[0])
+		Expect(err).NotTo(HaveOccurred())
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].Message).To(Equal("Pod default/test does not have an injected istio sidecar"))
+	})
+
+	It("should return error when spec.service.name is not defined", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "api-rule",
+				Namespace: "api-rule-ns",
+			},
+			Spec: v2alpha1.APIRuleSpec{
+				Service: &v2alpha1.Service{},
+				Rules: []v2alpha1.Rule{
+					{
+						Path:    "/abc",
+						NoAuth:  ptr.To(true),
+						Methods: []v2alpha1.HttpMethod{http.MethodPost},
+					},
+				},
+				Hosts: getHosts("test.dev"),
+			},
+		}
+
+		fakeClient := createFakeClient()
+
+		//when
+		_, err := validateSidecarInjection(context.Background(), fakeClient, "some.attribute", apiRule, apiRule.Spec.Rules[0])
+
+		//then
+		Expect(err).To(HaveOccurred())
+		Expect(err.Error()).To(Equal("service name is required but missing"))
+	})
+
+	It("should fail when the service has no selector", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "api-rule",
+				Namespace: "api-rule-ns",
+			},
+			Spec: v2alpha1.APIRuleSpec{
+				Service: getApiRuleService("spec-level", uint32(8080), ptr.To("spec-level-ns")),
+				Rules: []v2alpha1.Rule{
+					{
+						Path:    "/abc",
+						NoAuth:  ptr.To(true),
+						Methods: []v2alpha1.HttpMethod{http.MethodPost},
+					},
+				},
+				Hosts: getHosts("test.dev"),
+			},
+		}
+
+		specService := corev1.Service{
+			ObjectMeta: v1.ObjectMeta{
+				Name:      "spec-level",
+				Namespace: "spec-level-ns",
+			},
+		}
+
+		specLevelNs := getNamespace("spec-level-ns")
+
+		fakeClient := createFakeClient(&specService, specLevelNs)
+
+		//when
+		problems, err := validateSidecarInjection(context.Background(), fakeClient, "some.attribute", apiRule, apiRule.Spec.Rules[0])
+		Expect(err).NotTo(HaveOccurred())
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].Message).To(Equal("Service cannot have empty label selectors when the API Rule strategy is JWT"))
+	})
+})

--- a/internal/validation/v2alpha1/suite_test.go
+++ b/internal/validation/v2alpha1/suite_test.go
@@ -1,0 +1,44 @@
+package v2alpha1
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/reporters"
+	"github.com/onsi/ginkgo/v2/types"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+func Test(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "v2alpha1 validation Suite")
+}
+
+var _ = ReportAfterSuite("custom reporter", func(report types.Report) {
+	logger := zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter))
+
+	if key, ok := os.LookupEnv("ARTIFACTS"); ok {
+		reportsFilename := fmt.Sprintf("%s/%s", key, "junit-v2alpha1-validation.xml")
+		logger.Info("Generating reports at", "location", reportsFilename)
+		err := reporters.GenerateJUnitReport(report, reportsFilename)
+
+		if err != nil {
+			logger.Error(err, "Junit Report Generation Error")
+		}
+	} else {
+		if err := os.MkdirAll("../../reports", 0755); err != nil {
+			logger.Error(err, "could not create directory")
+		}
+
+		reportsFilename := fmt.Sprintf("%s/%s", "../../reports", "junit-v2alpha1-validation.xml")
+		logger.Info("Generating reports at", "location", reportsFilename)
+		err := reporters.GenerateJUnitReport(report, reportsFilename)
+
+		if err != nil {
+			logger.Error(err, "Junit Report Generation Error")
+		}
+	}
+})

--- a/internal/validation/v2alpha1/suite_test.go
+++ b/internal/validation/v2alpha1/suite_test.go
@@ -9,6 +9,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
 	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
@@ -97,4 +98,22 @@ func getApiRuleService(serviceName string, servicePort uint32, namespace ...*str
 		svc.Namespace = namespace[0]
 	}
 	return &svc
+}
+
+func getNamespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+func getHosts(hosts ...string) []*v2alpha1.Host {
+	var h []*v2alpha1.Host
+	for _, host := range hosts {
+		h = append(h, ptr.To(v2alpha1.Host(host)))
+
+	}
+
+	return h
 }

--- a/internal/validation/v2alpha1/v2alpha1.go
+++ b/internal/validation/v2alpha1/v2alpha1.go
@@ -23,6 +23,5 @@ func (a *APIRuleValidator) Validate(ctx context.Context, client client.Client, v
 
 	failures = append(failures, validateRules(ctx, client, ".spec.rules", a.ApiRule)...)
 
-	validation.NewInjectionValidator(ctx, client)
 	return failures
 }

--- a/internal/validation/v2alpha1/v2alpha1.go
+++ b/internal/validation/v2alpha1/v2alpha1.go
@@ -9,50 +9,20 @@ import (
 )
 
 type APIRuleValidator struct {
-	Api *gatewayv2alpha1.APIRule
-
-	// TODO: I don't know if those validators are enough, for now I added some boilerplate code
-	InjectionValidator *validation.InjectionValidator
-	RulesValidator     rulesValidator
-	JwtValidator       jwtValidator
-
-	DefaultDomainName string
+	ApiRule *gatewayv2alpha1.APIRule
 }
 
-type jwtValidator interface {
-	Validate(attributePath string, handler *gatewayv2alpha1.JwtConfig) []validation.Failure
-}
-
-type jwtValidatorImpl struct{}
-
-func (j *jwtValidatorImpl) Validate(attributePath string, jwtConfig *gatewayv2alpha1.JwtConfig) []validation.Failure {
-	//TODO implement me
-	return make([]validation.Failure, 0)
-}
-
-type rulesValidator interface {
-	Validate(attributePath string, rules []*gatewayv2alpha1.Rule) []validation.Failure
-}
-
-type rulesValidatorImpl struct{}
-
-func (r rulesValidatorImpl) Validate(attributePath string, rules []*gatewayv2alpha1.Rule) []validation.Failure {
-	//TODO implement me
-	return make([]validation.Failure, 0)
-}
-
-func NewAPIRuleValidator(ctx context.Context, client client.Client, api *gatewayv2alpha1.APIRule, defaultDomainName string) *APIRuleValidator {
+func NewAPIRuleValidator(apiRule *gatewayv2alpha1.APIRule) *APIRuleValidator {
 	return &APIRuleValidator{
-		Api:                api,
-		InjectionValidator: validation.NewInjectionValidator(ctx, client),
-		RulesValidator:     rulesValidatorImpl{},
-		JwtValidator:       &jwtValidatorImpl{},
-		DefaultDomainName:  defaultDomainName,
+		ApiRule: apiRule,
 	}
 }
 
-// TODO: Actually Validate
-func (*APIRuleValidator) Validate(ctx context.Context, client client.Client, vsList networkingv1beta1.VirtualServiceList) []validation.Failure {
-	//TODO implement me
-	return make([]validation.Failure, 0)
+func (a *APIRuleValidator) Validate(ctx context.Context, client client.Client, vsList networkingv1beta1.VirtualServiceList) []validation.Failure {
+	var failures []validation.Failure
+
+	failures = append(failures, validateRules(ctx, client, ".spec.rules", a.ApiRule)...)
+
+	validation.NewInjectionValidator(ctx, client)
+	return failures
 }

--- a/internal/validation/v2alpha1/v2alpha1.go
+++ b/internal/validation/v2alpha1/v2alpha1.go
@@ -21,7 +21,7 @@ func NewAPIRuleValidator(apiRule *gatewayv2alpha1.APIRule) *APIRuleValidator {
 func (a *APIRuleValidator) Validate(ctx context.Context, client client.Client, vsList networkingv1beta1.VirtualServiceList) []validation.Failure {
 	var failures []validation.Failure
 
-	failures = append(failures, validateRules(ctx, client, ".spec.rules", a.ApiRule)...)
+	failures = append(failures, validateRules(ctx, client, ".spec", a.ApiRule)...)
 
 	return failures
 }

--- a/internal/validation/v2alpha1/v2alpha1_test.go
+++ b/internal/validation/v2alpha1/v2alpha1_test.go
@@ -1,0 +1,38 @@
+package v2alpha1
+
+import (
+	"context"
+	"github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+)
+
+var _ = Describe("Validate", func() {
+
+	sampleServiceName := "some-service"
+	host := v2alpha1.Host(sampleServiceName + ".test.dev")
+
+	It("should invoke rules validation", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			Spec: v2alpha1.APIRuleSpec{
+				Rules:   nil,
+				Service: getApiRuleService(sampleServiceName, uint32(8080)),
+				Hosts:   []*v2alpha1.Host{&host},
+			},
+		}
+
+		service := getService(sampleServiceName)
+		fakeClient := createFakeClient(service)
+
+		//when
+		problems := (&APIRuleValidator{ApiRule: apiRule}).Validate(context.Background(), fakeClient, networkingv1beta1.VirtualServiceList{})
+
+		//then
+		Expect(problems).To(HaveLen(1))
+		Expect(problems[0].AttributePath).To(Equal(".spec.rules"))
+		Expect(problems[0].Message).To(Equal("No rules defined"))
+	})
+
+})

--- a/internal/validation/v2alpha1/v2alpha1_test.go
+++ b/internal/validation/v2alpha1/v2alpha1_test.go
@@ -1,33 +1,52 @@
-package v2alpha1
+package v2alpha1_test
 
 import (
 	"context"
-	"github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
+	gatewayv2alpha1 "github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
+	"github.com/kyma-project/api-gateway/internal/validation/v2alpha1"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 var _ = Describe("Validate", func() {
 
-	sampleServiceName := "some-service"
-	host := v2alpha1.Host(sampleServiceName + ".test.dev")
+	serviceName := "some-service"
+	host := gatewayv2alpha1.Host(serviceName + ".test.dev")
 
 	It("should invoke rules validation", func() {
 		//given
-		apiRule := &v2alpha1.APIRule{
-			Spec: v2alpha1.APIRuleSpec{
-				Rules:   nil,
-				Service: getApiRuleService(sampleServiceName, uint32(8080)),
-				Hosts:   []*v2alpha1.Host{&host},
+		apiRule := &gatewayv2alpha1.APIRule{
+			Spec: gatewayv2alpha1.APIRuleSpec{
+				Rules: nil,
+				Service: &gatewayv2alpha1.Service{
+					Name: ptr.To(serviceName),
+					Port: ptr.To(uint32(8080)),
+				},
+				Hosts: []*gatewayv2alpha1.Host{&host},
 			},
 		}
 
-		service := getService(sampleServiceName)
-		fakeClient := createFakeClient(service)
+		service := corev1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: serviceName,
+			},
+			Spec: corev1.ServiceSpec{
+				Selector: map[string]string{
+					"app": serviceName,
+				},
+			},
+		}
+		fakeClient := createFakeClient(&service)
 
 		//when
-		problems := (&APIRuleValidator{ApiRule: apiRule}).Validate(context.Background(), fakeClient, networkingv1beta1.VirtualServiceList{})
+		problems := (&v2alpha1.APIRuleValidator{ApiRule: apiRule}).Validate(context.Background(), fakeClient, networkingv1beta1.VirtualServiceList{})
 
 		//then
 		Expect(problems).To(HaveLen(1))
@@ -36,3 +55,13 @@ var _ = Describe("Validate", func() {
 	})
 
 })
+
+func createFakeClient(objs ...client.Object) client.Client {
+	scheme := runtime.NewScheme()
+	err := gatewayv2alpha1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+	err = corev1.AddToScheme(scheme)
+	Expect(err).NotTo(HaveOccurred())
+
+	return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objs...).Build()
+}

--- a/main.go
+++ b/main.go
@@ -163,6 +163,12 @@ func main() {
 			Cache: &client.CacheOptions{
 				DisableFor: []client.Object{
 					&rulev1alpha1.Rule{},
+					/*
+						Reading v1beta1 and v2alpha1 APIRules during reconciliation led to an issue that the APIRule could not be read in v2alpha1 after it was deleted.
+						This would self-heal in the next reconciliation loop.To avoid this confusion with this issue, we disable the cache for v2alpha1 APIRules.
+						This can probably be enabled again when reconciliation only uses v2alpha1.
+					*/
+					&gatewayv2alpha1.APIRule{},
 				},
 			},
 		},


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add all relevant validation for rules from v1beta1 Istio handler including sidecar injection for v2alpha1
- Update paths from v1beta1 validation to match with new v2alpha1 APIRule
- Move tests from validation/v1beta1 package and validation/v1beta1/istio package to v2alpha1 package to verify same functionality
- Don't test against exported functions in tests, to have a smaller scoping, especially since there is another PR that will change the behaviour of the exported Validate function.
- Disable cache for v2alpha1 APIRule since this caused an issue with reconciling an APIRule that was recreated after deletion
- 
**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
