### PR TITLE
chore: bump golang image to 1.22.5 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM europe-docker.pkg.dev/kyma-project/prod/external/golang:1.22.2-alpine3.19 as builder
+FROM europe-docker.pkg.dev/kyma-project/prod/external/library/golang:1.22.5-alpine as builder
 ARG TARGET_OS
 ARG TARGET_ARCH
 ARG VERSION

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kyma-project/api-gateway
 
-go 1.22.0
+go 1.22.5
 
 require (
 	github.com/avast/retry-go/v4 v4.6.0


### PR DESCRIPTION
/kind chore
/area api-gateway

Fixes:
CVE-2024-24787
CVE-2024-24788
CVE-2024-24789
CVE-2024-24790
CVE-2024-24791
