### PR TITLE
bug: fix premature error of kubectl get --raw /readyz

### DIFF
--- a/tests/integration/scripts/provision-gardener-gh.sh
+++ b/tests/integration/scripts/provision-gardener-gh.sh
@@ -60,16 +60,14 @@ kubectl create  --kubeconfig "${GARDENER_KUBECONFIG}" \
     base64 -d > "${CLUSTER_NAME}_kubeconfig.yaml"
 
 # wait until apiserver /readyz endpoint returns "ok"
-isOK=""
 timeout=0
-until [[ $isOK == "ok" ]]; do
-  isOK=$(kubectl --kubeconfig "${CLUSTER_NAME}_kubeconfig.yaml" get --raw "/readyz")
+until (kubectl --kubeconfig "${CLUSTER_NAME}_kubeconfig.yaml" get --raw "/readyz"); do
+  timeout+=1
   # 5 minutes
   if [[ $timeout -gt 300 ]]; then
     echo "Timed out waiting for API Server to be ready"
     exit 1
   fi
-  timeout+=1
   sleep 1
 done
 


### PR DESCRIPTION
/kind bug
/area ci

Seems that if API Server is not ready then endpoint will return non-200 response code. That also means kubectl will also return non-zero exit. Loop can be simplified to just check exit code and wait until its 0

See https://github.com/kyma-project/api-gateway/actions/runs/10249090704/job/28351826080#step:3:103