### PR TITLE
cicd: bump k8s versions for int tests

### DIFF
--- a/.github/actions/integration-tests/action.yaml
+++ b/.github/actions/integration-tests/action.yaml
@@ -47,9 +47,9 @@ runs:
         IMG: ${{ inputs.manager_image }}
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
-          k3d image import ${{ inputs.manager_image }} -c test-cluster-1
+          k3d image import ${{ inputs.manager_image }} -c k3s-default
         fi
-        kubectl config use-context k3d-test-cluster-1
+        kubectl config use-context k3s-default
         EXPORT_RESULT=true make install-istio deploy ${{ inputs.test_make_target }}
     - shell: bash
       name: gather deployment logs

--- a/.github/actions/integration-tests/action.yaml
+++ b/.github/actions/integration-tests/action.yaml
@@ -49,7 +49,7 @@ runs:
         if [ "${{ github.event_name }}" == "pull_request" ]; then
           k3d image import ${{ inputs.manager_image }} -c k3s-default
         fi
-        kubectl config use-context k3s-default
+        kubectl config use-context k3d-k3s-default
         EXPORT_RESULT=true make install-istio deploy ${{ inputs.test_make_target }}
     - shell: bash
       name: gather deployment logs

--- a/.github/actions/integration-tests/action.yaml
+++ b/.github/actions/integration-tests/action.yaml
@@ -29,14 +29,9 @@ runs:
         git fetch origin pull/${{ github.event.number }}/head:PR-${{ github.event.number }}
         git checkout PR-${{ github.event.number }}
     - name: Create Cluster
-      shell: bash
-      run: |
-        curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
-        k3d cluster create --agents 0 \
-                           --image docker.io/rancher/k3s:v1.29.7-k3s1 \
-                           --port 80:80@loadbalancer \
-                           --port 443:443@loadbalancer \
-                           --k3s-arg "--disable=traefik@server:0"
+      uses: ./.github/actions/provision-k3d-cluster
+      with:
+          version: "1.29.7"
     - name: Run integration tests
       shell: bash
       env:

--- a/.github/actions/integration-tests/action.yaml
+++ b/.github/actions/integration-tests/action.yaml
@@ -34,6 +34,7 @@ runs:
         cluster-name: "test-cluster-1"
         args: >-
           --agents 0
+          --image docker.io/rancher/k3s:v1.29.7-k3s1
           --port 80:80@loadbalancer
           --port 443:443@loadbalancer
           --k3s-arg "--disable=traefik@server:0"

--- a/.github/actions/integration-tests/action.yaml
+++ b/.github/actions/integration-tests/action.yaml
@@ -28,16 +28,15 @@ runs:
       run: |
         git fetch origin pull/${{ github.event.number }}/head:PR-${{ github.event.number }}
         git checkout PR-${{ github.event.number }}
-    - name: Create Single Cluster
-      uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 #v2.4.0
-      with:
-        cluster-name: "test-cluster-1"
-        args: >-
-          --agents 0
-          --image docker.io/rancher/k3s:v1.29.7-k3s1
-          --port 80:80@loadbalancer
-          --port 443:443@loadbalancer
-          --k3s-arg "--disable=traefik@server:0"
+    - name: Create Cluster
+      shell: bash
+      run: |
+        curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+        k3d cluster create --agents 0 \
+                           --image docker.io/rancher/k3s:v1.29.7-k3s1 \
+                           --port 80:80@loadbalancer \
+                           --port 443:443@loadbalancer \
+                           --k3s-arg "--disable=traefik@server:0"
     - name: Run integration tests
       shell: bash
       env:

--- a/.github/actions/k8s-compatibility-test/action.yaml
+++ b/.github/actions/k8s-compatibility-test/action.yaml
@@ -34,7 +34,7 @@ runs:
         cluster-name: "test-cluster-1"
         args: >-
           --agents 2
-          --image docker.io/rancher/k3s:v1.29.4-k3s1
+          --image docker.io/rancher/k3s:v1.30.3-k3s1
           --servers-memory=16g
           --port 80:80@loadbalancer
           --port 443:443@loadbalancer

--- a/.github/actions/k8s-compatibility-test/action.yaml
+++ b/.github/actions/k8s-compatibility-test/action.yaml
@@ -48,15 +48,15 @@ runs:
         IMG: ${{ inputs.manager_image }}
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
-          k3d image import ${{ inputs.manager_image }} -c test-cluster-1
+          k3d image import ${{ inputs.manager_image }} -c default
         fi
-        kubectl config use-context k3d-test-cluster-1
+        kubectl config use-context k3s-default
         EXPORT_RESULT=true make install-istio deploy ${{ inputs.test_make_target }}
     - name: Check deprecations
       run: |
         set -eou pipefail
         GO111MODULE=on go install github.com/prometheus/prom2json/cmd/prom2json@v1.3.3
-        kubectl get --context k3d-test-cluster-1 --raw /metrics | prom2json | jq '.[] | select(.name=="apiserver_requested_deprecated_apis").metrics[].labels' > deprecations.txt
+        kubectl get --context k3s-default --raw /metrics | prom2json | jq '.[] | select(.name=="apiserver_requested_deprecated_apis").metrics[].labels' > deprecations.txt
       shell: bash
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/actions/k8s-compatibility-test/action.yaml
+++ b/.github/actions/k8s-compatibility-test/action.yaml
@@ -29,16 +29,15 @@ runs:
         git fetch origin pull/${{ github.event.number }}/head:PR-${{ github.event.number }}
         git checkout PR-${{ github.event.number }}
     - name: Create Single Cluster
-      uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 #v2.4.0
-      with:
-        cluster-name: "test-cluster-1"
-        args: >-
-          --agents 2
-          --image docker.io/rancher/k3s:v1.30.3-k3s1
-          --servers-memory=16g
-          --port 80:80@loadbalancer
-          --port 443:443@loadbalancer
-          --k3s-arg "--disable=traefik@server:0"
+      shell: bash
+      run: |
+        curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+        k3d cluster create --agents 2 \
+                           --image docker.io/rancher/k3s:v1.30.3-k3s1 \
+                           --port 80:80@loadbalancer \
+                           --servers-memory=16g \
+                           --port 443:443@loadbalancer \
+                           --k3s-arg "--disable=traefik@server:0"
     - name: Provision Kyma and run tests
       shell: bash
       env:

--- a/.github/actions/k8s-compatibility-test/action.yaml
+++ b/.github/actions/k8s-compatibility-test/action.yaml
@@ -48,15 +48,15 @@ runs:
         IMG: ${{ inputs.manager_image }}
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
-          k3d image import ${{ inputs.manager_image }} -c default
+          k3d image import ${{ inputs.manager_image }} -c k3s-default
         fi
-        kubectl config use-context k3s-default
+        kubectl config use-context k3d-k3s-default
         EXPORT_RESULT=true make install-istio deploy ${{ inputs.test_make_target }}
     - name: Check deprecations
       run: |
         set -eou pipefail
         GO111MODULE=on go install github.com/prometheus/prom2json/cmd/prom2json@v1.3.3
-        kubectl get --context k3s-default --raw /metrics | prom2json | jq '.[] | select(.name=="apiserver_requested_deprecated_apis").metrics[].labels' > deprecations.txt
+        kubectl get --context k3d-k3s-default --raw /metrics | prom2json | jq '.[] | select(.name=="apiserver_requested_deprecated_apis").metrics[].labels' > deprecations.txt
       shell: bash
     - uses: actions/upload-artifact@v4
       with:

--- a/.github/actions/k8s-compatibility-test/action.yaml
+++ b/.github/actions/k8s-compatibility-test/action.yaml
@@ -28,17 +28,11 @@ runs:
       run: |
         git fetch origin pull/${{ github.event.number }}/head:PR-${{ github.event.number }}
         git checkout PR-${{ github.event.number }}
-    - name: Create Single Cluster
-      shell: bash
-      run: |
-        curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
-        k3d cluster create --agents 2 \
-                           --image docker.io/rancher/k3s:v1.30.3-k3s1 \
-                           --port 80:80@loadbalancer \
-                           --servers-memory=16g \
-                           --port 443:443@loadbalancer \
-                           --k3s-arg "--disable=traefik@server:0"
-    - name: Provision Kyma and run tests
+    - name: Create Cluster
+      uses: ./.github/actions/provision-k3d-cluster
+      with:
+        version: "1.30.3"
+    - name: Deploy APIGateway manager and run tests
       shell: bash
       env:
         KYMA_DOMAIN: "local.kyma.dev"

--- a/.github/actions/provision-k3d-cluster/action.yaml
+++ b/.github/actions/provision-k3d-cluster/action.yaml
@@ -13,7 +13,7 @@ runs:
       run: |
         curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
         k3d cluster create --agents 2 \
-                           --image docker.io/rancher/k3s:v{{ inputs.version }}-k3s1 \
+                           --image docker.io/rancher/k3s:v${{ inputs.version }}-k3s1 \
                            --servers-memory=16g \
                            --port 80:80@loadbalancer \
                            --port 443:443@loadbalancer \

--- a/.github/actions/provision-k3d-cluster/action.yaml
+++ b/.github/actions/provision-k3d-cluster/action.yaml
@@ -1,0 +1,20 @@
+name: 'Provision k3d cluster'
+description: 'Provisions a k3d cluster'
+inputs:
+  version:
+    description: 'Kubernetes version'
+    required: true
+
+runs:
+  using: "composite"
+  steps:
+    - name: Provision k3d cluster
+      shell: bash
+      run: |
+        curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+        k3d cluster create --agents 2 \
+                           --image docker.io/rancher/k3s:v{{ inputs.version }}-k3s1 \
+                           --servers-memory=16g \
+                           --port 80:80@loadbalancer \
+                           --port 443:443@loadbalancer \
+                           --k3s-arg "--disable=traefik@server:0"

--- a/.github/actions/upgrade-test/action.yaml
+++ b/.github/actions/upgrade-test/action.yaml
@@ -29,15 +29,15 @@ runs:
       run: |
         git fetch origin pull/${{ github.event.number }}/head:PR-${{ github.event.number }}
         git checkout PR-${{ github.event.number }}
-    - name: Create Single Cluster
-      uses: AbsaOSS/k3d-action@4e8b3239042be1dc0aed6c5eb80c13b18200fc79 #v2.4.0
-      with:
-        cluster-name: "test-cluster-1"
-        args: >-
-          --agents 0
-          --port 80:80@loadbalancer
-          --port 443:443@loadbalancer
-          --k3s-arg "--disable=traefik@server:0"
+    - name: Create Cluster
+      shell: bash
+      run: |
+        curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+        k3d cluster create --agents 0 \
+                           --image docker.io/rancher/k3s:v1.29.7-k3s1 \
+                           --port 80:80@loadbalancer \
+                           --port 443:443@loadbalancer \
+                           --k3s-arg "--disable=traefik@server:0"
     - name: Run test
       shell: bash
       env:

--- a/.github/actions/upgrade-test/action.yaml
+++ b/.github/actions/upgrade-test/action.yaml
@@ -50,7 +50,7 @@ runs:
         if [ "${{ github.event_name }}" == "pull_request" ]; then
           k3d image import ${{ inputs.manager_image }} -c k3s-default
         fi
-        kubectl config use-context k3s-default
+        kubectl config use-context k3d-k3s-default
         EXPORT_RESULT=true TARGET_BRANCH=${{inputs.target_branch}} make test-upgrade
     - name: Uploads artifacts
       uses: actions/upload-artifact@v4

--- a/.github/actions/upgrade-test/action.yaml
+++ b/.github/actions/upgrade-test/action.yaml
@@ -32,12 +32,10 @@ runs:
     - name: Create Cluster
       shell: bash
       run: |
-        curl -s https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
-        k3d cluster create --agents 0 \
-                           --image docker.io/rancher/k3s:v1.29.7-k3s1 \
-                           --port 80:80@loadbalancer \
-                           --port 443:443@loadbalancer \
-                           --k3s-arg "--disable=traefik@server:0"
+    - name: Create Cluster
+      uses: ./.github/actions/provision-k3d-cluster
+      with:
+        version: "1.29.7"
     - name: Run test
       shell: bash
       env:

--- a/.github/actions/upgrade-test/action.yaml
+++ b/.github/actions/upgrade-test/action.yaml
@@ -48,9 +48,9 @@ runs:
         OIDC_CONFIG_URL: ${{ inputs.oidc_well_known_url }}
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
-          k3d image import ${{ inputs.manager_image }} -c test-cluster-1
+          k3d image import ${{ inputs.manager_image }} -c k3s-default
         fi
-        kubectl config use-context k3d-test-cluster-1
+        kubectl config use-context k3s-default
         EXPORT_RESULT=true TARGET_BRANCH=${{inputs.target_branch}} make test-upgrade
     - name: Uploads artifacts
       uses: actions/upload-artifact@v4

--- a/hack/ci/custom-domain-gardener-aws.sh
+++ b/hack/ci/custom-domain-gardener-aws.sh
@@ -15,6 +15,6 @@ export GARDENER_PROVIDER="aws"
 export GARDENER_REGION="eu-west-1"
 export GARDENER_PROVIDER_SECRET_NAME="aws-gardener-access"
 export GARDENER_PROJECT_NAME="goats"
-export GARDENER_CLUSTER_VERSION="1.27.8"
+export GARDENER_CLUSTER_VERSION="1.29.7"
 
 ./hack/ci/custom-domain-gardener.sh

--- a/hack/ci/custom-domain-gardener-gcp.sh
+++ b/hack/ci/custom-domain-gardener-gcp.sh
@@ -15,6 +15,6 @@ export GARDENER_PROVIDER="gcp"
 export GARDENER_REGION="europe-west3"
 export GARDENER_PROVIDER_SECRET_NAME="goat"
 export GARDENER_PROJECT_NAME="goats"
-export GARDENER_CLUSTER_VERSION="1.27.8"
+export GARDENER_CLUSTER_VERSION="1.29.7"
 
 ./hack/ci/custom-domain-gardener.sh


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- bump k8s versions for int tests
- drop external gh action responsible for provisioning k3d
- provide own gh action for provisioning k3d