### PR TITLE
Fix conversion for v2alpha1 APIRule with JWT authorizations only

### DIFF
--- a/apis/gateway/v2alpha1/jwt_conversion.go
+++ b/apis/gateway/v2alpha1/jwt_conversion.go
@@ -2,6 +2,7 @@ package v2alpha1
 
 import (
 	"encoding/json"
+
 	"github.com/kyma-project/api-gateway/apis/gateway/v1beta1"
 	"github.com/kyma-project/api-gateway/internal/types/ory"
 )
@@ -50,7 +51,6 @@ func convertIstioJwtAccessStrategy(accessStrategy *v1beta1.Authenticator) (*v1be
 }
 
 func isConvertibleJwtConfig(accessStrategy *v1beta1.Authenticator) (bool, error) {
-
 	if accessStrategy.Config == nil {
 		return false, nil
 	}
@@ -60,7 +60,7 @@ func isConvertibleJwtConfig(accessStrategy *v1beta1.Authenticator) (bool, error)
 		return false, err
 	}
 
-	if len(istioJwtConfig.Authentications) > 0 {
+	if len(istioJwtConfig.Authentications) > 0 || len(istioJwtConfig.Authorizations) > 0 {
 		return true, nil
 	}
 

--- a/internal/validation/v2alpha1/gateway.go
+++ b/internal/validation/v2alpha1/gateway.go
@@ -2,6 +2,7 @@ package v2alpha1
 
 import (
 	"fmt"
+
 	gatewayv2alpha1 "github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
 	"github.com/kyma-project/api-gateway/internal/validation"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
@@ -9,13 +10,16 @@ import (
 
 func validateGateway(parentAttributePath string, gwList networkingv1beta1.GatewayList, apiRule *gatewayv2alpha1.APIRule) []validation.Failure {
 	var failures []validation.Failure
-	gatewayName := *apiRule.Spec.Gateway
 
-	if !gatewayExists(gwList, gatewayName) {
-		failures = append(failures, validation.Failure{
-			AttributePath: parentAttributePath + ".gateway",
-			Message:       "Gateway not found",
-		})
+	if apiRule.Spec.Gateway != nil {
+		gatewayName := *apiRule.Spec.Gateway
+
+		if !gatewayExists(gwList, gatewayName) {
+			failures = append(failures, validation.Failure{
+				AttributePath: parentAttributePath + ".gateway",
+				Message:       "Gateway not found",
+			})
+		}
 	}
 
 	return failures

--- a/internal/validation/v2alpha1/gateway_test.go
+++ b/internal/validation/v2alpha1/gateway_test.go
@@ -10,6 +10,24 @@ import (
 )
 
 var _ = Describe("Validate gateway", func() {
+	It("Should succeed if spec is empty", func() {
+		//given
+		apiRule := &v2alpha1.APIRule{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "some-name",
+				Namespace: "some-ns",
+			},
+			Spec: v2alpha1.APIRuleSpec{},
+		}
+		gatewayList := networkingv1beta1.GatewayList{}
+
+		//when
+		problems := validateGateway(".spec", gatewayList, apiRule)
+
+		//then
+		Expect(problems).To(BeEmpty())
+	})
+
 	It("Should fail if gateway does not exist", func() {
 		//given
 		apiRule := &v2alpha1.APIRule{
@@ -32,7 +50,7 @@ var _ = Describe("Validate gateway", func() {
 		Expect(problems[0].Message).To(Equal("Gateway not found"))
 	})
 
-	It("Should not fail if gateway exist", func() {
+	It("Should succeed if gateway exist", func() {
 		//given
 		apiRule := &v2alpha1.APIRule{
 			ObjectMeta: metav1.ObjectMeta{
@@ -58,6 +76,6 @@ var _ = Describe("Validate gateway", func() {
 		problems := validateGateway(".spec", gatewayList, apiRule)
 
 		//then
-		Expect(problems).To(HaveLen(0))
+		Expect(problems).To(BeEmpty())
 	})
 })


### PR DESCRIPTION
… configuration with authorizations only

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix conversion and validation for when v2alpha1 APIRule specifies JWT configuration with authorizations only

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
