### PR TITLE
Oathkeeper startup optimisation

### DIFF
--- a/internal/reconciliations/oathkeeper/deployment.go
+++ b/internal/reconciliations/oathkeeper/deployment.go
@@ -117,13 +117,13 @@ func getReplicasForDeployment(ctx context.Context, k8sClient client.Client) (str
 	}, &dep)
 
 	if k8serrors.IsNotFound(err) {
-		return "1", nil
+		return "", nil
 	} else if err != nil {
-		return "1", err
+		return "", err
 	}
 
 	if dep.Spec.Replicas == nil {
-		return "1", nil
+		return "", nil
 	}
 
 	return strconv.Itoa(int(*dep.Spec.Replicas)), nil

--- a/internal/reconciliations/oathkeeper/deployment.yaml
+++ b/internal/reconciliations/oathkeeper/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: ory
     app.kubernetes.io/name: oathkeeper
 spec:
-  replicas: {{ .Replicas }}
+  replicas: {{ if .Replicas }} {{ .Replicas }} {{ else }} 3 {{ end }}
   selector:
     matchLabels:
       app.kubernetes.io/instance: ory

--- a/internal/reconciliations/oathkeeper/deployment_light.yaml
+++ b/internal/reconciliations/oathkeeper/deployment_light.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/instance: ory
     app.kubernetes.io/name: oathkeeper
 spec:
-  replicas: {{ .Replicas }}
+  replicas: {{ if .Replicas }} {{ .Replicas }} {{ else }} 1 {{ end }}
   selector:
     matchLabels:
       app.kubernetes.io/instance: ory


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

HPA needs ~30s after a workload is applied to scale it to target min replicas. Since Oathkeeper starts with 1, and the target is 3, those 30s are spend idle, as only one replica is starting, and the other two will start after HPA kicks in.

Changes proposed in this pull request:

- Optimise Oathkeeper startup time by starting with replica number as in HPA config

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
