### PR TITLE
feat: replace getting converted resource in reconcile

### DIFF
--- a/apis/gateway/v2alpha1/apirule_conversion.go
+++ b/apis/gateway/v2alpha1/apirule_conversion.go
@@ -32,7 +32,7 @@ func convertMap(m map[v1beta1.StatusCode]State) map[State]v1beta1.StatusCode {
 // The 2 => 1 map is generated automatically based on 1 => 2 map
 var alpha1to1beta1statusConversionMap = convertMap(beta1toV2alpha1StatusConversionMap)
 
-// Converts this ApiRule (v2alpha1) to the Hub version (v1beta1)
+// ConvertTo Converts this ApiRule (v2alpha1) to the Hub version (v1beta1)
 func (apiRuleV2Alpha1 *APIRule) ConvertTo(hub conversion.Hub) error {
 	apiRuleBeta1 := hub.(*v1beta1.APIRule)
 

--- a/controllers/gateway/apirule_deletion.go
+++ b/controllers/gateway/apirule_deletion.go
@@ -18,7 +18,7 @@ func (r *APIRuleReconciler) reconcileAPIRuleDeletion(ctx context.Context, log lo
 			log.Error(err, "Error happened during deletion of APIRule subresources")
 			// if removing subresources ends in error, return with retry
 			// so that it can be retried
-			return doneReconcileErrorRequeue(r.OnErrorReconcilePeriod)
+			return doneReconcileErrorRequeue(err, r.OnErrorReconcilePeriod)
 		}
 
 		// remove finalizer so the reconciliation can proceed

--- a/controllers/gateway/reconcile_result.go
+++ b/controllers/gateway/reconcile_result.go
@@ -22,12 +22,12 @@ func doneReconcileDefaultRequeue(reconcilerPeriod time.Duration) (ctrl.Result, e
 	return ctrl.Result{RequeueAfter: after}, nil
 }
 
-func doneReconcileErrorRequeue(reconcilerPeriod time.Duration) (ctrl.Result, error) {
+func doneReconcileErrorRequeue(err error, reconcilerPeriod time.Duration) (ctrl.Result, error) {
 	after := errorReconciliationPeriod
 	if reconcilerPeriod != 0 {
 		after = reconcilerPeriod
 	}
-	return ctrl.Result{RequeueAfter: after}, nil
+	return ctrl.Result{RequeueAfter: after}, err
 }
 
 func doneReconcileMigrationRequeue(reconcilerPeriod time.Duration) (ctrl.Result, error) {
@@ -43,7 +43,7 @@ func (r *APIRuleReconciler) updateStatus(ctx context.Context, l logr.Logger,
 	l.Info("Updating APIRule status")
 	if err := r.Status().Update(ctx, apiRule); err != nil {
 		l.Error(err, "Error updating APIRule status")
-		return doneReconcileErrorRequeue(r.OnErrorReconcilePeriod)
+		return doneReconcileErrorRequeue(err, r.OnErrorReconcilePeriod)
 	}
 	if _, ok := apiRule.GetAnnotations()[migration.AnnotationName]; ok {
 		l.Info("Finished reconciliation", "next", r.MigrationReconcilePeriod)

--- a/internal/processing/reconciliation.go
+++ b/internal/processing/reconciliation.go
@@ -5,11 +5,9 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"github.com/go-logr/logr"
 	gatewayv1beta1 "github.com/kyma-project/api-gateway/apis/gateway/v1beta1"
 	"github.com/kyma-project/api-gateway/internal/processing/status"
-	ctrl "sigs.k8s.io/controller-runtime"
-
-	"github.com/go-logr/logr"
 	"github.com/kyma-project/api-gateway/internal/validation"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -33,8 +31,8 @@ type ReconciliationProcessor interface {
 }
 
 // Reconcile executes the reconciliation of the APIRule using the given reconciliation command.
-func Reconcile(ctx context.Context, client client.Client, log *logr.Logger, cmd ReconciliationCommand, req ctrl.Request) status.ReconciliationStatus {
-	l := log.WithValues("controller", "APIRule", "version", gatewayv1beta1.GroupVersion.String(), "request", req.NamespacedName)
+func Reconcile(ctx context.Context, client client.Client, log *logr.Logger, cmd ReconciliationCommand) status.ReconciliationStatus {
+	l := log.WithValues("controller", "APIRule", "version", gatewayv1beta1.GroupVersion.String())
 
 	validationFailures, err := cmd.Validate(ctx, client)
 	if err != nil {

--- a/internal/processing/reconciliation_test.go
+++ b/internal/processing/reconciliation_test.go
@@ -3,13 +3,11 @@ package processing_test
 import (
 	"context"
 	"fmt"
-	gatewayv1beta1 "github.com/kyma-project/api-gateway/apis/gateway/v1beta1"
-	"github.com/kyma-project/api-gateway/internal/processing/status"
-	k8stypes "k8s.io/apimachinery/pkg/types"
-
 	"github.com/go-logr/logr"
+	gatewayv1beta1 "github.com/kyma-project/api-gateway/apis/gateway/v1beta1"
 	"github.com/kyma-project/api-gateway/internal/builders"
 	"github.com/kyma-project/api-gateway/internal/processing"
+	"github.com/kyma-project/api-gateway/internal/processing/status"
 	v1beta1Status "github.com/kyma-project/api-gateway/internal/processing/status"
 	"github.com/kyma-project/api-gateway/internal/validation"
 	. "github.com/onsi/ginkgo/v2"
@@ -22,12 +20,6 @@ import (
 )
 
 var _ = Describe("Reconcile", func() {
-
-	req := ctrl.Request{NamespacedName: k8stypes.NamespacedName{
-		Namespace: "test-ns",
-		Name:      "test-name",
-	}}
-
 	It("should return api status error and vs/ar status skipped when an error happens during validation", func() {
 		// given
 		cmd := MockReconciliationCommand{
@@ -39,7 +31,7 @@ var _ = Describe("Reconcile", func() {
 		client := fake.NewClientBuilder().Build()
 
 		// when
-		status := processing.Reconcile(context.Background(), client, testLogger(), cmd, req).(status.ReconciliationV1beta1Status)
+		status := processing.Reconcile(context.Background(), client, testLogger(), cmd).(status.ReconciliationV1beta1Status)
 
 		// then
 		Expect(status.ApiRuleStatus.Code).To(Equal(gatewayv1beta1.StatusError))
@@ -65,7 +57,7 @@ var _ = Describe("Reconcile", func() {
 		client := fake.NewClientBuilder().Build()
 
 		// when
-		status := processing.Reconcile(context.Background(), client, testLogger(), cmd, req).(status.ReconciliationV1beta1Status)
+		status := processing.Reconcile(context.Background(), client, testLogger(), cmd).(status.ReconciliationV1beta1Status)
 
 		// then
 		Expect(status.ApiRuleStatus.Code).To(Equal(gatewayv1beta1.StatusError))
@@ -96,7 +88,7 @@ var _ = Describe("Reconcile", func() {
 		client := fake.NewClientBuilder().Build()
 
 		// when
-		status := processing.Reconcile(context.Background(), client, testLogger(), cmd, req).(status.ReconciliationV1beta1Status)
+		status := processing.Reconcile(context.Background(), client, testLogger(), cmd).(status.ReconciliationV1beta1Status)
 
 		// then
 		Expect(status.ApiRuleStatus.Code).To(Equal(gatewayv1beta1.StatusError))
@@ -128,7 +120,7 @@ var _ = Describe("Reconcile", func() {
 			client := fake.NewClientBuilder().Build()
 
 			// when
-			status := processing.Reconcile(context.Background(), client, testLogger(), cmd, req).(status.ReconciliationV1beta1Status)
+			status := processing.Reconcile(context.Background(), client, testLogger(), cmd).(status.ReconciliationV1beta1Status)
 
 			// then
 			Expect(status.ApiRuleStatus.Code).To(Equal(gatewayv1beta1.StatusError))
@@ -170,7 +162,7 @@ var _ = Describe("Reconcile", func() {
 		client := fake.NewClientBuilder().WithScheme(scheme).WithObjects(toBeUpdatedVs, toBeDeletedVs).Build()
 
 		// when
-		status := processing.Reconcile(context.Background(), client, testLogger(), cmd, req).(status.ReconciliationV1beta1Status)
+		status := processing.Reconcile(context.Background(), client, testLogger(), cmd).(status.ReconciliationV1beta1Status)
 
 		// then
 		Expect(status.ApiRuleStatus.Code).To(Equal(gatewayv1beta1.StatusOK))
@@ -208,7 +200,7 @@ var _ = Describe("Reconcile", func() {
 		client := fake.NewClientBuilder().WithScheme(scheme).Build()
 
 		// when
-		status := processing.Reconcile(context.Background(), client, testLogger(), cmd, req).(status.ReconciliationV1beta1Status)
+		status := processing.Reconcile(context.Background(), client, testLogger(), cmd).(status.ReconciliationV1beta1Status)
 
 		// then
 		Expect(status.ApiRuleStatus.Code).To(Equal(gatewayv1beta1.StatusError))


### PR DESCRIPTION
/kind feature
/area api-gateway

APIRule v2alpha1 was retrieved from APIServer. This introduced unnecessary dependency to conversion webhook. So instead of asking APIServer to get resource, call ConvertTo() and ConvertFrom() directly to convert v1beta1 resource into v2alpha1.

Additionally include error in doneReconcileErrorRequeue(), because it should return an errored reconcile result.

This resolves multiple instances of error
```
2024/09/06 14:02:53 http: TLS handshake error from 10.244.0.1:57417: EOF
```

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
#1148 