### PR TITLE
chore: switch main build jobs

### DIFF
--- a/.github/workflows/main-integration.yaml
+++ b/.github/workflows/main-integration.yaml
@@ -3,6 +3,10 @@
 
 name: Main Integration
 
+permissions:
+  id-token: write # This is required for requesting the JWT token
+  contents: read # This is required for actions/checkout
+
 on:
   push:
     paths-ignore:
@@ -17,33 +21,21 @@ on:
     - cron: '0 5 * * *' # Run every day at 05:00 AM
 
 jobs:
-  wait-for-image-build:
-    name: Wait for image build
-    runs-on: ubuntu-latest
-    outputs:
-      sha: ${{ steps.get-sha.outputs.sha }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: ./.github/actions/wait-for-job-succeed-or-fail
-        if: ${{ github.event_name != 'schedule' }}
-        with:
-          job-name: 'post-api-gateway-manager-build'
-          github-auth-token: ${{ secrets.GITHUB_TOKEN }}
-          commit-ref: ${{ github.sha }}
-      - id: get-sha
-        run: |
-          if [ "${{ github.event_name }}" != "schedule" ]; then
-            echo "sha=${{ github.sha }}" >> $GITHUB_OUTPUT
-          else
-            echo "sha=$(./scripts/get_latest_build_sha.sh)" >> $GITHUB_OUTPUT
-          fi
+  build:
+    name: build api-gateway image
+    uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+    with:
+      name: api-gateway
+      dockerfile: Dockerfile
+      context: .
+      build-args: |
+        VERSION=${{ github.sha }}
+      tags: "${{ github.sha }}"
 
   integration-tests:
     name: Integration tests
     runs-on: ubuntu-latest
-    needs: [wait-for-image-build]
+    needs: [build]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -58,7 +50,7 @@ jobs:
   upgrade-tests:
     name: Upgrade tests
     runs-on: ubuntu-latest
-    needs: [wait-for-image-build]
+    needs: [build]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -74,7 +66,7 @@ jobs:
   custom-domain-integration-gcp:
     name: Custom domain integration GCP
     runs-on: ubuntu-latest
-    needs: [wait-for-image-build]
+    needs: [build]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -93,7 +85,7 @@ jobs:
   custom-domain-integration-aws:
     name: Custom domain integration AWS
     runs-on: ubuntu-latest
-    needs: [wait-for-image-build]
+    needs: [build]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/verify-commit-pins.yaml
+++ b/.github/workflows/verify-commit-pins.yaml
@@ -20,3 +20,4 @@ jobs:
             actions/checkout
             actions/setup-go
             actions/upload-artifact
+            kyma-project/test-infra


### PR DESCRIPTION
/kind chore
/area api-gateway

Remove wait-for-build usage from main-integration.yaml and build directly.

#1271 
