### PR TITLE
bug: enable experimentalMemoryManagement in cypress

### DIFF
--- a/tests/ui/tests/cypress.config.ts
+++ b/tests/ui/tests/cypress.config.ts
@@ -12,6 +12,7 @@ module.exports = defineConfig({
   chromeWebSecurity: false,
   viewportWidth: 1500,
   viewportHeight: 1500,
+  experimentalMemoryManagement: true,
   video: true,
   videoCompression: false,
   screenshotsFolder: process?.env?.ARTIFACTS


### PR DESCRIPTION
/kind bug
/area api-gateway

Try to mitigate recent crash of Chromium by enabling `experimentalMemoryManagement` feature, as described in Cypress documentation.