### PR TITLE
Extend certificate key size of kyma-gateway to 4096

### DIFF
--- a/docs/release-notes/2.8.0.md
+++ b/docs/release-notes/2.8.0.md
@@ -1,0 +1,3 @@
+## New Features
+
+- Increase certificate key size of `kyma-gateway` to 4096 [#1357](https://github.com/kyma-project/api-gateway/pull/1357)

--- a/internal/reconciliations/gateway/certificate.yaml
+++ b/internal/reconciliations/gateway/certificate.yaml
@@ -12,3 +12,6 @@ metadata:
 spec:
   secretName: {{.SecretName}}
   commonName: "*.{{.Domain}}"
+  privateKey:
+    size: 4096
+


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Extend certificate key size of kyma gateway to 4096

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Additional information**
I run zero downtime test, and no downtime is present during the certificate switch

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
