### PR TITLE
bug: enable HA control plane nodes

### DIFF
--- a/hack/ci/shoot_aws.yaml
+++ b/hack/ci/shoot_aws.yaml
@@ -7,6 +7,10 @@ spec:
   cloudProfileName: aws
   region: ${GARDENER_REGION}
   purpose: evaluation
+  controlPlane:
+    highAvailability:
+      failureTolerance:
+        type: zone
   provider:
     type: aws
     infrastructureConfig:

--- a/hack/ci/shoot_gcp.yaml
+++ b/hack/ci/shoot_gcp.yaml
@@ -7,6 +7,10 @@ spec:
   cloudProfileName: gcp
   region: ${GARDENER_REGION}
   purpose: evaluation
+  controlPlane:
+    highAvailability:
+      failureTolerance:
+        type: zone
   provider:
     type: gcp
     infrastructureConfig:


### PR DESCRIPTION
/kind bug
/area ci

Enable gardener control-plane HA, as described in https://gardener.cloud/docs/gardener/shoot_high_availability/