### PR TITLE
feat: add envoyfilter and ratelimit builders

### DIFF
--- a/internal/builders/envoyfilter/envoyfilter.go
+++ b/internal/builders/envoyfilter/envoyfilter.go
@@ -1,0 +1,79 @@
+package envoyfilter
+
+import (
+	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
+	apiv1alpha3 "istio.io/client-go/pkg/apis/networking/v1alpha3"
+)
+
+type ConfigPatch = networkingv1alpha3.EnvoyFilter_EnvoyConfigObjectPatch
+
+type BuilderOption func(*Builder)
+
+type Builder struct {
+	name          string
+	namespace     string
+	selectors     map[string]string
+	annotations   map[string]string
+	ConfigPatches []*ConfigPatch
+}
+
+// WithName sets name of EnvoyFilter
+func (e *Builder) WithName(name string) *Builder {
+	e.name = name
+	return e
+}
+
+// WithNamespace sets namespace of EnvoyFilter
+func (e *Builder) WithNamespace(namespace string) *Builder {
+	e.namespace = namespace
+	return e
+}
+
+// WithAnnotation adds annotation to the EnvoyFilter. Can be used multiple times to add more annotations
+func (e *Builder) WithAnnotation(key, val string) *Builder {
+	if e.annotations == nil {
+		e.annotations = make(map[string]string)
+	}
+	e.annotations[key] = val
+	return e
+}
+
+// WithWorkloadSelector adds labels to EnvoyFilter's WorkloadSelector. Can be used multiple times to add more selectors
+func (e *Builder) WithWorkloadSelector(key, val string) *Builder {
+	if e.selectors == nil {
+		e.selectors = make(map[string]string)
+	}
+	e.selectors[key] = val
+	return e
+}
+
+// WithConfigPatch adds provided patch to the end of the EnvoyFilter patches chain
+func (e *Builder) WithConfigPatch(patch *ConfigPatch) *Builder {
+	e.ConfigPatches = append(e.ConfigPatches, patch)
+	return e
+}
+
+// Build returns EnvoyFilter generated from the configuration provided to the builder.
+func (e *Builder) Build() *apiv1alpha3.EnvoyFilter {
+	f := apiv1alpha3.EnvoyFilter{}
+	f.Name = e.name
+	f.Namespace = e.namespace
+
+	if len(e.selectors) > 0 {
+		f.Spec.WorkloadSelector = &networkingv1alpha3.WorkloadSelector{
+			Labels: e.selectors,
+		}
+	}
+
+	if len(e.annotations) > 0 {
+		f.Annotations = e.annotations
+	}
+
+	f.Spec.ConfigPatches = e.ConfigPatches
+	return &f
+}
+
+// NewEnvoyFilterBuilder returns EnvoyFilterBuilder for building istio EnvoyFilters
+func NewEnvoyFilterBuilder() *Builder {
+	return &Builder{}
+}

--- a/internal/builders/envoyfilter/envoyfilter_test.go
+++ b/internal/builders/envoyfilter/envoyfilter_test.go
@@ -1,0 +1,51 @@
+package envoyfilter
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
+	"testing"
+)
+
+var _ = Describe("EnvoyFilterBuilder", func() {
+	Context("Build", func() {
+		patch := networkingv1alpha3.EnvoyFilter_EnvoyConfigObjectPatch{
+			ApplyTo: networkingv1alpha3.EnvoyFilter_HTTP_ROUTE,
+			Patch: &networkingv1alpha3.EnvoyFilter_Patch{
+				Operation: networkingv1alpha3.EnvoyFilter_Patch_INSERT_BEFORE,
+			},
+		}
+		f := NewEnvoyFilterBuilder().
+			WithName("test").
+			WithNamespace("test").
+			WithAnnotation("test", "test").
+			WithAnnotation("foo", "bar").
+			WithWorkloadSelector("app", "test").
+			WithWorkloadSelector("foo", "bar").
+			WithConfigPatch(&patch).
+			Build()
+		It("has added name and namespace", func() {
+			Expect(f.Name).To(Equal("test"))
+			Expect(f.Namespace).To(Equal("test"))
+		})
+		It("has annotations added", func() {
+			Expect(f.Annotations).To(HaveLen(2))
+			Expect(f.Annotations).To(HaveKeyWithValue("test", "test"))
+			Expect(f.Annotations).To(HaveKeyWithValue("foo", "bar"))
+		})
+		It("has workloadSelector added", func() {
+			Expect(f.Spec.WorkloadSelector).ToNot(BeNil())
+			Expect(f.Spec.WorkloadSelector.GetLabels()).To(HaveLen(2))
+			Expect(f.Spec.WorkloadSelector.GetLabels()).To(HaveKeyWithValue("app", "test"))
+			Expect(f.Spec.WorkloadSelector.GetLabels()).To(HaveKeyWithValue("foo", "bar"))
+		})
+		It("has ConfigPatch added", func() {
+			Expect(f.Spec.ConfigPatches).To(HaveLen(1))
+		})
+	})
+})
+
+func TestEnvoyFilter(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "EnvoyFilter Package")
+}

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -1,0 +1,249 @@
+package ratelimit
+
+import (
+	"github.com/kyma-project/api-gateway/internal/builders/envoyfilter"
+	"google.golang.org/protobuf/types/known/structpb"
+	"istio.io/api/networking/v1alpha3"
+	"slices"
+	"time"
+)
+
+const (
+	LocalRateLimitFilterUrl  = "type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit"
+	TypedStruct              = "type.googleapis.com/udpa.type.v1.TypedStruct"
+	LocalRateLimitFilterName = "envoy.filters.http.local_ratelimit"
+)
+
+// RateLimit contains configuration for Rate Limiting service, exposing functions to manage Envoy's settings.
+type RateLimit struct {
+	limitType     string
+	limityTypeUrl string
+	actions       []Action
+	descriptors   []Descriptor
+	defaultBucket Bucket
+}
+
+// Action implements Envoy's Action API fields needed for Rate Limit configuration.
+// See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#config-route-v3-ratelimit-action
+type Action struct {
+	RequestHeaders RequestHeader
+}
+
+func (a Action) Value() *structpb.Value {
+	return structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{
+		"request_headers": a.RequestHeaders.Value(),
+	}})
+}
+
+// RequestHeader implements Envoy's RequestHeader's API fields.
+// See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/config/route/v3/route_components.proto#envoy-v3-api-msg-config-route-v3-ratelimit-action-requestheaders
+type RequestHeader struct {
+	Name          string
+	DescriptorKey string
+}
+
+func (rh RequestHeader) Value() *structpb.Value {
+	return structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{
+		"header_name":    structpb.NewStringValue(rh.Name),
+		"descriptor_key": structpb.NewStringValue(rh.DescriptorKey),
+	}})
+}
+
+// Descriptor describes each entry for rate limit.
+type Descriptor struct {
+	Entries DescriptorEntries
+	Bucket  Bucket
+}
+
+// DescriptorEntries wraps a list of DescriptorEntry and implements PBValue interface
+type DescriptorEntries []DescriptorEntry
+
+func (de DescriptorEntries) Value() *structpb.Value {
+	var values []*structpb.Value
+	for _, entry := range de {
+		values = append(values, entry.Value())
+	}
+	return structpb.NewListValue(&structpb.ListValue{Values: values})
+}
+
+func (d Descriptor) Value() *structpb.Value {
+	return structpb.NewStructValue(&structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"entries":      d.Entries.Value(),
+			"token_bucket": d.Bucket.Value(),
+		},
+	})
+}
+
+// DescriptorEntry contains routes to which local rate limits apply in scope of each Descriptor
+type DescriptorEntry struct {
+	Key string
+	Val string
+}
+
+func (e DescriptorEntry) Value() *structpb.Value {
+	return structpb.NewStructValue(&structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"key":   structpb.NewStringValue(e.Key),
+			"value": structpb.NewStringValue(e.Val),
+		},
+	})
+}
+
+// Bucket implements token_bucket fields from Envoy API.
+// See: https://www.envoyproxy.io/docs/envoy/latest/api-v3/extensions/filters/http/local_ratelimit/v3/local_rate_limit.proto#envoy-v3-api-msg-extensions-filters-http-local-ratelimit-v3-localratelimit
+type Bucket struct {
+	MaxTokens     int
+	TokensPerFill int
+	FillInterval  time.Duration
+}
+
+func (b Bucket) Value() *structpb.Value {
+	return structpb.NewStructValue(&structpb.Struct{
+		Fields: map[string]*structpb.Value{
+			"fill_interval":   structpb.NewStringValue(b.FillInterval.String()),
+			"max_tokens":      structpb.NewNumberValue(float64(b.MaxTokens)),
+			"tokens_per_fill": structpb.NewNumberValue(float64(b.TokensPerFill))},
+	})
+}
+
+// it returns generic http filter needed for applying local rate limit
+func localHttpFilterPatch() *envoyfilter.ConfigPatch {
+	return &v1alpha3.EnvoyFilter_EnvoyConfigObjectPatch{
+		ApplyTo: v1alpha3.EnvoyFilter_HTTP_FILTER,
+		Match: &v1alpha3.EnvoyFilter_EnvoyConfigObjectMatch{
+			Context: v1alpha3.EnvoyFilter_SIDECAR_INBOUND,
+			ObjectTypes: &v1alpha3.EnvoyFilter_EnvoyConfigObjectMatch_Listener{
+				Listener: &v1alpha3.EnvoyFilter_ListenerMatch{
+					FilterChain: &v1alpha3.EnvoyFilter_ListenerMatch_FilterChainMatch{
+						Filter: &v1alpha3.EnvoyFilter_ListenerMatch_FilterMatch{
+							Name: "envoy.filters.network.http_connection_manager",
+						},
+					},
+				},
+			},
+		},
+		Patch: &v1alpha3.EnvoyFilter_Patch{
+			Operation: v1alpha3.EnvoyFilter_Patch_INSERT_BEFORE,
+			Value: &structpb.Struct{Fields: map[string]*structpb.Value{
+				"name": structpb.NewStringValue(LocalRateLimitFilterName),
+				"typed_config": structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{
+					"@type":    structpb.NewStringValue(TypedStruct),
+					"type_url": structpb.NewStringValue(LocalRateLimitFilterUrl),
+					"value": structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{
+						"stat_prefix": structpb.NewStringValue("http_local_rate_limiter"),
+					}}),
+				}}),
+			}}},
+	}
+}
+
+// RateLimitConfigPatch generates Istio-compatible ConfigPatch containing local rate limit configuration
+func (rl *RateLimit) RateLimitConfigPatch() *envoyfilter.ConfigPatch {
+	return &envoyfilter.ConfigPatch{
+		ApplyTo: v1alpha3.EnvoyFilter_HTTP_ROUTE,
+		Match: &v1alpha3.EnvoyFilter_EnvoyConfigObjectMatch{
+			Context: v1alpha3.EnvoyFilter_SIDECAR_INBOUND,
+		},
+		Patch: &v1alpha3.EnvoyFilter_Patch{
+			Operation: v1alpha3.EnvoyFilter_Patch_MERGE,
+			Value: &structpb.Struct{Fields: map[string]*structpb.Value{
+				"route": structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{
+					"rate_limits": structpb.NewListValue(&structpb.ListValue{Values: []*structpb.Value{
+						structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{
+							"actions": func() *structpb.Value {
+								var actVal []*structpb.Value
+								for _, a := range rl.actions {
+									actVal = append(actVal, a.Value())
+								}
+								return structpb.NewListValue(&structpb.ListValue{Values: actVal})
+							}(),
+						}}),
+					}}),
+				}}),
+				"typed_per_filter_config": structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{
+					LocalRateLimitFilterName: structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{
+						"@type":    structpb.NewStringValue(rl.limitType),
+						"type_url": structpb.NewStringValue(rl.limityTypeUrl),
+						"value": structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{
+							"stat_prefix":                structpb.NewStringValue("rate_limit"),
+							"enable_x_ratelimit_headers": structpb.NewStringValue("DRAFT_VERSION_03"),
+							"filter_enabled": structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{
+								"runtime_key": structpb.NewStringValue("local_rate_limit_enabled"),
+								"default_value": structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{
+									"numerator":   structpb.NewNumberValue(float64(100)),
+									"denominator": structpb.NewStringValue("HUNDRED"),
+								}}),
+							}}),
+							"filter_enforced": structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{
+								"runtime_key": structpb.NewStringValue("local_rate_limit_enforced"),
+								"default_value": structpb.NewStructValue(&structpb.Struct{Fields: map[string]*structpb.Value{
+									"numerator":   structpb.NewNumberValue(float64(100)),
+									"denominator": structpb.NewStringValue("HUNDRED"),
+								}}),
+							}}),
+							"always_consume_default_token_bucket": structpb.NewBoolValue(false),
+							"token_bucket":                        rl.defaultBucket.Value(),
+							"descriptors": func() *structpb.Value {
+								var vals []*structpb.Value
+								for _, a := range rl.descriptors {
+									vals = append(vals, a.Value())
+								}
+								return structpb.NewListValue(&structpb.ListValue{Values: vals})
+							}(),
+						}}),
+					}}),
+				}}),
+			}},
+		},
+	}
+}
+
+func hasHeader(header RequestHeader, actions []Action) bool {
+	for _, a := range actions {
+		if a.RequestHeaders.Name == header.Name {
+			return true
+		}
+	}
+	return false
+}
+
+// For adds rate limit for specific descriptor. From this descriptor a RequestHeader is created, that is then added
+// to the Action list.
+func (rl *RateLimit) For(descriptor Descriptor) *RateLimit {
+	for _, d := range descriptor.Entries {
+		name := d.Key
+		// These particular values are pseudo headers defined in Envoy API.
+		// They need to be prefixed with ':'
+		if slices.Contains([]string{"path", "method", "scheme"}, name) {
+			name = ":" + name
+		}
+		rh := RequestHeader{Name: name, DescriptorKey: d.Key}
+		if !hasHeader(rh, rl.actions) {
+			rl.actions = append(rl.actions, Action{RequestHeaders: rh})
+		}
+	}
+	rl.descriptors = append(rl.descriptors, descriptor)
+	return rl
+}
+
+// WithDefaultBucket adds configuration for the token bucked used by default.
+func (rl *RateLimit) WithDefaultBucket(bucket Bucket) *RateLimit {
+	rl.defaultBucket = bucket
+	return rl
+}
+
+// AddToEnvoyFilter parses RateLimit configuration, then applies the parsed ConfigPatches directly into the
+// envoyfilter.Builder struct.
+func (rl *RateLimit) AddToEnvoyFilter(filter *envoyfilter.Builder) {
+	filter.WithConfigPatch(localHttpFilterPatch())
+	filter.WithConfigPatch(rl.RateLimitConfigPatch())
+}
+
+// NewLocalRateLimit returns RateLimit struct for configuring local rate limits
+func NewLocalRateLimit() *RateLimit {
+	return &RateLimit{
+		limitType:     TypedStruct,
+		limityTypeUrl: LocalRateLimitFilterUrl,
+	}
+}

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -1,0 +1,235 @@
+package ratelimit
+
+import (
+	"github.com/kyma-project/api-gateway/internal/builders/envoyfilter"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/util/json"
+	"os"
+	"sigs.k8s.io/yaml"
+	"testing"
+	"time"
+)
+
+var _ = Describe("RateLimit", func() {
+	Context("NewLocalRateLimit", func() {
+		It("should return a new RateLimit For descriptors d0, d1", func() {
+			d0 := Descriptor{
+				Entries: DescriptorEntries{
+					{Key: "x-api-version", Val: "v1"},
+					{Key: "path", Val: "/headers"},
+				},
+				Bucket: Bucket{
+					MaxTokens:     2,
+					TokensPerFill: 2,
+					FillInterval:  30 * time.Second,
+				},
+			}
+			d1 := Descriptor{
+				Entries: DescriptorEntries{
+					{Key: "path", Val: "/ip"},
+				},
+				Bucket: Bucket{
+					MaxTokens:     20,
+					TokensPerFill: 10,
+					FillInterval:  30 * time.Second,
+				},
+			}
+
+			rl := NewLocalRateLimit().
+				For(d0).
+				For(d1)
+			Expect(rl.descriptors).Should(HaveLen(2))
+			Expect(rl.actions).Should(HaveLen(2))
+		})
+		It("should have :path action when descriptor contains pseudo header 'path'", func() {
+			d := Descriptor{
+				Entries: DescriptorEntries{
+					{Key: "path", Val: "/headers"},
+				},
+				Bucket: Bucket{
+					MaxTokens:     2,
+					TokensPerFill: 2,
+					FillInterval:  30 * time.Second,
+				},
+			}
+			rl := NewLocalRateLimit().For(d)
+			Expect(rl.descriptors).Should(HaveLen(1))
+			Expect(rl.actions).Should(HaveLen(1))
+			Expect(rl.actions[0].RequestHeaders.Name).Should(Equal(":path"))
+			Expect(rl.actions[0].RequestHeaders.DescriptorKey).Should(Equal("path"))
+		})
+		It("should return a new RateLimit For defaultBucket b", func() {
+			b := Bucket{
+				MaxTokens:     10,
+				TokensPerFill: 5,
+				FillInterval:  30 * time.Second,
+			}
+			rl := NewLocalRateLimit().WithDefaultBucket(b)
+			Expect(rl.defaultBucket).Should(Equal(b))
+		})
+	})
+	Context("AddToEnvoyFilter", func() {
+		b := Bucket{
+			MaxTokens:     10,
+			TokensPerFill: 5,
+			FillInterval:  30 * time.Second,
+		}
+		d0 := Descriptor{
+			Entries: DescriptorEntries{
+				{Key: "x-api-version", Val: "v1"},
+				{Key: "path", Val: "/headers"},
+			},
+			Bucket: Bucket{
+				MaxTokens:     2,
+				TokensPerFill: 2,
+				FillInterval:  30 * time.Second,
+			},
+		}
+		d1 := Descriptor{
+			Entries: DescriptorEntries{
+				{Key: "path", Val: "/ip"},
+			},
+			Bucket: Bucket{
+				MaxTokens:     20,
+				TokensPerFill: 10,
+				FillInterval:  30 * time.Second,
+			},
+		}
+		It("adds 2 ConfigPatches to the EnvoyFilterBuilder", func() {
+			builder := envoyfilter.NewEnvoyFilterBuilder().
+				WithName("httpbin-local-rate-limit").
+				WithNamespace("default").
+				WithWorkloadSelector("app", "httpbin")
+			rl := NewLocalRateLimit().
+				For(d1).
+				For(d0).
+				WithDefaultBucket(b)
+			rl.AddToEnvoyFilter(builder)
+			Expect(builder.ConfigPatches).To(HaveLen(2))
+		})
+	})
+	Context("RateLimitConfigPatch", func() {
+		d0 := Descriptor{
+			Entries: DescriptorEntries{
+				{Key: "x-api-version", Val: "v1"},
+				{Key: "path", Val: "/headers"},
+			},
+			Bucket: Bucket{
+				MaxTokens:     2,
+				TokensPerFill: 2,
+				FillInterval:  30 * time.Second,
+			},
+		}
+		defaultBucket := Bucket{
+			MaxTokens:     20,
+			TokensPerFill: 10,
+			FillInterval:  30 * time.Second,
+		}
+		rl := NewLocalRateLimit().For(d0).WithDefaultBucket(defaultBucket)
+		config := rl.RateLimitConfigPatch()
+		It("returns ConfigPatch with 2 route actions", func() {
+			vals := config.Patch.Value.GetFields()
+			rateLimits := vals["route"].GetStructValue().GetFields()["rate_limits"].GetListValue().GetValues()
+			Expect(rateLimits).Should(HaveLen(1))
+			actions := rateLimits[0].GetStructValue().GetFields()["actions"].GetListValue().GetValues()
+			Expect(actions).Should(HaveLen(2))
+
+			exp1 := Action{RequestHeaders: RequestHeader{Name: "x-api-version", DescriptorKey: "x-api-version"}}
+			Expect(actions).Should(ContainElement(exp1.Value()))
+			exp2 := Action{RequestHeaders: RequestHeader{Name: ":path", DescriptorKey: "path"}}
+			Expect(actions).Should(ContainElement(exp2.Value()))
+		})
+		It("returns ConfigPatch With Default bucket", func() {
+			vals := config.Patch.Value.GetFields()
+			config := vals["typed_per_filter_config"].GetStructValue().GetFields()[LocalRateLimitFilterName]
+			Expect(config).ShouldNot(BeNil())
+			gotBucket := config.GetStructValue().GetFields()["value"].GetStructValue().GetFields()["token_bucket"]
+			expBucket := Bucket{
+				MaxTokens:     20,
+				TokensPerFill: 10,
+				FillInterval:  30 * time.Second,
+			}
+			Expect(gotBucket).Should(Equal(expBucket.Value()))
+		})
+		It("returns ConfigPatch with 1 descriptor", func() {
+			vals := config.Patch.Value.GetFields()
+			config := vals["typed_per_filter_config"].GetStructValue().GetFields()[LocalRateLimitFilterName]
+			Expect(config).ShouldNot(BeNil())
+			gotDesc := config.GetStructValue().GetFields()["value"].GetStructValue().GetFields()["descriptors"].GetListValue().GetValues()
+			Expect(gotDesc).Should(HaveLen(1))
+
+			expDesc := Descriptor{
+				Entries: DescriptorEntries{
+					{Key: "x-api-version", Val: "v1"},
+					{Key: "path", Val: "/headers"},
+				},
+				Bucket: Bucket{
+					MaxTokens:     2,
+					TokensPerFill: 2,
+					FillInterval:  30 * time.Second,
+				},
+			}
+
+			Expect(gotDesc).Should(ContainElement(expDesc.Value()))
+		})
+	})
+	Context("RateLimit to EnvoyFilter conversion", func() {
+		d0 := Descriptor{
+			Entries: DescriptorEntries{
+				{Key: "x-api-version", Val: "v1"},
+				{Key: "path", Val: "/headers"},
+			},
+			Bucket: Bucket{
+				MaxTokens:     2,
+				TokensPerFill: 2,
+				FillInterval:  30 * time.Second,
+			},
+		}
+		d1 := Descriptor{
+			Entries: DescriptorEntries{
+				{Key: "path", Val: "/ip"},
+			},
+			Bucket: Bucket{
+				MaxTokens:     20,
+				TokensPerFill: 10,
+				FillInterval:  30 * time.Second,
+			},
+		}
+		bucket := Bucket{
+			MaxTokens:     10,
+			TokensPerFill: 5,
+			FillInterval:  30 * time.Second,
+		}
+		rl := NewLocalRateLimit().
+			For(d1).
+			For(d0).
+			WithDefaultBucket(bucket)
+		builder := envoyfilter.NewEnvoyFilterBuilder().
+			WithName("httpbin-local-rate-limit").
+			WithNamespace("default").
+			WithWorkloadSelector("app", "httpbin")
+		rl.AddToEnvoyFilter(builder)
+		It("builds EnvoyFilter with expected configuration", func() {
+			f, err := os.ReadFile("testdata/envoy_patches.yaml")
+			Expect(err).Should(Succeed())
+			var fi []envoyfilter.ConfigPatch
+			exp, err := yaml.YAMLToJSON(f)
+			Expect(err).To(Succeed())
+			Expect(json.Unmarshal(exp, &fi)).Should(Succeed())
+			result := builder.Build()
+			got, err := json.Marshal(result.Spec.ConfigPatches)
+			Expect(err).Should(Succeed())
+			// This may fail if struct gets marshalled in not expected order.
+			// However, I don't have much idea how to cover if marshaled structure is compatible with Envoy's
+			// So just make sure the testdata is ordered.
+			// Probably EnvTest would be better.
+			Expect(got).Should(Equal(exp))
+		})
+	})
+})
+
+func TestRateLimitSuite(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "RateLimit Suite")
+}

--- a/internal/ratelimit/testdata/envoy_patches.yaml
+++ b/internal/ratelimit/testdata/envoy_patches.yaml
@@ -1,0 +1,70 @@
+- applyTo: HTTP_FILTER
+  match:
+    context: SIDECAR_INBOUND
+    listener:
+      filterChain:
+        filter:
+          name: "envoy.filters.network.http_connection_manager"
+  patch:
+    operation: INSERT_BEFORE
+    value:
+      name: envoy.filters.http.local_ratelimit
+      typed_config:
+        "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+        type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+        value:
+          stat_prefix: http_local_rate_limiter
+- applyTo: HTTP_ROUTE
+  match:
+    context: SIDECAR_INBOUND
+  patch:
+    operation: MERGE
+    value:
+      route:
+        rate_limits:
+          - actions:
+              - request_headers:
+                  header_name: ":path"
+                  descriptor_key: "path"
+              - request_headers:
+                  header_name: "x-api-version"
+                  descriptor_key: "x-api-version"
+      typed_per_filter_config:
+        envoy.filters.http.local_ratelimit:
+          "@type": type.googleapis.com/udpa.type.v1.TypedStruct
+          type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
+          value:
+            stat_prefix: rate_limit
+            enable_x_ratelimit_headers: DRAFT_VERSION_03
+            filter_enabled:
+              runtime_key: local_rate_limit_enabled
+              default_value:
+                numerator: 100
+                denominator: HUNDRED
+            filter_enforced:
+              runtime_key: local_rate_limit_enforced
+              default_value:
+                numerator: 100
+                denominator: HUNDRED
+            always_consume_default_token_bucket: false
+            token_bucket:
+              max_tokens: 10
+              tokens_per_fill: 5
+              fill_interval: 30s
+            descriptors:
+              - entries:
+                  - key: path
+                    value: /ip
+                token_bucket:
+                  max_tokens: 20
+                  tokens_per_fill: 10
+                  fill_interval: 30s
+              - entries:
+                  - key: x-api-version
+                    value: v1
+                  - key: path
+                    value: /headers
+                token_bucket:
+                  max_tokens: 2
+                  tokens_per_fill: 2
+                  fill_interval: 30s


### PR DESCRIPTION
/area api-gateway
/kind feature

- Implement EnvoyFilterBuilder struct for easier construction of EnvoyFilter CR
- Implement LocalRateLimit package which operates on Envoy API, then builds config patches compatible with istio's EnvoyFilter API
- Add unit tests for introduced code

#1368 