### PR TITLE
hack: consolidate pull-request status into one job

### DIFF
--- a/.github/workflows/pull-build-push.yaml
+++ b/.github/workflows/pull-build-push.yaml
@@ -20,33 +20,11 @@ on:
       - 'main'
 
 jobs:
-  filter-changes:
-    name: List relevant VCS changes
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files_ignore: |
-            docs/**
-            **/*.md
-            OWNERS
-            CODEOWNERS
-            sec-scanners-config.yaml
-            .github/**
-            .**
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}'
-
   build-image:
     name: Build and push manager image
-    needs: [filter-changes]
     environment: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' && 'restricted' || 'internal' }}
     runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.draft == false && needs.filter-changes.outputs.check == 'true' }}
+    if: ${{ github.event.pull_request.draft == false }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pull-integration-release.yaml
+++ b/.github/workflows/pull-integration-release.yaml
@@ -7,7 +7,6 @@ jobs:
   integration-tests:
     name: Integration tests
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:
@@ -28,7 +27,6 @@ jobs:
   migration-downtime-tests:
     name: Zero Downtime Migration Tests
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:
@@ -46,7 +44,6 @@ jobs:
   k8s-compatibility-check:
     name: Kubernetes version compatibility test
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/pull-integration.yaml
+++ b/.github/workflows/pull-integration.yaml
@@ -7,10 +7,28 @@ on:
   workflow_call:
 
 jobs:
+  changed-files:
+    name: Changed files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
+        id: changed-files
+        with:
+          files_ignore: |
+            docs/**
+            **/*.md
+            tests/performance/**
+            OWNERS
+            CODEOWNERS
+            sec-scanners-config.yaml
+            .github/**
+            external-images.yaml
   integration-tests:
     name: Integration tests
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    needs: [ changed-files ]
+    if: needs.changed-files.outputs.any_changed == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -29,7 +47,8 @@ jobs:
   k8s-compatibility-check:
     name: Kubernetes version compatibility test
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    needs: [ changed-files ]
+    if: needs.changed-files.outputs.any_changed == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -48,6 +67,8 @@ jobs:
   upgrade-tests:
     name: Upgrade tests
     runs-on: ubuntu-latest
+    needs: [ changed-files ]
+    if: needs.changed-files.outputs.any_changed == 'true'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/pull-request-release.yaml
+++ b/.github/workflows/pull-request-release.yaml
@@ -7,35 +7,10 @@ on:
       - 'release-**'
 
 jobs:
-  check-build-image:
-    name: Check whether build image should run
-    environment: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' && 'restricted' || 'internal' }}
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.draft == false }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files_ignore: |
-            docs/**
-            **/*.md
-            **/*.yaml
-            tests/performance/**
-            OWNERS
-            CODEOWNERS
-            .github/**
-            .reuse/**
-            external-images.yaml
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
   build-image:
     name: Build manager image
-    needs: [check-build-image]
-    if: ${{ needs.check-build-image.outputs.check == 'true' }}
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
+    if: github.event.pull_request.draft == false
     with:
       name: api-gateway-manager
       dockerfile: Dockerfile
@@ -43,111 +18,37 @@ jobs:
       build-args: |
         VERSION=PR-${{ github.event.number }}
 
-  check-unit-test:
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    name: Check whether unit test & lint should run based on the changed files
-    environment: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' && 'restricted' || 'internal' }}
+  unit-tests:
+    name: Unit tests & lint
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files_ignore: |
-            docs/**
-            **/*.md
-            tests/performance/**
-            OWNERS
-            CODEOWNERS
-            sec-scanners-config.yaml
-            .github/**
-            .reuse/**
-            external-images.yaml
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
-  dispatch-unit-test:
-    name: Dispatch unit test
-    needs: [check-unit-test]
     uses: ./.github/workflows/pull-unit-lint.yaml
-    if: ${{ needs.check-unit-test.outputs.check == 'true' }}
     secrets: inherit
 
-  check-integration:
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    name: Check whether integration tests should run based on the changed files
-    environment: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' && 'restricted' || 'internal' }}
+  integration-tests:
+    name: Integration tests
+    needs: [ build-image ]
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files_ignore: |
-            docs/**
-            **/*.md
-            tests/performance/**
-            OWNERS
-            CODEOWNERS
-            sec-scanners-config.yaml
-            .github/**
-            external-images.yaml
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
-  dispatch-integration:
-    name: Dispatch integration tests
-    needs: [ check-integration,build-image ]
     uses: ./.github/workflows/pull-integration-release.yaml
-    if: ${{ needs.check-integration.outputs.check == 'true' }}
     secrets: inherit
 
-  check-ui:
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    name: Check whether UI tests should run based on the changed files
-    environment: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' && 'restricted' || 'internal' }}
+  ui-tests:
+    name: UI tests
+    needs: [build-image]
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files: |
-            config/ui-extensions/**
-            config/crd/**
-            tests/ui/**
-            .github/workflows/ui-tests.yaml
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
-  dispatch-ui:
-    name: Dispatch UI tests
-    needs: [check-ui,build-image]
     uses: ./.github/workflows/ui-tests.yaml
-    if: ${{ needs.check-ui.outputs.check == 'true' }}
     secrets: inherit
 
-  check-verify-pins:
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    name: Check whether to run verify-commit-pins
-    environment: ${{ github.event.pull_request.author_association != 'COLLABORATOR' && github.event.pull_request.author_association != 'OWNER' && 'restricted' || 'internal' }}
+  verify-pins:
+    name: Verify-commit-pins
+    if: github.event.pull_request.draft == false
+    uses: ./.github/workflows/verify-commit-pins.yaml
+    secrets: inherit
+
+  pull-request-status:
+    needs: [ build-image, unit-tests, integration-tests, ui-tests, verify-pins ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files: |
-            .github/workflows/**
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
-  dispatch-verify-pins:
-    name: Dispatch verify-commit-pins
-    needs: [check-verify-pins]
-    uses: ./.github/workflows/verify-commit-pins.yaml
-    if: ${{ needs.check-verify-pins.outputs.check == 'true' }}
-    secrets: inherit
+      - if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -30,35 +30,10 @@ jobs:
         env:
           PULL_BASE_SHA: ${{ github.event.pull_request.base.sha }}
           PULL_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-  check-build-image:
-    name: Check whether build image should run
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    runs-on: ubuntu-latest
-    if: ${{ github.event.pull_request.draft == false }}
-    steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files_ignore: |
-            docs/**
-            **/*.md
-            **/*.yaml
-            tests/performance/**
-            OWNERS
-            CODEOWNERS
-            .github/**
-            .reuse/**
-            external-images.yaml
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
-
   build-image:
     name: Build manager image
     runs-on: ubuntu-latest
-    needs: [check-build-image]
-    if: ${{ needs.check-build-image.outputs.check == 'true' }}
+    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,107 +43,37 @@ jobs:
         with:
           operator-image-name: "api-gateway-manager:PR-${{github.event.number}}"
 
-  check-unit-test:
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    name: Check whether unit test & lint should run based on the changed files
+  unit-tests:
+    name: Unit tests & lint
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files_ignore: |
-            docs/**
-            **/*.md
-            tests/performance/**
-            OWNERS
-            CODEOWNERS
-            sec-scanners-config.yaml
-            .github/**
-            .reuse/**
-            external-images.yaml
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
-  dispatch-unit-test:
-    name: Dispatch unit test
-    needs: [check-unit-test]
     uses: ./.github/workflows/pull-unit-lint.yaml
-    if: ${{ needs.check-unit-test.outputs.check == 'true' }}
     secrets: inherit
 
-  check-integration:
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    name: Check whether integration tests should run based on the changed files
+  integration-tests:
+    name: Integration tests
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files_ignore: |
-            docs/**
-            **/*.md
-            tests/performance/**
-            OWNERS
-            CODEOWNERS
-            sec-scanners-config.yaml
-            .github/**
-            external-images.yaml
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
-  dispatch-integration:
-    name: Dispatch integration tests
-    needs: [check-integration,build-image]
+    needs: [build-image]
     uses: ./.github/workflows/pull-integration.yaml
-    if: ${{ needs.check-integration.outputs.check == 'true' }}
     secrets: inherit
 
-  check-ui:
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    name: Check whether UI tests should run based on the changed files
+  ui-tests:
+    name: UI tests
     if: github.event.pull_request.draft == false
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files: |
-            config/ui-extensions/**
-            config/crd/**
-            tests/ui/**
-            .github/workflows/ui-tests.yaml
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
-  dispatch-ui:
-    name: Dispatch UI tests
-    needs: [check-ui,build-image]
+    needs: [build-image]
     uses: ./.github/workflows/ui-tests.yaml
-    if: ${{ needs.check-ui.outputs.check == 'true' }}
     secrets: inherit
 
-  check-verify-pins:
-    outputs:
-      check: ${{ steps.changed-files.outputs.any_modified }}
-    name: Check whether to run verify-commit-pins
+  verify-pins:
+    name: Verify-commit-pins
+    if: github.event.pull_request.draft == false
+    uses: ./.github/workflows/verify-commit-pins.yaml
+    secrets: inherit
+
+  pull-request-status:
+    needs: [ build-image, unit-tests, integration-tests, ui-tests, verify-pins ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
-        id: changed-files
-        with:
-          files: |
-            .github/workflows/**
-      - name: List all changed files
-        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
-  dispatch-verify-pins:
-    name: Dispatch verify-commit-pins
-    needs: [check-verify-pins]
-    uses: ./.github/workflows/verify-commit-pins.yaml
-    if: ${{ needs.check-verify-pins.outputs.check == 'true' }}
-    secrets: inherit
+      - if: ${{ !(contains(needs.*.result, 'failure')) }}
+        run: exit 0
+      - if: ${{ contains(needs.*.result, 'failure') }}
+        run: exit 1

--- a/.github/workflows/pull-unit-lint.yaml
+++ b/.github/workflows/pull-unit-lint.yaml
@@ -6,10 +6,31 @@ on:
   workflow_call:
 
 jobs:
+  changed-files:
+    name: Check changed files
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
+        id: changed-files
+        with:
+          files_ignore: |
+            docs/**
+            **/*.md
+            tests/performance/**
+            OWNERS
+            CODEOWNERS
+            sec-scanners-config.yaml
+            .github/**
+            .reuse/**
+            external-images.yaml
+      - name: List all changed files
+        run: echo '${{ steps.changed-files.outputs.all_changed_files }}' >> $GITHUB_STEP_SUMMARY
   lint:
     name: Golang lint check
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    needs: [ changed-files ]
+    if: needs.changed-files.outputs.any_changed == 'true'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -27,7 +48,8 @@ jobs:
   run-unit-tests:
     name: Run unit tests
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
+    needs: [ changed-files ]
+    if: needs.changed-files.outputs.any_changed == 'true'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -41,4 +63,3 @@ jobs:
           PULL_BASE_SHA=${{ github.event.pull_request.base.sha}} \
           PULL_NUMBER=${{ github.event.number }} \
           ./hack/ci/code-coverage-guard.sh
-

--- a/.github/workflows/ui-tests.yaml
+++ b/.github/workflows/ui-tests.yaml
@@ -6,17 +6,25 @@ on:
 jobs:
   run-ui-tests:
     name: Run UI tests
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
+        id: changed-files
+        with:
+          files: |
+            config/ui-extensions/**
+            config/crd/**
+            tests/ui/**
+            .github/workflows/ui-tests.yaml
       - uses: ./.github/actions/load-manager-image
       - uses: actions/setup-go@v5
         with:
           go-version-file: 'go.mod'
-      - name: Run tests
+      - name: Tests
+        if: steps.changed-files.outputs.any_changed == 'true'
         run: |
           sudo echo "127.0.0.1 local.kyma.dev" | sudo tee -a /etc/hosts
           wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | sudo bash

--- a/.github/workflows/verify-commit-pins.yaml
+++ b/.github/workflows/verify-commit-pins.yaml
@@ -10,10 +10,15 @@ jobs:
   verify-actions:
     name: Ensure SHA pinned actions
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == false
     steps:
       - uses: actions/checkout@v4
+      - uses: tj-actions/changed-files@e9772d140489982e0e3704fea5ee93d536f1e275
+        id: changed
+        with:
+          files: |
+            .github/workflows/**
       - uses: zgosalvez/github-actions-ensure-sha-pinned-actions@3c16e895bb662b4d7e284f032cbe8835a57773cc # 3.0.11
+        if: ${{ steps.changed.outputs.any_changed == 'true' }}
         with:
           # We only want to allow official GitHub Actions
           allowlist: |


### PR DESCRIPTION
/kind chore
/area ci

Modify usage of tj-changed files in specific files. Any kind of status other than failure is treated as `success`.
Introduce pull-request-status job that returns `success`, if all jobs return success.
This PR moves the usage of changed files filter into respective files, making the jobs in `pull-request.yaml` always reported. If any of the jobs/steps fail, the pull-request-status job will result in a failure.
This job can be used as required status check

After this PR gets merged, new status checks will have to be set:
- pull-request-status

References:
- https://github.com/orgs/community/discussions/4324#discussioncomment-3477871
