### PR TITLE
Improved resiliency of custom domain integration tests

### DIFF
--- a/hack/ci/custom-domain-gardener-aws.sh
+++ b/hack/ci/custom-domain-gardener-aws.sh
@@ -15,6 +15,6 @@ export GARDENER_PROVIDER="aws"
 export GARDENER_REGION="eu-west-1"
 export GARDENER_PROVIDER_SECRET_NAME="aws-gardener-access"
 export GARDENER_PROJECT_NAME="goats"
-export GARDENER_CLUSTER_VERSION="1.29.7"
+export GARDENER_CLUSTER_VERSION="1.29.9"
 
 ./hack/ci/custom-domain-gardener.sh $@

--- a/hack/ci/custom-domain-gardener-gcp.sh
+++ b/hack/ci/custom-domain-gardener-gcp.sh
@@ -15,6 +15,6 @@ export GARDENER_PROVIDER="gcp"
 export GARDENER_REGION="europe-west3"
 export GARDENER_PROVIDER_SECRET_NAME="goat"
 export GARDENER_PROJECT_NAME="goats"
-export GARDENER_CLUSTER_VERSION="1.29.7"
+export GARDENER_CLUSTER_VERSION="1.29.9"
 
 ./hack/ci/custom-domain-gardener.sh $@

--- a/hack/ci/provision-gardener.sh
+++ b/hack/ci/provision-gardener.sh
@@ -95,7 +95,9 @@ until (kubectl --kubeconfig "${CLUSTER_NAME}_kubeconfig.yaml" get --raw "/readyz
   sleep 1
 done
 
+echo "waiting for shoot operations to be completed..."
+kubectl wait --kubeconfig "${GARDENER_KUBECONFIG}" --for=jsonpath='{.status.lastOperation.state}'=Succeeded --timeout=600s "shoots/${CLUSTER_NAME}"
+
 # replace the default kubeconfig
 mkdir -p ~/.kube
 mv "${CLUSTER_NAME}_kubeconfig.yaml" ~/.kube/config
-

--- a/hack/ci/provision-gardener.sh
+++ b/hack/ci/provision-gardener.sh
@@ -74,7 +74,7 @@ until (echo "$shoot_template" | kubectl --kubeconfig "${GARDENER_KUBECONFIG}" ap
   sleep 15
 done
 
-echo "waiting fo cluster to be ready..."
+echo "waiting for cluster to be ready..."
 kubectl wait  --kubeconfig "${GARDENER_KUBECONFIG}" --for=condition=EveryNodeReady shoot/${CLUSTER_NAME} --timeout=17m
 # create kubeconfig request, that creates a kubeconfig which is valid for one day
 kubectl create  --kubeconfig "${GARDENER_KUBECONFIG}" \


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- waiting for shoot provisioning in the provision-gardener script, so it finished when the cluster is fully provisioned
- waiting for shoot provisioning once again after shoot resource is patched in the custom-domain-gardener.sh, so the istio is installed on fully provisioned cluster
- waiting for the ingress gateway to be reachable via external IP before executing tests
- upgraded Gardener cluster version from 1.29.7 to 1.29.9

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
Randomly failing custom domain integration tests with messages like "connection reset by peer" when trying to reach httpbin endpoint.
