### PR TITLE
Validation of path conflicts with `{**}` or `{*}` operators

### DIFF
--- a/internal/path/parser/parser.go
+++ b/internal/path/parser/parser.go
@@ -1,1 +1,0 @@
-package parser

--- a/internal/path/parser/parser.go
+++ b/internal/path/parser/parser.go
@@ -1,0 +1,1 @@
+package parser

--- a/internal/path/segment_trie/segment_trie.go
+++ b/internal/path/segment_trie/segment_trie.go
@@ -1,0 +1,181 @@
+// Package segment_trie provides a trie data structure for segmenting paths.
+// It is used to validate that no path conflicts occur in a APIRule.
+package segment_trie
+
+import (
+	"errors"
+	"github.com/kyma-project/api-gateway/internal/path/token"
+	"strings"
+)
+
+type SegmentTrie struct {
+	Root *Node
+}
+
+type Node struct {
+	EndNode  bool             `json:"-"`
+	Children map[string]*Node `json:"children"`
+	Suffixes []string         `json:"suffixes"`
+}
+
+func (n *Node) String() string {
+	if n.EndNode {
+		return "{}"
+	}
+	b := strings.Builder{}
+	b.WriteString("{")
+	for k, v := range n.Children {
+		b.WriteString(`"`)
+		b.WriteString(k)
+		b.WriteString(`":`)
+		b.WriteString(v.String())
+		b.WriteString(",")
+	}
+	return strings.Trim(b.String(), ",") + "}"
+}
+
+func New() *SegmentTrie {
+	return &SegmentTrie{
+		Root: &Node{
+			EndNode:  true,
+			Children: map[string]*Node{},
+		},
+	}
+}
+
+func (t *SegmentTrie) InsertAndCheckCollisions(tokens []token.Token) error {
+	if len(tokens) == 0 {
+		return nil
+	}
+	node := t.Root
+	pathExist := findExistingPath(node, false, tokens, 0)
+	if pathExist {
+		return errors.New("path collision detected")
+	}
+	for i, tok := range tokens {
+		node.EndNode = false
+		if tok.Type == token.BRACED_DOUBLE_ASTERIX {
+			if _, ok := node.Children["{**}"]; !ok {
+				node.Children["{**}"] = &Node{
+					EndNode:  true,
+					Children: make(map[string]*Node),
+					Suffixes: []string{token.List(tokens[i+1:]).String()},
+				}
+			} else {
+				node.Children["{**}"].Suffixes = append(node.Children["{**}"].Suffixes, token.List(tokens[i:]).String())
+			}
+		} else {
+			if _, ok := node.Children[tok.Literal]; !ok {
+				node.Children[tok.Literal] = &Node{
+					EndNode:  true,
+					Children: make(map[string]*Node),
+				}
+			}
+		}
+
+		if _, ok := node.Children[tok.Literal]; !ok {
+			return errors.New("path collision detected")
+		}
+		node = node.Children[tok.Literal]
+	}
+	return nil
+}
+
+func suffixExist(node *Node, suffix []token.Token, cur int) bool {
+	if len(suffix) == 0 {
+		return true
+	}
+
+	if cur >= len(suffix) {
+		return true
+	}
+
+	if cnode, ok := node.Children["{**}"]; ok {
+		tokensString := token.List(suffix).String()
+		for _, suffix := range cnode.Suffixes {
+			if strings.HasSuffix(tokensString, suffix) || strings.HasSuffix(suffix, tokensString) {
+				return true
+			}
+		}
+	}
+
+	if _, ok := node.Children[suffix[cur].Literal]; ok {
+		if suffixExist(node.Children[suffix[cur].Literal], suffix, cur+1) {
+			return true
+		}
+	}
+
+	for k, v := range node.Children {
+		if k != "{**}" && suffixExist(v, suffix, cur) {
+			return true
+		}
+	}
+	return false
+}
+
+func findExistingPath(node *Node, isNodeDoubleAsterix bool, tokens []token.Token, cur int) bool {
+	if len(tokens) == 0 {
+		return node.EndNode
+	}
+
+	if cur >= len(tokens) {
+		return node.EndNode
+	}
+
+	if isNodeDoubleAsterix {
+		if hasAnySuffix(tokens, node.Suffixes) {
+			return true
+		} else {
+			return false
+		}
+	}
+
+	switch tokens[cur].Type {
+	case token.IDENT:
+		if _, ok := node.Children[tokens[cur].Literal]; ok {
+			if findExistingPath(node.Children[tokens[cur].Literal], false, tokens, cur+1) {
+				return true
+			}
+		}
+
+		if _, ok := node.Children["{*}"]; ok {
+			if findExistingPath(node.Children["{*}"], false, tokens, cur+1) {
+				return true
+			}
+		}
+
+		if _, ok := node.Children["{**}"]; ok {
+			if findExistingPath(node.Children["{**}"], true, tokens, cur+1) {
+				return true
+			}
+		}
+	case token.BRACED_ASTERIX:
+		for key, node := range node.Children {
+			if findExistingPath(node, key == "{**}", tokens, cur+1) {
+				return true
+			}
+		}
+	case token.BRACED_DOUBLE_ASTERIX:
+		bracedAsterixSuffix := tokens[cur+1:]
+		return suffixExist(node, bracedAsterixSuffix, 0)
+	}
+	return false
+}
+
+func hasAnySuffix(tokens token.List, suffixes []string) bool {
+	if len(suffixes) == 0 {
+		return true
+	}
+	tokensString := tokens.String()
+
+	for _, suffix := range suffixes {
+		if strings.HasSuffix(tokensString, suffix) {
+			return true
+		}
+	}
+	return false
+}
+
+func (t *SegmentTrie) String() string {
+	return t.Root.String()
+}

--- a/internal/path/segment_trie/segment_trie.go
+++ b/internal/path/segment_trie/segment_trie.go
@@ -123,11 +123,7 @@ func findExistingPath(node *Node, isNodeDoubleAsterix bool, tokens []token.Token
 	}
 
 	if isNodeDoubleAsterix {
-		if hasAnySuffix(tokens, node.Suffixes) {
-			return true
-		} else {
-			return false
-		}
+		return hasAnySuffix(tokens, node.Suffixes)
 	}
 
 	switch tokens[cur].Type {

--- a/internal/path/segment_trie/segment_trie.go
+++ b/internal/path/segment_trie/segment_trie.go
@@ -1,5 +1,18 @@
-// Package segment_trie provides a trie data structure for segmenting paths.
-// It is used to validate that no path conflicts occur in a APIRule.
+// Package segment_trie provides a trie data structure for storing URL paths.
+// It has the main purpose of checking for path collisions.
+//
+// The SegmentTrie is a trie data structure that segments paths into tokens.
+// Stored paths can contain the `{*}` and `{**}` operators:
+//   - operator `{*}` is used to match a single segment in a path, and may include a prefix and/or suffix.
+//   - operator `{**}` is used any number of segments in a path, and may include a prefix and/or suffix.
+//     It must be the last operator in the stored path (this is not validated but is assumed to be true).
+//
+// It does two things that are not done by a regular trie:
+//   - Nodes that are pointed to by `{**}` don't store their children,
+//     instead they store the path suffix that exists after `{**}`.
+//     Conflicts are checked by comparing the suffixes of paths with the same segments that precede `{**}`.
+//     This can be done, since the `{**}` operator must be the last in the path.
+//   - `{*}` nodes are stored just like any other exact segment node, but are always included in conflict search.
 package segment_trie
 
 import (

--- a/internal/path/segment_trie/segment_trie.go
+++ b/internal/path/segment_trie/segment_trie.go
@@ -61,10 +61,13 @@ func (t *SegmentTrie) InsertAndCheckCollisions(tokens []token.Token) error {
 		return nil
 	}
 	node := t.Root
-	pathExist := findExistingPath(node, false, tokens, 0)
-	if pathExist {
-		return errors.New("path collision detected")
+	if !t.Root.EndNode {
+		pathExist := findExistingPath(node, false, tokens, 0)
+		if pathExist {
+			return errors.New("path collision detected")
+		}
 	}
+
 	for i, tok := range tokens {
 		node.EndNode = false
 		if tok.Type == token.BRACED_DOUBLE_ASTERIX {

--- a/internal/path/segment_trie/segment_trie.go
+++ b/internal/path/segment_trie/segment_trie.go
@@ -108,10 +108,6 @@ func suffixExist(node *Node, suffix []token.Token, cur int) bool {
 }
 
 func findExistingPath(node *Node, tokens []token.Token, cur int) bool {
-	if len(tokens) == 0 {
-		return node.EndNode
-	}
-
 	if cur >= len(tokens) {
 		return node.EndNode
 	}
@@ -155,9 +151,6 @@ func findExistingPath(node *Node, tokens []token.Token, cur int) bool {
 }
 
 func hasAnySuffix(tokens token.List, suffixes []string) bool {
-	if len(suffixes) == 0 {
-		return false
-	}
 	tokensString := tokens.String()
 
 	for _, suffix := range suffixes {

--- a/internal/path/segment_trie/segment_trie.go
+++ b/internal/path/segment_trie/segment_trie.go
@@ -74,9 +74,6 @@ func (t *SegmentTrie) InsertAndCheckCollisions(tokens []token.Token) error {
 			}
 		}
 
-		if _, ok := node.Children[tok.Literal]; !ok {
-			return errors.New("path collision detected")
-		}
 		node = node.Children[tok.Literal]
 	}
 	return nil

--- a/internal/path/segment_trie/segment_trie_test.go
+++ b/internal/path/segment_trie/segment_trie_test.go
@@ -31,6 +31,14 @@ func TestTableConflictChecking(t *testing.T) {
 			conflictNumber: 1,
 		},
 		{
+			name: "Conflict: exact with exact",
+			paths: []string{
+				"/abc/def/ghi",
+				"/abc/def/ghi",
+			},
+			conflictNumber: 1,
+		},
+		{
 			name: "Conflict: exact with double asterisk",
 			paths: []string{
 				"/abc/def/ghi",

--- a/internal/path/segment_trie/segment_trie_test.go
+++ b/internal/path/segment_trie/segment_trie_test.go
@@ -17,6 +17,12 @@ func TestSegmentTrie(t *testing.T) {
 }
 
 var _ = Describe("SegmentTrie", func() {
+	It("should not panic on a multiple operator path", func() {
+		trie := New()
+		err := trie.InsertAndCheckCollisions(token.TokenizePath("/abc/{**}/def/{**}"))
+		Expect(err).To(BeNil())
+	})
+
 	DescribeTable("Conflict Checking",
 		func(paths []string, conflictNumber int) {
 			trie := New()

--- a/internal/path/segment_trie/segment_trie_test.go
+++ b/internal/path/segment_trie/segment_trie_test.go
@@ -23,6 +23,12 @@ var _ = Describe("SegmentTrie", func() {
 		Expect(err).To(BeNil())
 	})
 
+	It("should return nil for empty path", func() {
+		trie := New()
+		err := trie.InsertAndCheckCollisions([]token.Token{})
+		Expect(err).To(BeNil())
+	})
+
 	DescribeTable("Conflict Checking",
 		func(paths []string, conflictNumber int) {
 			trie := New()
@@ -87,6 +93,22 @@ var _ = Describe("SegmentTrie", func() {
 			"/abc/{**}/def",
 			"/abc/{**}/ghi",
 			"/abc/{**}/foo/bar",
+		}, 0),
+		Entry("Conflict: exact path with single asterisk path", []string{
+			"/abc/{*}",
+			"/abc/def",
+		}, 1),
+		Entry("Conflict: exact path with double asterisk path", []string{
+			"/abc/{**}",
+			"/abc/def",
+		}, 1),
+		Entry("Conflict: double asterisk with a different containing the first one", []string{
+			"/abc/{**}/def",
+			"/abc/def/{**}/def",
+		}, 1),
+		Entry("No conflict: single double asterisk with single path", []string{
+			"/a/{**}/abc",
+			"/a/b/{**}/abc/abcd",
 		}, 0))
 })
 

--- a/internal/path/segment_trie/segment_trie_test.go
+++ b/internal/path/segment_trie/segment_trie_test.go
@@ -39,15 +39,21 @@ var _ = Describe("SegmentTrie", func() {
 		Entry("No conflict: only one double asterisk", []string{
 			"/{**}",
 		}, 0),
+		Entry("No conflict: prefix and double asterisk", []string{
+			"/abc/{**}",
+		}, 0),
 		Entry("Conflict: exact with single asterisk", []string{
 			"/abc/def/ghi",
 			"/abc/{*}/ghi",
 		}, 1),
 		Entry("Conflict: exact with exact", []string{
+			"/abc/def",
 			"/abc/def/ghi",
 			"/abc/def/ghi",
-		}, 1),
+			"/abc/def",
+		}, 2),
 		Entry("Conflict: exact with double asterisk", []string{
+			"/abc/def",
 			"/abc/def/ghi",
 			"/abc/{**}/ghi",
 			"/abc/{**}",
@@ -66,6 +72,7 @@ var _ = Describe("SegmentTrie", func() {
 			"/abc/{**}",
 		}, 2),
 		Entry("No conflict: exact paths", []string{
+			"/abc/def",
 			"/abc/def/ghi",
 			"/abc/def/foo",
 			"/def/ghi",

--- a/internal/path/segment_trie/segment_trie_test.go
+++ b/internal/path/segment_trie/segment_trie_test.go
@@ -1,0 +1,146 @@
+package segment_trie_test
+
+import (
+	"github.com/kyma-project/api-gateway/internal/path/token"
+	"github.com/thoas/go-funk"
+	"strings"
+	"testing"
+
+	. "github.com/kyma-project/api-gateway/internal/path/segment_trie"
+)
+
+func handleError(trie *SegmentTrie, t *testing.T, err error) {
+	if err != nil {
+		t.Logf("Tree: %s", trie.String())
+		t.Errorf("Expected no error, got %s", err)
+	}
+}
+
+func TestTableConflictChecking(t *testing.T) {
+	tt := []struct {
+		name           string
+		paths          []string
+		conflictNumber int
+	}{
+		{
+			name: "Conflict: exact with single asterisk",
+			paths: []string{
+				"/abc/def/ghi",
+				"/abc/{*}/ghi",
+			},
+			conflictNumber: 1,
+		},
+		{
+			name: "Conflict: exact with double asterisk",
+			paths: []string{
+				"/abc/def/ghi",
+				"/abc/{**}/ghi",
+				"/abc/{**}",
+				"/{**}/ghi",
+				"/{**}",
+				"/{**}/def/ghi",
+			},
+			conflictNumber: 5,
+		},
+		{
+			name: "Conflict: double asterisk with single asterisk",
+			paths: []string{
+				"/abc/{**}/ghi",
+				"/abc/{*}/ghi",
+				"/{*}/{*}/ghi",
+			},
+			conflictNumber: 2,
+		},
+		{
+			name: "Conflict: double asterisk with double asterisk",
+			paths: []string{
+				"/abc/{**}/def/ghi",
+				"/abc/{**}/ghi",
+				"/abc/{**}",
+			},
+			conflictNumber: 2,
+		},
+		{
+			name: "No conflict: exact paths",
+			paths: []string{
+				"/abc/def/ghi",
+				"/abc/def/foo",
+				"/def/ghi",
+			},
+			conflictNumber: 0,
+		},
+		{
+			name: "No conflict: paths with single asterisk, but different suffix",
+			paths: []string{
+				"/abc/{*}/def",
+				"/abc/{*}/ghi",
+				"/abc/{*}/foo/bar",
+				"/abc/{*}",
+			},
+			conflictNumber: 0,
+		},
+		{
+			name: "No conflict: paths with double asterisk, but different suffix",
+			paths: []string{
+				"/abc/{**}/def",
+				"/abc/{**}/ghi",
+				"/abc/{**}/foo/bar",
+			},
+			conflictNumber: 0,
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			trie := New()
+			errNumber := 0
+			for _, path := range tc.paths {
+				tokenizedPath := token.TokenizePath(path)
+				err := trie.InsertAndCheckCollisions(tokenizedPath)
+				if err != nil {
+					errNumber++
+				}
+			}
+			if errNumber != tc.conflictNumber {
+				t.Logf("Tree: %s", trie.String())
+				t.Errorf("Expected %d conflicts, got %d", tc.conflictNumber, errNumber)
+			}
+		})
+	}
+}
+
+func BenchmarkSegmentTrieInsertion(b *testing.B) {
+	b.StopTimer()
+	pathNumber := b.N
+
+	paths := make([]string, pathNumber)
+
+	for i := 0; i < pathNumber; i++ {
+		numSegments := funk.RandomInt(1, 10)
+		pathBuilder := strings.Builder{}
+		for j := 0; j < numSegments; j++ {
+			pathBuilder.WriteString("/")
+			if r := funk.RandomInt(0, 6); r == 0 {
+				pathBuilder.WriteString("{**}")
+			} else if r == 1 {
+				pathBuilder.WriteString("{*}")
+			} else {
+				pathBuilder.WriteString(funk.RandomString(1))
+			}
+		}
+		path := pathBuilder.String()
+		paths[i] = path
+	}
+
+	errNr := 0
+	trie := New()
+	b.StartTimer()
+	for i := 0; i < pathNumber; i++ {
+		err := trie.InsertAndCheckCollisions(token.TokenizePath(paths[i]))
+		if err != nil {
+			errNr++
+		}
+	}
+	b.StopTimer()
+	b.Logf("Number of conflicts: %d, Number of paths: %d, Benchmark time: %s", errNr, pathNumber, b.Elapsed().String())
+}

--- a/internal/path/segment_trie/segment_trie_test.go
+++ b/internal/path/segment_trie/segment_trie_test.go
@@ -36,6 +36,9 @@ var _ = Describe("SegmentTrie", func() {
 			}
 			Expect(errNumber).To(Equal(conflictNumber))
 		},
+		Entry("No conflict: only one double asterisk", []string{
+			"/{**}",
+		}, 0),
 		Entry("Conflict: exact with single asterisk", []string{
 			"/abc/def/ghi",
 			"/abc/{*}/ghi",

--- a/internal/path/segment_trie/segment_trie_test.go
+++ b/internal/path/segment_trie/segment_trie_test.go
@@ -9,13 +9,6 @@ import (
 	. "github.com/kyma-project/api-gateway/internal/path/segment_trie"
 )
 
-func handleError(trie *SegmentTrie, t *testing.T, err error) {
-	if err != nil {
-		t.Logf("Tree: %s", trie.String())
-		t.Errorf("Expected no error, got %s", err)
-	}
-}
-
 func TestTableConflictChecking(t *testing.T) {
 	tt := []struct {
 		name           string

--- a/internal/path/token/token.go
+++ b/internal/path/token/token.go
@@ -22,6 +22,10 @@ const (
 	SEPARATOR = "/"
 )
 
+const (
+	EMPTY_LITERAL = ""
+)
+
 type List []Token
 
 func (tk List) String() string {
@@ -40,7 +44,7 @@ func TokenizePath(apiPath string) []Token {
 	for _, tok := range strings.Split(apiPath, SEPARATOR) {
 		switch {
 		case tok == "":
-			tokens = append(tokens, Token{Type: EMPTY, Literal: ""})
+			tokens = append(tokens, Token{Type: EMPTY, Literal: EMPTY_LITERAL})
 		case tok == BRACED_ASTERIX:
 			tokens = append(tokens, Token{Type: BRACED_ASTERIX, Literal: BRACED_ASTERIX})
 		case tok == BRACED_DOUBLE_ASTERIX:

--- a/internal/path/token/token.go
+++ b/internal/path/token/token.go
@@ -12,18 +12,16 @@ type Token struct {
 }
 
 const (
-	IDENT = "IDENT"
-	EMPTY = "EMPTY"
+	Ident = "IDENT"
+	Empty = "EMPTY"
 
-	BRACED_DOUBLE_ASTERIX = "{**}"
-	BRACED_ASTERIX        = "{*}"
-	ASTERISK              = "*"
+	BracedDoubleAsterix = "{**}"
+	BracedAsterix       = "{*}"
+	Asterix             = "*"
 
-	SEPARATOR = "/"
-)
+	Separator = "/"
 
-const (
-	EMPTY_LITERAL = ""
+	EmptyLiteral = ""
 )
 
 type List []Token
@@ -31,7 +29,7 @@ type List []Token
 func (tk List) String() string {
 	var sb strings.Builder
 	for _, t := range tk {
-		sb.WriteString(SEPARATOR)
+		sb.WriteString(Separator)
 		sb.WriteString(t.Literal)
 	}
 	return sb.String()
@@ -39,20 +37,20 @@ func (tk List) String() string {
 
 func TokenizePath(apiPath string) []Token {
 	var tokens []Token
-	apiPath = strings.TrimLeft(apiPath, SEPARATOR)
+	apiPath = strings.TrimLeft(apiPath, Separator)
 
-	for _, tok := range strings.Split(apiPath, SEPARATOR) {
+	for _, tok := range strings.Split(apiPath, Separator) {
 		switch {
 		case tok == "":
-			tokens = append(tokens, Token{Type: EMPTY, Literal: EMPTY_LITERAL})
-		case tok == BRACED_ASTERIX:
-			tokens = append(tokens, Token{Type: BRACED_ASTERIX, Literal: BRACED_ASTERIX})
-		case tok == BRACED_DOUBLE_ASTERIX:
-			tokens = append(tokens, Token{Type: BRACED_DOUBLE_ASTERIX, Literal: BRACED_DOUBLE_ASTERIX})
-		case tok == ASTERISK:
-			tokens = append(tokens, Token{Type: ASTERISK, Literal: ASTERISK})
+			tokens = append(tokens, Token{Type: Empty, Literal: EmptyLiteral})
+		case tok == BracedAsterix:
+			tokens = append(tokens, Token{Type: BracedAsterix, Literal: BracedAsterix})
+		case tok == BracedDoubleAsterix:
+			tokens = append(tokens, Token{Type: BracedDoubleAsterix, Literal: BracedDoubleAsterix})
+		case tok == Asterix:
+			tokens = append(tokens, Token{Type: Asterix, Literal: Asterix})
 		default:
-			tokens = append(tokens, Token{Type: IDENT, Literal: tok})
+			tokens = append(tokens, Token{Type: Ident, Literal: tok})
 		}
 	}
 

--- a/internal/path/token/token.go
+++ b/internal/path/token/token.go
@@ -51,5 +51,6 @@ func TokenizePath(apiPath string) []Token {
 			tokens = append(tokens, Token{Type: IDENT, Literal: tok})
 		}
 	}
+
 	return tokens
 }

--- a/internal/path/token/token.go
+++ b/internal/path/token/token.go
@@ -1,0 +1,55 @@
+package token
+
+import (
+	"strings"
+)
+
+type TokenType string
+
+type Token struct {
+	Type    TokenType
+	Literal string
+}
+
+const (
+	IDENT = "IDENT"
+	EMPTY = "EMPTY"
+
+	BRACED_DOUBLE_ASTERIX = "{**}"
+	BRACED_ASTERIX        = "{*}"
+	ASTERISK              = "*"
+
+	SEPARATOR = "/"
+)
+
+type List []Token
+
+func (tk List) String() string {
+	var sb strings.Builder
+	for _, t := range tk {
+		sb.WriteString(SEPARATOR)
+		sb.WriteString(t.Literal)
+	}
+	return sb.String()
+}
+
+func TokenizePath(apiPath string) []Token {
+	var tokens []Token
+	apiPath = strings.TrimLeft(apiPath, SEPARATOR)
+
+	for _, tok := range strings.Split(apiPath, SEPARATOR) {
+		switch {
+		case tok == "":
+			tokens = append(tokens, Token{Type: EMPTY, Literal: ""})
+		case tok == BRACED_ASTERIX:
+			tokens = append(tokens, Token{Type: BRACED_ASTERIX, Literal: BRACED_ASTERIX})
+		case tok == BRACED_DOUBLE_ASTERIX:
+			tokens = append(tokens, Token{Type: BRACED_DOUBLE_ASTERIX, Literal: BRACED_DOUBLE_ASTERIX})
+		case tok == ASTERISK:
+			tokens = append(tokens, Token{Type: ASTERISK, Literal: ASTERISK})
+		default:
+			tokens = append(tokens, Token{Type: IDENT, Literal: tok})
+		}
+	}
+	return tokens
+}

--- a/internal/path/token/token_test.go
+++ b/internal/path/token/token_test.go
@@ -26,56 +26,56 @@ var _ = Describe("Token", func() {
 		Entry(
 			"ident",
 			"/path",
-			[]Token{{Type: IDENT, Literal: "path"}},
+			[]Token{{Type: Ident, Literal: "path"}},
 		),
 		Entry(
 			"ident / empty",
 			"/path/",
-			[]Token{{Type: IDENT, Literal: "path"}, {Type: EMPTY, Literal: ""}},
+			[]Token{{Type: Ident, Literal: "path"}, {Type: Empty, Literal: ""}},
 		),
 		Entry(
 			"asterisk",
 			"/*",
-			[]Token{{Type: ASTERISK, Literal: "*"}},
+			[]Token{{Type: Asterix, Literal: "*"}},
 		),
 		Entry(
 			"braced double asterisk",
 			"/{**}",
-			[]Token{{Type: BRACED_DOUBLE_ASTERIX, Literal: "{**}"}},
+			[]Token{{Type: BracedDoubleAsterix, Literal: "{**}"}},
 		),
 		Entry(
 			"braced asterisk",
 			"/{*}",
-			[]Token{{Type: BRACED_ASTERIX, Literal: "{*}"}},
+			[]Token{{Type: BracedAsterix, Literal: "{*}"}},
 		),
 		Entry(
 			"ident / braced double asterisk",
 			"/path/{**}",
-			[]Token{{Type: IDENT, Literal: "path"}, {Type: BRACED_DOUBLE_ASTERIX, Literal: "{**}"}},
+			[]Token{{Type: Ident, Literal: "path"}, {Type: BracedDoubleAsterix, Literal: "{**}"}},
 		),
 		Entry(
 			"ident / braced asterisk",
 			"/path/{*}",
-			[]Token{{Type: IDENT, Literal: "path"}, {Type: BRACED_ASTERIX, Literal: "{*}"}},
+			[]Token{{Type: Ident, Literal: "path"}, {Type: BracedAsterix, Literal: "{*}"}},
 		),
 		Entry(
 			"ident / braced double asterisk / ident",
 			"/path/{**}/path2",
-			[]Token{{Type: IDENT, Literal: "path"}, {Type: BRACED_DOUBLE_ASTERIX, Literal: "{**}"}, {Type: IDENT, Literal: "path2"}},
+			[]Token{{Type: Ident, Literal: "path"}, {Type: BracedDoubleAsterix, Literal: "{**}"}, {Type: Ident, Literal: "path2"}},
 		),
 		Entry(
 			"ident / braced asterisk / ident",
 			"/path/{*}/path2",
-			[]Token{{Type: IDENT, Literal: "path"}, {Type: BRACED_ASTERIX, Literal: "{*}"}, {Type: IDENT, Literal: "path2"}},
+			[]Token{{Type: Ident, Literal: "path"}, {Type: BracedAsterix, Literal: "{*}"}, {Type: Ident, Literal: "path2"}},
 		),
 	)
 
 	Describe("TokenListString", func() {
 		It("should convert token list to string", func() {
 			tokens := List{
-				{Type: IDENT, Literal: "path"},
-				{Type: BRACED_DOUBLE_ASTERIX, Literal: "{**}"},
-				{Type: IDENT, Literal: "path2"},
+				{Type: Ident, Literal: "path"},
+				{Type: BracedDoubleAsterix, Literal: "{**}"},
+				{Type: Ident, Literal: "path2"},
 			}
 			expected := "/path/{**}/path2"
 			Expect(tokens.String()).To(Equal(expected))

--- a/internal/path/token/token_test.go
+++ b/internal/path/token/token_test.go
@@ -2,114 +2,83 @@ package token_test
 
 import (
 	. "github.com/kyma-project/api-gateway/internal/path/token"
-
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"testing"
 )
 
-func TestTableParsePath(t *testing.T) {
-	tests := []struct {
-		name   string
-		path   string
-		tokens []Token
-	}{
-		{
-			name: "ident",
-			path: "/path",
-			tokens: []Token{
-				{Type: IDENT, Literal: "path"},
-			},
-		},
-		{
-			name: "ident / empty",
-			path: "/path/",
-			tokens: []Token{
-				{Type: IDENT, Literal: "path"},
-				{Type: EMPTY, Literal: ""},
-			},
-		},
-		{
-			name: "asterisk",
-			path: "/*",
-			tokens: []Token{
-				{Type: ASTERISK, Literal: "*"},
-			},
-		},
-		{
-			name: "braced double asterisk",
-			path: "/{**}",
-			tokens: []Token{
-				{Type: BRACED_DOUBLE_ASTERIX, Literal: "{**}"},
-			},
-		},
-		{
-			name: "braced asterisk",
-			path: "/{*}",
-			tokens: []Token{
-				{Type: BRACED_ASTERIX, Literal: "{*}"},
-			},
-		},
-		{
-			name: "ident / braced double asterisk",
-			path: "/path/{**}",
-			tokens: []Token{
-				{Type: IDENT, Literal: "path"},
-				{Type: BRACED_DOUBLE_ASTERIX, Literal: "{**}"},
-			},
-		},
-		{
-			name: "ident / braced asterisk",
-			path: "/path/{*}",
-			tokens: []Token{
-				{Type: IDENT, Literal: "path"},
-				{Type: BRACED_ASTERIX, Literal: "{*}"},
-			},
-		},
-		{
-			name: "ident / braced double asterisk / ident",
-			path: "/path/{**}/path2",
-			tokens: []Token{
-				{Type: IDENT, Literal: "path"},
-				{Type: BRACED_DOUBLE_ASTERIX, Literal: "{**}"},
-				{Type: IDENT, Literal: "path2"},
-			},
-		},
-		{
-			name: "ident / braced asterisk / ident",
-			path: "/path/{*}/path2",
-			tokens: []Token{
-				{Type: IDENT, Literal: "path"},
-				{Type: BRACED_ASTERIX, Literal: "{*}"},
-				{Type: IDENT, Literal: "path2"},
-			},
-		},
-	}
+func TestToken(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Token Suite")
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			tokens := TokenizePath(tt.path)
-			if len(tokens) != len(tt.tokens) {
-				t.Fatalf("expected %d tokens, got %d", len(tt.tokens), len(tokens))
-			}
+var _ = Describe("Token", func() {
+	DescribeTable("ParsePath",
+		func(path string, expectedTokens []Token) {
+			tokens := TokenizePath(path)
+			Expect(tokens).To(HaveLen(len(expectedTokens)))
 			for i, tok := range tokens {
-				if tok.Type != tt.tokens[i].Type {
-					t.Fatalf("expected token type %s, got %s", tt.tokens[i].Type, tok.Type)
-				}
-				if tok.Literal != tt.tokens[i].Literal {
-					t.Fatalf("expected token literal %s, got %s", tt.tokens[i].Literal, tok.Literal)
-				}
+				Expect(tok.Type).To(Equal(expectedTokens[i].Type))
+				Expect(tok.Literal).To(Equal(expectedTokens[i].Literal))
 			}
-		})
-	}
-}
+		},
 
-func TestTokenListString(t *testing.T) {
-	tokens := List{
-		{Type: IDENT, Literal: "path"},
-		{Type: BRACED_DOUBLE_ASTERIX, Literal: "{**}"},
-		{Type: IDENT, Literal: "path2"},
-	}
-	expected := "/path/{**}/path2"
-	if tokens.String() != expected {
-		t.Fatalf("expected %s, got %s", expected, tokens.String())
-	}
-}
+		Entry(
+			"ident",
+			"/path",
+			[]Token{{Type: IDENT, Literal: "path"}},
+		),
+		Entry(
+			"ident / empty",
+			"/path/",
+			[]Token{{Type: IDENT, Literal: "path"}, {Type: EMPTY, Literal: ""}},
+		),
+		Entry(
+			"asterisk",
+			"/*",
+			[]Token{{Type: ASTERISK, Literal: "*"}},
+		),
+		Entry(
+			"braced double asterisk",
+			"/{**}",
+			[]Token{{Type: BRACED_DOUBLE_ASTERIX, Literal: "{**}"}},
+		),
+		Entry(
+			"braced asterisk",
+			"/{*}",
+			[]Token{{Type: BRACED_ASTERIX, Literal: "{*}"}},
+		),
+		Entry(
+			"ident / braced double asterisk",
+			"/path/{**}",
+			[]Token{{Type: IDENT, Literal: "path"}, {Type: BRACED_DOUBLE_ASTERIX, Literal: "{**}"}},
+		),
+		Entry(
+			"ident / braced asterisk",
+			"/path/{*}",
+			[]Token{{Type: IDENT, Literal: "path"}, {Type: BRACED_ASTERIX, Literal: "{*}"}},
+		),
+		Entry(
+			"ident / braced double asterisk / ident",
+			"/path/{**}/path2",
+			[]Token{{Type: IDENT, Literal: "path"}, {Type: BRACED_DOUBLE_ASTERIX, Literal: "{**}"}, {Type: IDENT, Literal: "path2"}},
+		),
+		Entry(
+			"ident / braced asterisk / ident",
+			"/path/{*}/path2",
+			[]Token{{Type: IDENT, Literal: "path"}, {Type: BRACED_ASTERIX, Literal: "{*}"}, {Type: IDENT, Literal: "path2"}},
+		),
+	)
+
+	Describe("TokenListString", func() {
+		It("should convert token list to string", func() {
+			tokens := List{
+				{Type: IDENT, Literal: "path"},
+				{Type: BRACED_DOUBLE_ASTERIX, Literal: "{**}"},
+				{Type: IDENT, Literal: "path2"},
+			}
+			expected := "/path/{**}/path2"
+			Expect(tokens.String()).To(Equal(expected))
+		})
+	})
+})

--- a/internal/path/token/token_test.go
+++ b/internal/path/token/token_test.go
@@ -1,0 +1,115 @@
+package token_test
+
+import (
+	. "github.com/kyma-project/api-gateway/internal/path/token"
+
+	"testing"
+)
+
+func TestTableParsePath(t *testing.T) {
+	tests := []struct {
+		name   string
+		path   string
+		tokens []Token
+	}{
+		{
+			name: "ident",
+			path: "/path",
+			tokens: []Token{
+				{Type: IDENT, Literal: "path"},
+			},
+		},
+		{
+			name: "ident / empty",
+			path: "/path/",
+			tokens: []Token{
+				{Type: IDENT, Literal: "path"},
+				{Type: EMPTY, Literal: ""},
+			},
+		},
+		{
+			name: "asterisk",
+			path: "/*",
+			tokens: []Token{
+				{Type: ASTERISK, Literal: "*"},
+			},
+		},
+		{
+			name: "braced double asterisk",
+			path: "/{**}",
+			tokens: []Token{
+				{Type: BRACED_DOUBLE_ASTERIX, Literal: "{**}"},
+			},
+		},
+		{
+			name: "braced asterisk",
+			path: "/{*}",
+			tokens: []Token{
+				{Type: BRACED_ASTERIX, Literal: "{*}"},
+			},
+		},
+		{
+			name: "ident / braced double asterisk",
+			path: "/path/{**}",
+			tokens: []Token{
+				{Type: IDENT, Literal: "path"},
+				{Type: BRACED_DOUBLE_ASTERIX, Literal: "{**}"},
+			},
+		},
+		{
+			name: "ident / braced asterisk",
+			path: "/path/{*}",
+			tokens: []Token{
+				{Type: IDENT, Literal: "path"},
+				{Type: BRACED_ASTERIX, Literal: "{*}"},
+			},
+		},
+		{
+			name: "ident / braced double asterisk / ident",
+			path: "/path/{**}/path2",
+			tokens: []Token{
+				{Type: IDENT, Literal: "path"},
+				{Type: BRACED_DOUBLE_ASTERIX, Literal: "{**}"},
+				{Type: IDENT, Literal: "path2"},
+			},
+		},
+		{
+			name: "ident / braced asterisk / ident",
+			path: "/path/{*}/path2",
+			tokens: []Token{
+				{Type: IDENT, Literal: "path"},
+				{Type: BRACED_ASTERIX, Literal: "{*}"},
+				{Type: IDENT, Literal: "path2"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tokens := TokenizePath(tt.path)
+			if len(tokens) != len(tt.tokens) {
+				t.Fatalf("expected %d tokens, got %d", len(tt.tokens), len(tokens))
+			}
+			for i, tok := range tokens {
+				if tok.Type != tt.tokens[i].Type {
+					t.Fatalf("expected token type %s, got %s", tt.tokens[i].Type, tok.Type)
+				}
+				if tok.Literal != tt.tokens[i].Literal {
+					t.Fatalf("expected token literal %s, got %s", tt.tokens[i].Literal, tok.Literal)
+				}
+			}
+		})
+	}
+}
+
+func TestTokenListString(t *testing.T) {
+	tokens := List{
+		{Type: IDENT, Literal: "path"},
+		{Type: BRACED_DOUBLE_ASTERIX, Literal: "{**}"},
+		{Type: IDENT, Literal: "path2"},
+	}
+	expected := "/path/{**}/path2"
+	if tokens.String() != expected {
+		t.Fatalf("expected %s, got %s", expected, tokens.String())
+	}
+}

--- a/internal/validation/v2alpha1/rules.go
+++ b/internal/validation/v2alpha1/rules.go
@@ -21,10 +21,6 @@ func validateRules(ctx context.Context, client client.Client, parentAttributePat
 		return problems
 	}
 
-	if path, method, conflict := hasPathByMethodConflict(rules); conflict {
-		problems = append(problems, validation.Failure{AttributePath: rulesAttributePath, Message: fmt.Sprintf("Path %s with method %s conflicts with at least one of the other defined paths", path, method)})
-	}
-
 	for i, rule := range rules {
 		ruleAttributePath := fmt.Sprintf("%s[%d]", rulesAttributePath, i)
 
@@ -52,6 +48,10 @@ func validateRules(ctx context.Context, client client.Client, parentAttributePat
 		}
 
 		problems = append(problems, validatePath(ruleAttributePath, rule.Path)...)
+	}
+
+	if path, method, conflict := hasPathByMethodConflict(rules); conflict {
+		problems = append(problems, validation.Failure{AttributePath: rulesAttributePath, Message: fmt.Sprintf("Path %s with method %s conflicts with at least one of the other defined paths", path, method)})
 	}
 
 	jwtAuthFailures := validateJwtAuthenticationEquality(rulesAttributePath, rules)

--- a/internal/validation/v2alpha1/rules.go
+++ b/internal/validation/v2alpha1/rules.go
@@ -51,7 +51,15 @@ func validateRules(ctx context.Context, client client.Client, parentAttributePat
 	}
 
 	if path, method, conflict := hasPathByMethodConflict(rules); conflict {
-		problems = append(problems, validation.Failure{AttributePath: rulesAttributePath, Message: fmt.Sprintf("Path %s with method %s conflicts with at least one of the other defined paths", path, method)})
+		problems = append(problems,
+			validation.Failure{
+				AttributePath: rulesAttributePath,
+				Message: fmt.Sprintf(
+					"Path %s with method %s conflicts with at least one of the other defined paths",
+					path,
+					method),
+			},
+		)
 	}
 
 	jwtAuthFailures := validateJwtAuthenticationEquality(rulesAttributePath, rules)

--- a/internal/validation/v2alpha1/rules.go
+++ b/internal/validation/v2alpha1/rules.go
@@ -102,6 +102,10 @@ func validateEnvoyTemplate(validationPath string, path string) []validation.Fail
 func hasPathByMethodConflict(rules []gatewayv2alpha1.Rule) (path string, method gatewayv2alpha1.HttpMethod, conflict bool) {
 	rulesByMethod := map[gatewayv2alpha1.HttpMethod][]gatewayv2alpha1.Rule{}
 	for _, rule := range rules {
+		if len(rule.Methods) == 0 {
+			rulesByMethod["NO_METHODS"] = append(rulesByMethod["NO_METHODS"], rule)
+		}
+
 		for _, method := range rule.Methods {
 			rulesByMethod[method] = append(rulesByMethod[method], rule)
 		}

--- a/internal/validation/v2alpha1/rules.go
+++ b/internal/validation/v2alpha1/rules.go
@@ -120,7 +120,6 @@ func hasPathByMethodConflict(rules []gatewayv2alpha1.Rule) (path string, method 
 				return rule.Path, m, true
 			}
 		}
-		println(trie.String())
 	}
 
 	return "", "", false

--- a/internal/validation/v2alpha1/rules_test.go
+++ b/internal/validation/v2alpha1/rules_test.go
@@ -115,6 +115,11 @@ var _ = Describe("Validate rules", func() {
 						Methods: []v2alpha1.HttpMethod{http.MethodGet},
 					},
 					{
+						Path:    "/abc/def",
+						NoAuth:  ptr.To(true),
+						Methods: []v2alpha1.HttpMethod{http.MethodGet},
+					},
+					{
 						Path:    "/abc",
 						NoAuth:  ptr.To(true),
 						Methods: []v2alpha1.HttpMethod{http.MethodGet, http.MethodPost},

--- a/internal/validation/v2alpha1/rules_test.go
+++ b/internal/validation/v2alpha1/rules_test.go
@@ -132,7 +132,7 @@ var _ = Describe("Validate rules", func() {
 		//then
 		Expect(problems).To(HaveLen(1))
 		Expect(problems[0].AttributePath).To(Equal(".spec.rules"))
-		Expect(problems[0].Message).To(Equal("multiple rules defined for the same path and method"))
+		Expect(problems[0].Message).To(Equal("Path /abc with method GET conflicts with at least one of the other defined paths"))
 	})
 
 	DescribeTable("should fail for invalid path", func(path string, shouldFail bool, expectedMessage string) {


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

I implemented the conflict validation based on the Trie data structure.

It does two things that are not done by a regular trie:
   - Nodes that are pointed to by `{**}` don't store their children, instead they store the path suffix that exists after `{**}`. Conflicts are checked by comparing the suffixes of paths with the same segments that precede `{**}`. This can be done, since the `{**}` operator must be the last in the path.
   - `{*}` nodes are stored just like any other exact segment node, but are always included in conflict search.
---
Changes proposed in this pull request:

- Add conflict validation to envoy template paths

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
