### PR TITLE
bug: add GITHUB_TOKEN as env variable to actions

### DIFF
--- a/.github/actions/integration-tests/action.yaml
+++ b/.github/actions/integration-tests/action.yaml
@@ -39,6 +39,7 @@ runs:
         CLIENT_ID: ${{ inputs.client_id }}
         CLIENT_SECRET: ${{ inputs.client_secret }}
         OIDC_CONFIG_URL: ${{ inputs.oidc_well_known_url }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         IMG: ${{ inputs.manager_image }}
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then

--- a/.github/actions/k8s-compatibility-test/action.yaml
+++ b/.github/actions/k8s-compatibility-test/action.yaml
@@ -40,6 +40,7 @@ runs:
         CLIENT_SECRET: ${{ inputs.client_secret }}
         OIDC_CONFIG_URL: ${{ inputs.oidc_well_known_url }}
         IMG: ${{ inputs.manager_image }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         if [ "${{ github.event_name }}" == "pull_request" ]; then
           k3d image import ${{ inputs.manager_image }} -c k3s-default

--- a/.github/workflows/pull-unit-lint.yaml
+++ b/.github/workflows/pull-unit-lint.yaml
@@ -60,6 +60,8 @@ jobs:
         with:
           go-version-file: 'go.mod'
       - name: Run tests
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           PULL_PULL_SHA=${{ github.event.pull_request.head.sha}} \
           PULL_BASE_SHA=${{ github.event.pull_request.base.sha}} \


### PR DESCRIPTION
/kind bug
/area ci

Add exported `GITHUB_TOKEN` variable to use by install_kustomize.sh script. The script checks if variable is exported, and if it is, authenticates.

See https://github.com/kubernetes-sigs/kustomize/blob/bb7a28070905adae77c6f82b912a862de2b3a052/hack/install_kustomize.sh#L137
