### PR TITLE
chore: separate main and release images

### DIFF
--- a/.github/workflows/create-release.yaml
+++ b/.github/workflows/create-release.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Check security-scanner config
         shell: bash
         run: |
-          if [[ $( yq eval ".protecode[0]" sec-scanners-config.yaml ) == "europe-docker.pkg.dev/kyma-project/prod/api-gateway-manager:${{ github.event.inputs.name }}" ]]; then
+          if [[ $( yq eval ".protecode[0]" sec-scanners-config.yaml ) == "europe-docker.pkg.dev/kyma-project/prod/api-gateway/releases/api-gateway-manager:${{ github.event.inputs.name }}" ]]; then
             exit 0
           else
             echo "Error: api-gateway-manager image tag in sec-scanners-config doesn't match release ${{ github.event.inputs.name }}"
@@ -43,7 +43,7 @@ jobs:
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     needs: [check-prerequisites]
     with:
-      name: api-gateway-manager
+      name: api-gateway/releases/api-gateway-manager
       dockerfile: Dockerfile
       context: .
       build-args: |

--- a/.github/workflows/main-integration.yaml
+++ b/.github/workflows/main-integration.yaml
@@ -24,7 +24,7 @@ jobs:
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     if: ${{ github.event_name != 'schedule' }}
     with:
-      name: api-gateway-manager
+      name: api-gateway/main/api-gateway-manager
       dockerfile: Dockerfile
       context: .
       build-args: |
@@ -60,7 +60,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          manager_image: "europe-docker.pkg.dev/kyma-project/prod/api-gateway-manager:${{ needs.get-sha.outputs.sha }}"
+          manager_image: "europe-docker.pkg.dev/kyma-project/prod/api-gateway/main/api-gateway-manager:${{ needs.get-sha.outputs.sha }}"
           client_id: ${{ secrets.CLIENT_ID }}
           client_secret: ${{ secrets.CLIENT_SECRET }}
           oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
@@ -83,7 +83,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          manager_image: "europe-docker.pkg.dev/kyma-project/prod/api-gateway-manager:${{ needs.get-sha.outputs.sha }}"
+          manager_image: "europe-docker.pkg.dev/kyma-project/prod/api-gateway/main/api-gateway-manager:${{ needs.get-sha.outputs.sha }}"
           test_make_target: ${{ matrix.test_make_target }}
 
   upgrade-tests:
@@ -100,7 +100,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          manager_image: "europe-docker.pkg.dev/kyma-project/prod/api-gateway-manager:${{ needs.get-sha.outputs.sha }}"
+          manager_image: "europe-docker.pkg.dev/kyma-project/prod/api-gateway/main/api-gateway-manager:${{ needs.get-sha.outputs.sha }}"
           client_id: ${{ secrets.CLIENT_ID }}
           client_secret: ${{ secrets.CLIENT_SECRET }}
           oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
@@ -121,7 +121,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          manager_image: "europe-docker.pkg.dev/kyma-project/prod/api-gateway-manager:${{ needs.get-sha.outputs.sha }}"
+          manager_image: "europe-docker.pkg.dev/kyma-project/prod/api-gateway/main/api-gateway-manager:${{ needs.get-sha.outputs.sha }}"
           gardener_secret: ${{ secrets.GARDENER_TOKEN }}
           script: ./hack/ci/custom-domain-gardener-gcp.sh
           client_id: ${{ secrets.CLIENT_ID }}
@@ -144,7 +144,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          manager_image: "europe-docker.pkg.dev/kyma-project/prod/api-gateway-manager:${{ needs.get-sha.outputs.sha }}"
+          manager_image: "europe-docker.pkg.dev/kyma-project/prod/api-gateway/main/api-gateway-manager:${{ needs.get-sha.outputs.sha }}"
           gardener_secret: ${{ secrets.GARDENER_TOKEN }}
           script: ./hack/ci/custom-domain-gardener-aws.sh
           client_id: ${{ secrets.CLIENT_ID }}

--- a/.github/workflows/pull-integration-release.yaml
+++ b/.github/workflows/pull-integration-release.yaml
@@ -23,7 +23,7 @@ jobs:
           client_id: ${{ secrets.CLIENT_ID }}
           client_secret: ${{ secrets.CLIENT_SECRET }}
           oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-          manager_image: "europe-docker.pkg.dev/kyma-project/dev/api-gateway-manager:PR-${{github.event.number}}"
+          manager_image: "europe-docker.pkg.dev/kyma-project/dev/api-gateway/pr/api-gateway-manager:PR-${{github.event.number}}"
           test_make_target: ${{ matrix.test_make_target }}
 
   migration-downtime-tests:
@@ -42,7 +42,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          manager_image: "europe-docker.pkg.dev/kyma-project/dev/api-gateway-manager:PR-${{github.event.number}}"
+          manager_image: "europe-docker.pkg.dev/kyma-project/dev/api-gateway/pr/api-gateway-manager:PR-${{github.event.number}}"
           test_make_target: ${{ matrix.test_make_target }}
 
   k8s-compatibility-check:
@@ -64,7 +64,7 @@ jobs:
           client_id: ${{ secrets.CLIENT_ID }}
           client_secret: ${{ secrets.CLIENT_SECRET }}
           oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-          manager_image: "europe-docker.pkg.dev/kyma-project/dev/api-gateway-manager:PR-${{github.event.number}}"
+          manager_image: "europe-docker.pkg.dev/kyma-project/dev/api-gateway/pr/api-gateway-manager:PR-${{github.event.number}}"
           test_make_target: ${{ matrix.test_make_target }}
 
   upgrade-tests:
@@ -79,7 +79,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          manager_image: "europe-docker.pkg.dev/kyma-project/dev/api-gateway-manager:PR-${{github.event.number}}"
+          manager_image: "europe-docker.pkg.dev/kyma-project/dev/api-gateway/pr/api-gateway-manager:PR-${{github.event.number}}"
           client_id: ${{ secrets.CLIENT_ID }}
           client_secret: ${{ secrets.CLIENT_SECRET }}
           oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
@@ -101,7 +101,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          manager_image: "europe-docker.pkg.dev/kyma-project/dev/api-gateway-manager:PR-${{github.event.number}}"
+          manager_image: "europe-docker.pkg.dev/kyma-project/dev/api-gateway/pr/api-gateway-manager:PR-${{github.event.number}}"
           gardener_secret: ${{ secrets.GARDENER_TOKEN }}
           script: ./hack/ci/custom-domain-gardener-gcp.sh
           client_id: ${{ secrets.CLIENT_ID }}
@@ -126,7 +126,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          manager_image: "europe-docker.pkg.dev/kyma-project/dev/api-gateway-manager:PR-${{github.event.number}}"
+          manager_image: "europe-docker.pkg.dev/kyma-project/dev/api-gateway/pr/api-gateway-manager:PR-${{github.event.number}}"
           gardener_secret: ${{ secrets.GARDENER_TOKEN }}
           script: ./hack/ci/custom-domain-gardener-aws.sh
           client_id: ${{ secrets.CLIENT_ID }}

--- a/.github/workflows/pull-request-release.yaml
+++ b/.github/workflows/pull-request-release.yaml
@@ -12,7 +12,7 @@ jobs:
     if: github.event.pull_request.draft == false
     uses: kyma-project/test-infra/.github/workflows/image-builder.yml@main
     with:
-      name: api-gateway-manager
+      name: api-gateway/pr/api-gateway-manager
       dockerfile: Dockerfile
       context: .
       build-args: |

--- a/.github/workflows/ui-tests-periodic.yaml
+++ b/.github/workflows/ui-tests-periodic.yaml
@@ -32,8 +32,8 @@ jobs:
         run: |
           sudo echo "127.0.0.1 local.kyma.dev" | sudo tee -a /etc/hosts
           wget -q -O - https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | sudo bash
-          docker pull europe-docker.pkg.dev/kyma-project/prod/api-gateway-manager:"${{ needs.get-sha.outputs.sha }}"
-          IMG=europe-docker.pkg.dev/kyma-project/prod/api-gateway-manager:"${{ needs.get-sha.outputs.sha }}" ./tests/ui/tests/scripts/k3d-ci-kyma-dashboard-integration.sh stage
+          docker pull europe-docker.pkg.dev/kyma-project/prod/api-gateway/main/api-gateway-manager:"${{ needs.get-sha.outputs.sha }}"
+          IMG=europe-docker.pkg.dev/kyma-project/prod/api-gateway/main/api-gateway-manager:"${{ needs.get-sha.outputs.sha }}" ./tests/ui/tests/scripts/k3d-ci-kyma-dashboard-integration.sh stage
       - uses: actions/upload-artifact@v4
         if: always()
         name: Export Cypress output

--- a/scripts/publish_assets.sh
+++ b/scripts/publish_assets.sh
@@ -10,7 +10,7 @@ set -x
 RELEASE_TAG=$1
 RELEASE_ID=$2
 
-IMG="europe-docker.pkg.dev/kyma-project/prod/api-gateway-manager:${RELEASE_TAG}" VERSION=$RELEASE_TAG make generate-manifests
+IMG="europe-docker.pkg.dev/kyma-project/prod/api-gateway/releases/api-gateway-manager:${RELEASE_TAG}" VERSION=$RELEASE_TAG make generate-manifests
 
 REPOSITORY=${REPOSITORY:-kyma-project/api-gateway}
 GITHUB_URL=https://uploads.github.com/repos/${REPOSITORY}


### PR DESCRIPTION
/kind chore
/area ci

Separate images that we run on main/releases/pr in order to keep better isolation between the artifacts to allow introducing registry automations.

#1234 