### PR TITLE
bug: add export of image-builder built artifact

### DIFF
--- a/.github/workflows/pull-request-release.yaml
+++ b/.github/workflows/pull-request-release.yaml
@@ -25,10 +25,10 @@ jobs:
       - id: save
         run: |
           # taking only first image is enough, because 'images' point to single image with multiple tags
-          img="$(echo ${{ needs.build-image.outputs.images }} | jq -r '.[0]')"
+          src="$(echo '${{ needs.build-image.outputs.images }}' | jq -r '.[0]')"
           dest="api-gateway-manager:PR-${{ github.event.number }}"
-          docker pull "$img"
-          docker tag "$img" "$dest"
+          docker pull "$src"
+          docker tag "$src" "$dest"
           docker save "$dest" > /tmp/manager-image.tar
       - id: upload
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
/kind bug
/area ci

ui-tests were broken since the beginning in pull-request-release flow, because image-builder didn't export the built artifact as tar. UI tests load the image from the uploaded artifact.

Basically, after build, pull, re-tag and save the image to use it as artifact in UI tests. Kind of emulate what docker build action is doing.