### PR TITLE
Add pod antiaffinity to oathkeeper pods (HA/multi-az support)

### DIFF
--- a/docs/contributor/04-10-technical-design.md
+++ b/docs/contributor/04-10-technical-design.md
@@ -3,6 +3,8 @@
 API Gateway Operator consists of two controllers that reconcile different CRs. To understand the reasons for using a single operator with multiple controllers instead of multiple operators, refer to the [Architecture Decision Record](https://github.com/kyma-project/api-gateway/issues/495).
 API Gateway Operator has a dependency on [Istio](https://istio.io/) and [Ory Oathkeeper](https://www.ory.sh/docs/oathkeeper), and it installs Ory Oathkeeper itself.
 
+Oathkeeper Deployment configures **PodAntiAffinity** to ensure that its Pods are evenly spread across all nodes and, if possible, across different zones. This guarantees High availability (HA) of the [Ory Oathkeeper](https://www.ory.sh/docs/oathkeeper) installation.
+
 The following diagram illustrates the APIRule reconciliation process and the resources created in the process:
 
 ![Kyma API Gateway Overview](../assets/operator-contributor-skr-overview.svg)

--- a/docs/release-notes/2.11.0.md
+++ b/docs/release-notes/2.11.0.md
@@ -1,0 +1,3 @@
+## New Features
+
+- Add zone-based `podAntiAffinity` rules for the `ory-oathkeeper` Deployment. [#1463](https://github.com/kyma-project/api-gateway/pull/1463)

--- a/internal/reconciliations/oathkeeper/deployment.yaml
+++ b/internal/reconciliations/oathkeeper/deployment.yaml
@@ -29,6 +29,27 @@ spec:
       annotations:
         readiness.status.sidecar.istio.io/initialDelaySeconds: "10"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - oathkeeper
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                    - oathkeeper
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
         - command:
             - oathkeeper

--- a/internal/reconciliations/oathkeeper/deployment.yaml
+++ b/internal/reconciliations/oathkeeper/deployment.yaml
@@ -29,27 +29,6 @@ spec:
       annotations:
         readiness.status.sidecar.istio.io/initialDelaySeconds: "10"
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - oathkeeper
-              topologyKey: kubernetes.io/hostname
-            weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                  - key: app.kubernetes.io/name
-                    operator: In
-                    values:
-                    - oathkeeper
-              topologyKey: topology.kubernetes.io/zone
-            weight: 100
       containers:
         - command:
             - oathkeeper
@@ -200,12 +179,18 @@ spec:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
+            - podAffinityTerm:
                 labelSelector:
                   matchLabels:
-                    app: oathkeeper
+                    app.kubernetes.io/name: oathkeeper
                 topologyKey: "kubernetes.io/hostname"
+              weight: 100
+            - podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app.kubernetes.io/name: oathkeeper
+                topologyKey: topology.kubernetes.io/zone
+              weight: 100
       volumes:
         - configMap:
             name: ory-oathkeeper-config

--- a/internal/reconciliations/oathkeeper/deployment_light.yaml
+++ b/internal/reconciliations/oathkeeper/deployment_light.yaml
@@ -29,27 +29,6 @@ spec:
       annotations:
         readiness.status.sidecar.istio.io/initialDelaySeconds: "10"
     spec:
-      affinity:
-        podAntiAffinity:
-          preferredDuringSchedulingIgnoredDuringExecution:
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                - key: app.kubernetes.io/name
-                  operator: In
-                  values:
-                  - oathkeeper
-              topologyKey: kubernetes.io/hostname
-            weight: 100
-          - podAffinityTerm:
-              labelSelector:
-                matchExpressions:
-                  - key: app.kubernetes.io/name
-                    operator: In
-                    values:
-                    - oathkeeper
-              topologyKey: topology.kubernetes.io/zone
-            weight: 100
       containers:
         - command:
             - oathkeeper

--- a/internal/reconciliations/oathkeeper/deployment_light.yaml
+++ b/internal/reconciliations/oathkeeper/deployment_light.yaml
@@ -29,6 +29,27 @@ spec:
       annotations:
         readiness.status.sidecar.istio.io/initialDelaySeconds: "10"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/name
+                  operator: In
+                  values:
+                  - oathkeeper
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                  - key: app.kubernetes.io/name
+                    operator: In
+                    values:
+                    - oathkeeper
+              topologyKey: topology.kubernetes.io/zone
+            weight: 100
       containers:
         - command:
             - oathkeeper


### PR DESCRIPTION

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Add pod antiaffinity to oathkeeper pods , schedule on different nodes and zones (HA/multi-az support)

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
https://github.com/kyma-project/api-gateway/issues/1171