### PR TITLE
Fixed support for using oauth2-mock in custom domain tests

### DIFF
--- a/tests/integration/env_vars_custom_domain.sh
+++ b/tests/integration/env_vars_custom_domain.sh
@@ -17,19 +17,16 @@ if [[ -z ${TEST_SA_ACCESS_KEY_PATH} ]]; then
   exit 2
 fi
 
-if [[ -z ${OIDC_CONFIG_URL} ]]; then
-  >&2 echo "Environment variable OIDC_CONFIG_URL is required but not set"
-  exit 2
-fi
+if [[ -n ${OIDC_CONFIG_URL} ]]; then
+  if [[ -z ${CLIENT_ID} ]]; then
+    >&2 echo "Environment variable CLIENT_ID is required when OIDC_CONFIG_URL is set"
+    exit 2
+  fi
 
-if [[ -z ${CLIENT_ID} ]]; then
-  >&2 echo "Environment variable CLIENT_ID is required but not set"
-  exit 2
-fi
-
-if [[ -z ${CLIENT_SECRET} ]]; then
-  >&2 echo "Environment variable CLIENT_SECRET is required but not set"
-  exit 2
+  if [[ -z ${CLIENT_SECRET} ]]; then
+    >&2 echo "Environment variable CLIENT_SECRET is required when OIDC_CONFIG_URL is set"
+    exit 2
+  fi
 fi
 
 export TEST_OIDC_CONFIG_URL="${OIDC_CONFIG_URL}"

--- a/tests/integration/testsuites/custom-domain/manifests/oauth-strategy.yaml
+++ b/tests/integration/testsuites/custom-domain/manifests/oauth-strategy.yaml
@@ -15,7 +15,6 @@ spec:
       accessStrategies:
         - handler: oauth2_introspection
           config:
-            required_scope: ["read"]
             introspection_url: "{{ .IssuerUrl }}/oauth2/introspect"
             token_from:
               header: "opaque-token"


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fixed support for using oauth2-mock in custom domain tests
  - oauth2 mock is deployed after test namespace is created
  - removed scope from apirule configuration (so the scope is not required when requesting the token, which is more compatible with external OIDC)
  - adapted validation in env_vars_custom_domain script, to it is possible to run custom domain scripts via make (without OIDC)

**Pre-Merge Checklist**

- [x] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
