### PR TITLE
Add forced restart of Oathkeeper 

### DIFF
--- a/internal/reconciliations/oathkeeper/oathkeeper.go
+++ b/internal/reconciliations/oathkeeper/oathkeeper.go
@@ -39,8 +39,13 @@ func (r Reconciler) ReconcileAndVerifyReadiness(ctx context.Context, k8sClient c
 	}
 
 	if !apiGatewayCR.IsInDeletion() {
+		err := restartOathkeeper(ctx, k8sClient)
+		if err != nil {
+			return controllers.ErrorStatus(err, "Failed to restart Oathkeeper", conditions.OathkeeperReconcileFailed.Condition())
+		}
+
 		ctrl.Log.Info("Waiting for Oathkeeper Deployment to become ready")
-		err := waitForOathkeeperDeploymentToBeReady(ctx, k8sClient, r.ReadinessRetryConfig)
+		err = waitForOathkeeperDeploymentToBeReady(ctx, k8sClient, r.ReadinessRetryConfig)
 		if err != nil {
 			return controllers.ErrorStatus(err, "Oathkeeper did not start successfully", conditions.OathkeeperReconcileFailed.Condition())
 		}


### PR DESCRIPTION
We often see flaky tests, because Oathkeeper doesn't reach it's minimum availability. Unfortunately, I wasn't possible to reproduce this behaviour to gain more insights why Oathkeeper does not become available.
We also experienced unavailable Oathkeeper deployments on production clusters in the past. We also don't have any insights from those cases. In those cases a restart of the deployment was done and Oathkeeper started successfully.
Because of this knowledge, we can assume that a restart may help Oathkeeper to recover successfully.

**Description**

Changes proposed in this pull request:

- Force a restart of Oathkeeper if minimum availability wasn't reached for at least 5 minutes

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
