### PR TITLE
Add Oathkeeper logs in integration tests

### DIFF
--- a/tests/integration/pkg/oathkeeper/log.go
+++ b/tests/integration/pkg/oathkeeper/log.go
@@ -1,0 +1,67 @@
+package oathkeeper
+
+import (
+	"bytes"
+	"context"
+	"io"
+	corev1 "k8s.io/api/core/v1"
+	v12 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"log"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
+)
+
+func LogInfo() {
+	conf := config.GetConfigOrDie()
+	k8sClient := kubernetes.NewForConfigOrDie(conf)
+	ctx := context.Background()
+
+	pods, err := k8sClient.CoreV1().Pods("kyma-system").List(ctx, v12.ListOptions{
+		LabelSelector: "app.kubernetes.io/name=oathkeeper",
+	})
+	if err != nil {
+		log.Printf("Fetching Oathkeeper pods for logging: %s", err.Error())
+	}
+
+	for _, pod := range pods.Items {
+
+		log.Printf("Pod %s status: %s", pod.Name, pod.Status.Phase)
+		for _, condition := range pod.Status.Conditions {
+			log.Printf("Pod %s condition: '%s', status: '%s', reasson: '%s' message: '%s'", pod.Name, condition.Type, condition.Status, condition.Reason, condition.Message)
+		}
+
+		for _, containerStatus := range pod.Status.ContainerStatuses {
+			log.Printf("Pod %s container %s status: %v", pod.Name, containerStatus.Name, containerStatus.State)
+		}
+
+		writeLogs(ctx, k8sClient, pod, "oathkeeper")
+		writeLogs(ctx, k8sClient, pod, "oathkeeper-maester")
+		writeLogs(ctx, k8sClient, pod, "init")
+	}
+}
+
+func writeLogs(ctx context.Context, c *kubernetes.Clientset, pod corev1.Pod, container string) {
+
+	req := c.CoreV1().Pods(pod.Namespace).GetLogs(pod.Name, &corev1.PodLogOptions{
+		Container: container,
+	})
+	logs, err := req.Stream(ctx)
+	if err != nil {
+		log.Printf("Fetching %s container logs: %s", container, err.Error())
+	}
+	defer func() {
+		e := logs.Close()
+		if e != nil {
+			log.Printf("error %s closing logs stream: %s", container, err.Error())
+		}
+	}()
+	buf := new(bytes.Buffer)
+	_, err = io.Copy(buf, logs)
+	if err != nil {
+		log.Printf("Copying %s container logs: %s", container, err.Error())
+	}
+	str := buf.String()
+	log.Printf("Logs for container %s:", container)
+	log.Println(str)
+}

--- a/tests/integration/pkg/oathkeeper/log.go
+++ b/tests/integration/pkg/oathkeeper/log.go
@@ -28,7 +28,8 @@ func LogInfo() {
 
 		log.Printf("Pod %s status: %s", pod.Name, pod.Status.Phase)
 		for _, condition := range pod.Status.Conditions {
-			log.Printf("Pod %s condition: '%s', status: '%s', reasson: '%s' message: '%s'", pod.Name, condition.Type, condition.Status, condition.Reason, condition.Message)
+			log.Printf("Pod %s condition: '%s', status: '%s', reasson: '%s' message: '%s'", pod.Name,
+				condition.Type, condition.Status, condition.Reason, condition.Message)
 		}
 
 		for _, containerStatus := range pod.Status.ContainerStatuses {

--- a/tests/integration/pkg/oathkeeper/log.go
+++ b/tests/integration/pkg/oathkeeper/log.go
@@ -28,7 +28,7 @@ func LogInfo() {
 
 		log.Printf("Pod %s status: %s", pod.Name, pod.Status.Phase)
 		for _, condition := range pod.Status.Conditions {
-			log.Printf("Pod %s condition: '%s', status: '%s', reasson: '%s' message: '%s'", pod.Name,
+			log.Printf("Pod %s condition: '%s', status: '%s', reason: '%s' message: '%s'", pod.Name,
 				condition.Type, condition.Status, condition.Reason, condition.Message)
 		}
 

--- a/tests/integration/testsuites/gateway/scenario.go
+++ b/tests/integration/testsuites/gateway/scenario.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/helpers"
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/hooks"
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/manifestprocessor"
+	"github.com/kyma-project/api-gateway/tests/integration/pkg/oathkeeper"
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/resource"
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/testcontext"
 	oryv1alpha1 "github.com/ory/oathkeeper-maester/api/v1alpha1"
@@ -176,7 +177,7 @@ func (c *scenario) checkCustomAPIGatewayCRState(name, state, description string)
 }
 
 func (c *scenario) checkAPIGatewayCRState(state, description string) error {
-	return retry.Do(func() error {
+	err := retry.Do(func() error {
 		res := schema.GroupVersionResource{Group: "operator.kyma-project.io", Version: "v1alpha1", Resource: "apigateways"}
 		gateway, err := c.k8sClient.Resource(res).Get(context.Background(), hooks.ApiGatewayCRName, metav1.GetOptions{})
 		if err != nil {
@@ -207,6 +208,12 @@ func (c *scenario) checkAPIGatewayCRState(state, description string) error {
 		}
 		return nil
 	}, testcontext.GetRetryOpts()...)
+
+	if err != nil {
+		oathkeeper.LogInfo()
+	}
+
+	return err
 }
 
 func (c *scenario) thereIsAGateway(name string, namespace string) error {


### PR DESCRIPTION
**Description**

Changes proposed in this pull request:

- Add logs for Oathkeeper pods and container logs when APIGateway CR is in unexpected state during integration tests

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
