### PR TITLE
Use static kubeconfig name in github actions

### DIFF
--- a/.github/actions/integration-test-gardener/action.yaml
+++ b/.github/actions/integration-test-gardener/action.yaml
@@ -58,14 +58,18 @@ runs:
         OIDC_CONFIG_URL: ${{ inputs.oidc_well_known_url }}
         TEST_SA_ACCESS_KEY_PATH: "${{ github.workspace }}/service-account.json"
         GARDENER_KUBECONFIG: "gardener_kubeconfig.yaml"
+        PERSISTENT_CLUSTER_KUBECONFIG: "cluster_kubeconfig.yaml"
       run: |
         EXPORT_RESULT=true \
         ${{ inputs.script }} ${{ inputs.test_make_target }}
-    - shell: bash
-      name: gather deployment logs
+    - name: Gather deployment logs
+      shell: bash
+      env:
+        PERSISTENT_CLUSTER_KUBECONFIG: "cluster_kubeconfig.yaml"
       if: failure()
       run: |
         mkdir logs
+        export KUBECONFIG="${PERSISTENT_CLUSTER_KUBECONFIG}"
         (kubectl logs -n kyma-system deployments/istio-controller-manager || true) > logs/istio-controller-manager.log
         (kubectl logs -n kyma-system deployments/api-gateway-controller-manager || true) > logs/api-gateway-controller-manager.log
         (kubectl logs -n istio-system deployments/istio-ingressgateway || true) > logs/istio-ingressgateway.log

--- a/hack/ci/custom-domain-gardener.sh
+++ b/hack/ci/custom-domain-gardener.sh
@@ -78,7 +78,12 @@ CLUSTER_NAME=ag-$(echo $RANDOM | md5sum | head -c 7)
 export CLUSTER_NAME
 
 TMP_FOLDER=$(mktemp -d)
-export CLUSTER_KUBECONFIG="${TMP_FOLDER}/${CLUSTER_NAME}_kubeconfig.yaml"
+
+if [ -z "${PERSISTENT_CLUSTER_KUBECONFIG}" ]; then
+    export CLUSTER_KUBECONFIG="${PERSISTENT_CLUSTER_KUBECONFIG}"
+else
+    export CLUSTER_KUBECONFIG="${TMP_FOLDER}/${CLUSTER_NAME}_kubeconfig.yaml"
+fi
 
 ./hack/ci/provision-gardener.sh
 


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Don't generate random names for kubeconfig to get logs in the next step

**Pre-Merge Checklist**

- [x] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
