### PR TITLE
[backport 2.10] Allow for exposing of same path without "/" if already exposed using wildcard

### DIFF
--- a/internal/path/segment_trie/segment_trie.go
+++ b/internal/path/segment_trie/segment_trie.go
@@ -144,6 +144,9 @@ func findExistingPath(node *Node, tokens []token.Token, cur int) bool {
 			}
 		}
 	case token.BracedDoubleAsterix:
+		if node.EndNode {
+			return false
+		}
 		bracedAsterixSuffix := tokens[cur+1:]
 		return suffixExist(node, bracedAsterixSuffix, 0)
 	}

--- a/internal/path/segment_trie/segment_trie_test.go
+++ b/internal/path/segment_trie/segment_trie_test.go
@@ -48,6 +48,22 @@ var _ = Describe("SegmentTrie", func() {
 		Entry("No conflict: prefix and double asterisk", []string{
 			"/abc/{**}",
 		}, 0),
+		Entry("No conflict: path without / at end and same path with double asterisk", []string{
+			"/abc",
+			"/abc/{**}",
+		}, 0),
+		Entry("No conflict: path without / at end and same path with single asterisk", []string{
+			"/abc",
+			"/abc/{*}",
+		}, 0),
+		Entry("Conflict: path with / at end and same path with single asterisk", []string{
+			"/abc/",
+			"/abc/{*}",
+		}, 1),
+		Entry("Conflict: path with / at end and same path with double asterisk", []string{
+			"/abc/",
+			"/abc/{**}",
+		}, 1),
 		Entry("Conflict: exact with single asterisk", []string{
 			"/abc/def/ghi",
 			"/abc/{*}/ghi",


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Allow for exposing of same path without "/" if already exposed using wildcard

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
