### PR TITLE
bug: fix bucket validation in ratelimit_types.go

### DIFF
--- a/apis/gateway/ratelimit/v1alpha1/ratelimit_types.go
+++ b/apis/gateway/ratelimit/v1alpha1/ratelimit_types.go
@@ -27,7 +27,7 @@ const (
 )
 
 // BucketConfig represents a rate limit bucket configuration.
-// +kubebuilder:validation:XValidation:rule="((has(self.path)?1:0)+(has(self.headers)?1:0))==1",message="path or headers must be set"
+// +kubebuilder:validation:XValidation:rule="has(self.path) || has(self.headers)",message="At least one of 'path' or 'headers' must be set"
 type BucketConfig struct {
 	Path    string            `json:"path,omitempty"`
 	Headers map[string]string `json:"headers,omitempty"`

--- a/config/crd/bases/gateway.kyma-project.io_ratelimits.yaml
+++ b/config/crd/bases/gateway.kyma-project.io_ratelimits.yaml
@@ -89,8 +89,8 @@ spec:
                       - bucket
                       type: object
                       x-kubernetes-validations:
-                      - message: path or headers must be set
-                        rule: ((has(self.path)?1:0)+(has(self.headers)?1:0))==1
+                      - message: At least one of 'path' or 'headers' must be set
+                        rule: has(self.path) || has(self.headers)
                     type: array
                   defaultBucket:
                     description: BucketSpec defines the token bucket specification.


### PR DESCRIPTION
As defined in [ADR](https://github.com/kyma-project/api-gateway/blob/main/docs/contributor/adr/0011-rate-limit.md#usage-example), allow scenario where both `path` and `headers` can be defined for single token bucket.
Cover with controller integration tests.

> It is also possible to combine request descriptors, for example rate limit on path and headers, in the same rate limit configuration. In this case the rate limit is applied only if all specified descriptors are present in the request.


/kind bug
/area api-gateway

#1629 