### PR TITLE
tests: delete custom domain resources in reversed order

### DIFF
--- a/tests/integration/testsuites/custom-domain/testsuite.go
+++ b/tests/integration/testsuites/custom-domain/testsuite.go
@@ -210,9 +210,12 @@ func (t *testsuite) createCustomDomainResources() error {
 
 func (t *testsuite) deleteCustomDomainResources() error {
 	log.Printf("Deleting custom domain resources")
-	err := t.resourceManager.DeleteResources(t.k8sClient, t.customDomainResources...)
-	if err != nil {
-		return err
+	// reverse order - secret should be created at the beginning, but deleted at the end, etc.
+	for i := len(t.customDomainResources) - 1; i >= 0; i-- {
+		err := t.resourceManager.DeleteResources(t.k8sClient, t.customDomainResources[i])
+		if err != nil {
+			return err
+		}
 	}
 	log.Printf("Custom domain resources deleted")
 	return nil


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- delete custom domain resources in reversed order, so the secret is still there when DNS entry is being deleted (otherwise DNS entries are not cleaned up properly)

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
