### PR TITLE
[backport 2.10] Enable internal traffic for workloads exposed by v2alpha1 APIRule

### DIFF
--- a/docs/release-notes/2.10.4.md
+++ b/docs/release-notes/2.10.4.md
@@ -1,0 +1,3 @@
+## Bugfixes
+
+We've fixed the [issue](https://github.com/kyma-project/api-gateway/issues/1632) where a workload exposed via a `v2alpha1` APIRule was not accessible from within the cluster.

--- a/docs/release-notes/2.12.0.md
+++ b/docs/release-notes/2.12.0.md
@@ -1,0 +1,3 @@
+## Bugfixes
+
+We've fixed the [issue](https://github.com/kyma-project/api-gateway/issues/1632) where a workload exposed via a `v2alpha1` APIRule was not accessible from within the cluster.

--- a/internal/builders/istio.go
+++ b/internal/builders/istio.go
@@ -192,6 +192,12 @@ func (rf *FromBuilder) WithForcedJWTAuthorizationV2alpha1(authentications []*gat
 	return rf
 }
 
+func (rf *FromBuilder) ExcludingIngressGatewaySource() *FromBuilder {
+	source := v1beta1.Source{NotPrincipals: []string{istioIngressGatewayPrincipal}}
+	rf.value.Source = &source
+	return rf
+}
+
 func (rf *FromBuilder) WithIngressGatewaySource() *FromBuilder {
 	source := v1beta1.Source{Principals: []string{istioIngressGatewayPrincipal}}
 	rf.value.Source = &source

--- a/internal/processing/processors/v2alpha1/authorizationpolicy/audience_test.go
+++ b/internal/processing/processors/v2alpha1/authorizationpolicy/audience_test.go
@@ -25,7 +25,7 @@ var _ = Describe("JwtAuthorization Policy Processor", func() {
 
 		svc := newServiceBuilderWithDummyData().build()
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 		// when
 		result, err := processor.EvaluateReconciliation(context.Background(), client)
@@ -54,7 +54,7 @@ var _ = Describe("JwtAuthorization Policy Processor", func() {
 			build()
 		svc := newServiceBuilderWithDummyData().build()
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 		// when
 		result, err := processor.EvaluateReconciliation(context.Background(), client)

--- a/internal/processing/processors/v2alpha1/authorizationpolicy/ext_auth_test.go
+++ b/internal/processing/processors/v2alpha1/authorizationpolicy/ext_auth_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Processing ExtAuth rules", func() {
 
 		svc := newServiceBuilderWithDummyData().build()
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 		// when
 		results, err := processor.EvaluateReconciliation(context.Background(), client)
@@ -84,7 +84,7 @@ var _ = Describe("Processing ExtAuth rules", func() {
 			build()
 		svc := newServiceBuilderWithDummyData().build()
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 		// when
 		results, err := processor.EvaluateReconciliation(context.Background(), client)

--- a/internal/processing/processors/v2alpha1/authorizationpolicy/internal_access_test.go
+++ b/internal/processing/processors/v2alpha1/authorizationpolicy/internal_access_test.go
@@ -1,0 +1,95 @@
+package authorizationpolicy_test
+
+import (
+	"context"
+	"github.com/kyma-project/api-gateway/internal/processing/processors/v2alpha1/authorizationpolicy"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	securityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
+)
+
+var _ = Describe("Internal access from cluster APs", func() {
+	It("should create an AP for internal access, one if only one service is used", func() {
+		// given
+		ruleJwt := newNoAuthRuleBuilderWithDummyData().
+			withPath("/abc").
+			build()
+
+		noAuthRule := newNoAuthRuleBuilderWithDummyData().
+			withPath("/def").
+			build()
+
+		apiRule := newAPIRuleBuilderWithDummyData().
+			withRules(ruleJwt, noAuthRule).
+			build()
+		svc := newServiceBuilderWithDummyData().build()
+		client := getFakeClient(svc)
+		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+
+		// when
+		result, err := processor.EvaluateReconciliation(context.Background(), client)
+
+		Expect(err).To(BeNil())
+		Expect(result).To(HaveLen(3))
+
+		goodAps := 0
+		for i := 0; i < 3; i++ {
+			ap := result[i].Obj.(*securityv1beta1.AuthorizationPolicy)
+			if len(ap.Spec.Rules[0].To) == 0 {
+				Expect(len(ap.Spec.Rules[0].From)).To(Equal(1))
+				Expect(ap.Spec.Rules[0].From[0].Source.NotPrincipals).To(ConsistOf("cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"))
+				goodAps++
+			} else if len(ap.Spec.Rules[0].To) == 1 {
+				if ap.Spec.Rules[0].To[0].Operation.Paths[0] == "/abc" {
+					goodAps++
+				} else if ap.Spec.Rules[0].To[0].Operation.Paths[0] == "/def" {
+					goodAps++
+				}
+			}
+		}
+		Expect(goodAps).To(Equal(3))
+	})
+
+	It("should create an AP for internal access, two if two services are used", func() {
+		// given
+		ruleJwt := newNoAuthRuleBuilderWithDummyData().
+			withPath("/abc").
+			build()
+
+		noAuthRule := newNoAuthRuleBuilderWithDummyData().
+			withPath("/def").
+			withServiceName("different-service").
+			build()
+
+		apiRule := newAPIRuleBuilderWithDummyData().
+			withRules(ruleJwt, noAuthRule).
+			build()
+		svc := newServiceBuilderWithDummyData().build()
+		differentSvc := newServiceBuilderWithDummyData().withName("different-service").addSelector("a", "b").build()
+		client := getFakeClient(svc, differentSvc)
+		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+
+		// when
+		result, err := processor.EvaluateReconciliation(context.Background(), client)
+
+		Expect(err).To(BeNil())
+		Expect(result).To(HaveLen(4))
+
+		for _, apResult := range result {
+			ap := apResult.Obj.(*securityv1beta1.AuthorizationPolicy)
+
+			if len(ap.Spec.Rules[0].To) > 0 {
+				Expect(len(ap.Spec.Rules[0].To[0].Operation.Paths)).To(Equal(1))
+				if ap.Spec.Rules[0].To[0].Operation.Paths[0] == "/abc" {
+					Expect(ap.Spec.Rules[0].To[0].Operation.Paths).To(ContainElement("/abc"))
+				} else if ap.Spec.Rules[0].To[0].Operation.Paths[0] == "/def" {
+					Expect(ap.Spec.Rules[0].To[0].Operation.Paths).To(ContainElement("/def"))
+				}
+			} else {
+				Expect(len(ap.Spec.Rules[0].From)).To(Equal(1))
+				Expect(ap.Spec.Rules[0].From[0].Source.NotPrincipals).To(ConsistOf("cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"))
+			}
+		}
+	})
+})

--- a/internal/processing/processors/v2alpha1/authorizationpolicy/jwt_rules_test.go
+++ b/internal/processing/processors/v2alpha1/authorizationpolicy/jwt_rules_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Processing JWT rules", func() {
 		svc := newServiceBuilderWithDummyData().build()
 
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 		// when
 		result, err := processor.EvaluateReconciliation(context.Background(), client)
@@ -106,7 +106,7 @@ var _ = Describe("Processing JWT rules", func() {
 		apiRule := newAPIRuleBuilderWithDummyData().withRules(jwtRule).build()
 		svc := newServiceBuilderWithDummyData().build()
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 		// when
 		result, err := processor.EvaluateReconciliation(context.Background(), client)
@@ -175,7 +175,7 @@ var _ = Describe("Processing JWT rules", func() {
 		apiRule := newAPIRuleBuilderWithDummyData().withRules(ruleJwt).build()
 		svc := newServiceBuilderWithDummyData().build()
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 		// when
 		result, err := processor.EvaluateReconciliation(context.Background(), client)
@@ -256,7 +256,7 @@ var _ = Describe("Processing JWT rules", func() {
 				withRules(rules...).
 				build()
 
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)
@@ -313,7 +313,7 @@ var _ = Describe("Processing JWT rules", func() {
 			apiRule := newAPIRuleBuilderWithDummyData().
 				withServiceName(serviceName).
 				withRules(jwtRule).build()
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)
@@ -369,7 +369,7 @@ var _ = Describe("Processing JWT rules", func() {
 				build()
 
 			apiRule := newAPIRuleBuilderWithDummyData().withRules(jwtRule).build()
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)
@@ -424,7 +424,7 @@ var _ = Describe("Processing JWT rules", func() {
 				build()
 
 			apiRule := newAPIRuleBuilderWithDummyData().withRules(jwtRule).build()
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)
@@ -491,7 +491,7 @@ var _ = Describe("Processing JWT rules", func() {
 				build()
 
 			apiRule := newAPIRuleBuilderWithDummyData().withRules(jwtRule).build()
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)

--- a/internal/processing/processors/v2alpha1/authorizationpolicy/no_auth_rules_test.go
+++ b/internal/processing/processors/v2alpha1/authorizationpolicy/no_auth_rules_test.go
@@ -31,7 +31,7 @@ var _ = Describe("Processing NoAuth rules", func() {
 			build()
 		svc := newServiceBuilderWithDummyData().build()
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 		// when
 		results, err := processor.EvaluateReconciliation(context.Background(), client)

--- a/internal/processing/processors/v2alpha1/authorizationpolicy/processor.go
+++ b/internal/processing/processors/v2alpha1/authorizationpolicy/processor.go
@@ -15,8 +15,22 @@ import (
 func NewProcessor(log *logr.Logger, rule *gatewayv2alpha1.APIRule) Processor {
 	return Processor{
 		apiRule: rule,
-		creator: creator{},
-		Log:     log,
+		creator: creator{
+			allowInternalTraffic: true,
+		},
+		Log: log,
+	}
+}
+
+// NewProcessorWithoutInternalTraffic returns a Processor with the desired state handling for AuthorizationPolicy.
+// This processor will not create AuthorizationPolicy for internal traffic.
+func NewProcessorWithoutInternalTraffic(log *logr.Logger, rule *gatewayv2alpha1.APIRule) Processor {
+	return Processor{
+		apiRule: rule,
+		creator: creator{
+			allowInternalTraffic: false,
+		},
+		Log: log,
 	}
 }
 
@@ -25,7 +39,8 @@ func NewMigrationProcessor(log *logr.Logger, rule *gatewayv2alpha1.APIRule, oryP
 	return Processor{
 		apiRule: rule,
 		creator: creator{
-			oryPassthrough: oryPassthrough,
+			oryPassthrough:       oryPassthrough,
+			allowInternalTraffic: true,
 		},
 		Log: log,
 	}

--- a/internal/processing/processors/v2alpha1/authorizationpolicy/processor_test.go
+++ b/internal/processing/processors/v2alpha1/authorizationpolicy/processor_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Processing", func() {
 			build()
 		svc := newServiceBuilderWithDummyData().build()
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 		// when
 		result, err := processor.EvaluateReconciliation(context.Background(), client)
@@ -53,7 +53,7 @@ var _ = Describe("Processing", func() {
 			build()
 		svc := newServiceBuilderWithDummyData().build()
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 		// when
 		result, err := processor.EvaluateReconciliation(context.Background(), client)
@@ -92,7 +92,7 @@ var _ = Describe("Processing", func() {
 			addSelector("app", ruleServiceName).
 			build()
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 		// when
 		result, err := processor.EvaluateReconciliation(context.Background(), client)
@@ -128,7 +128,7 @@ var _ = Describe("Processing", func() {
 			addSelector("app", ruleServiceName).
 			build()
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 		// when
 		result, err := processor.EvaluateReconciliation(context.Background(), client)
@@ -156,7 +156,7 @@ var _ = Describe("Processing", func() {
 		svc := newServiceBuilderWithDummyData().build()
 		client := getFakeClient(svc)
 
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 		// when
 		result, err := processor.EvaluateReconciliation(context.Background(), client)
@@ -181,7 +181,7 @@ var _ = Describe("Processing", func() {
 		svc := newServiceBuilderWithDummyData().build()
 		client := getFakeClient(existingAp, svc)
 
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 		// when
 		result, err := processor.EvaluateReconciliation(context.Background(), client)
@@ -202,7 +202,7 @@ var _ = Describe("Processing", func() {
 		apiRule := newAPIRuleBuilderWithDummyData().build()
 		svc := newServiceBuilderWithDummyData().build()
 		ctrlClient := getFakeClient(existingAp, svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 		// when
 		result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)
@@ -233,7 +233,7 @@ var _ = Describe("Processing", func() {
 			apiRule := newAPIRuleBuilderWithDummyData().
 				withRules(existingRule, newRule).
 				build()
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)
@@ -263,7 +263,7 @@ var _ = Describe("Processing", func() {
 			apiRule := newAPIRuleBuilderWithDummyData().
 				withRules(existingRule, newRule).
 				build()
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)
@@ -298,7 +298,7 @@ var _ = Describe("Processing", func() {
 				addSelector("app", "new-service").
 				build()
 			ctrlClient := getFakeClient(existingAp, svc1, svc2)
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)
@@ -326,7 +326,7 @@ var _ = Describe("Processing", func() {
 			apiRule := newAPIRuleBuilderWithDummyData().
 				withRules(rule).
 				build()
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)
@@ -361,7 +361,7 @@ var _ = Describe("Processing", func() {
 			apiRule := newAPIRuleBuilderWithDummyData().
 				withRules(unchangedRule, updatedRule).
 				build()
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)
@@ -400,7 +400,7 @@ var _ = Describe("Processing", func() {
 				withRules(movedRule).
 				withServiceNamespace(specNewServiceNamespace).
 				build()
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)
@@ -432,7 +432,7 @@ var _ = Describe("Processing", func() {
 			apiRule := newAPIRuleBuilderWithDummyData().
 				withRules(movedRule).
 				build()
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)
@@ -476,7 +476,7 @@ var _ = Describe("Processing", func() {
 			apiRule := newAPIRuleBuilderWithDummyData().
 				withRules(unchangedRule, updatedRule).
 				build()
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)
@@ -506,7 +506,7 @@ var _ = Describe("Processing", func() {
 				build()
 			client := getFakeClient(svc)
 
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), client)
@@ -539,7 +539,7 @@ var _ = Describe("Processing", func() {
 				build()
 			client := getFakeClient(svc)
 
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), client)
@@ -569,7 +569,7 @@ var _ = Describe("Processing", func() {
 				build()
 			client := getFakeClient(svc)
 
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), client)
@@ -615,7 +615,7 @@ var _ = Describe("Processing", func() {
 			apiRule := newAPIRuleBuilderWithDummyData().
 				withRules(rule).
 				build()
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			processor := authorizationpolicy.NewProcessorWithoutInternalTraffic(&testLogger, apiRule)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)

--- a/internal/processing/processors/v2alpha1/reconciliation_test.go
+++ b/internal/processing/processors/v2alpha1/reconciliation_test.go
@@ -58,7 +58,7 @@ var _ = Describe("Reconciliation", func() {
 			}
 
 			// then
-			Expect(createdObjects).To(HaveLen(2))
+			Expect(createdObjects).To(HaveLen(3))
 
 			Expect(createdObjects[0]).To(BeAssignableToTypeOf(&networkingv1beta1.VirtualService{}))
 			Expect(createdObjects[1]).To(BeAssignableToTypeOf(&securityv1beta1.AuthorizationPolicy{}))
@@ -88,7 +88,7 @@ var _ = Describe("Reconciliation", func() {
 			}
 
 			// then
-			Expect(createdObjects).To(HaveLen(3))
+			Expect(createdObjects).To(HaveLen(4))
 
 			vsCreated, apCreated, raCreated := false, false, false
 
@@ -180,7 +180,7 @@ var _ = Describe("Reconciliation", func() {
 			}
 
 			// then
-			Expect(createdObjects).To(HaveLen(3))
+			Expect(createdObjects).To(HaveLen(4))
 
 			vsCreated, raCreated, apCreated := false, false, false
 
@@ -248,7 +248,7 @@ var _ = Describe("Reconciliation", func() {
 			}
 
 			// then
-			Expect(createdObjects).To(HaveLen(5))
+			Expect(createdObjects).To(HaveLen(6))
 
 			vsCreated, apCreated := false, false
 			numberOfCreatedRequestAuthentications := 0
@@ -324,7 +324,7 @@ var _ = Describe("Reconciliation", func() {
 			}
 
 			// then
-			Expect(createdObjects).To(HaveLen(4))
+			Expect(createdObjects).To(HaveLen(5))
 
 			vsCreated, raCreated, apCreated := false, false, false
 
@@ -423,17 +423,23 @@ var _ = Describe("Reconciliation", func() {
 					case v1beta12.AuthorizationPolicy_ALLOW:
 						Expect(obj.Spec.Rules).To(HaveLen(1))
 
-						if expectedOathkeeperPassthrough {
-							Expect(obj.Spec.Rules[0].From).To(HaveLen(2))
-							Expect(obj.Spec.Rules[0].From[0].Source.Principals).To(HaveLen(1))
-							Expect(obj.Spec.Rules[0].From[0].Source.Principals[0]).To(Equal("cluster.local/ns/kyma-system/sa/oathkeeper-maester-account"))
+						if obj.Spec.Rules[0].To != nil {
+							if expectedOathkeeperPassthrough {
+								Expect(obj.Spec.Rules[0].From).To(HaveLen(2))
+								Expect(obj.Spec.Rules[0].From[0].Source.Principals).To(HaveLen(1))
+								Expect(obj.Spec.Rules[0].From[0].Source.Principals[0]).To(Equal("cluster.local/ns/kyma-system/sa/oathkeeper-maester-account"))
 
-							Expect(obj.Spec.Rules[0].From[1].Source.Principals).To(HaveLen(1))
-							Expect(obj.Spec.Rules[0].From[1].Source.Principals[0]).To(Equal("cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"))
+								Expect(obj.Spec.Rules[0].From[1].Source.Principals).To(HaveLen(1))
+								Expect(obj.Spec.Rules[0].From[1].Source.Principals[0]).To(Equal("cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"))
+							} else {
+								Expect(obj.Spec.Rules[0].From).To(HaveLen(1))
+								Expect(obj.Spec.Rules[0].From[0].Source.Principals).To(HaveLen(1))
+								Expect(obj.Spec.Rules[0].From[0].Source.Principals[0]).To(Equal("cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"))
+							}
 						} else {
 							Expect(obj.Spec.Rules[0].From).To(HaveLen(1))
-							Expect(obj.Spec.Rules[0].From[0].Source.Principals).To(HaveLen(1))
-							Expect(obj.Spec.Rules[0].From[0].Source.Principals[0]).To(Equal("cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"))
+							Expect(obj.Spec.Rules[0].From[0].Source.NotPrincipals).To(HaveLen(1))
+							Expect(obj.Spec.Rules[0].From[0].Source.NotPrincipals[0]).To(Equal("cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"))
 						}
 					}
 					apNumber++
@@ -447,9 +453,9 @@ var _ = Describe("Reconciliation", func() {
 			Expect(apNumber).To(Equal(numAPActions))
 			Expect(ruleNumber).To(Equal(numRuleActions))
 		},
-			Entry("Step 1: Create AuthorizationPolicies and RequestAuthentications", "", 1, 0, 0, 0, true),
-			Entry("Step 2: Switch VirtualServices", "apply-istio-authorization", 1, 0, 1, 0, true),
-			Entry("Step 3: Remove OryRule", "vs-switch-to-service", 1, 0, 1, 1, false))
+			Entry("Step 1: Create AuthorizationPolicies and RequestAuthentications", "", 2, 0, 0, 0, true),
+			Entry("Step 2: Switch VirtualServices", "apply-istio-authorization", 2, 0, 1, 0, true),
+			Entry("Step 3: Remove OryRule", "vs-switch-to-service", 2, 0, 1, 1, false))
 	})
 
 	Context("validation", func() {


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Backport `Enable internal traffic for workloads exposed by v2alpha1 APIRule`

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
