### PR TITLE
feat: add Dockerfile.debug

### DIFF
--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,0 +1,42 @@
+# Build the manager binary
+FROM golang:1.23.5-alpine AS builder
+ARG GO_BUILD_TAGS
+ARG VERSION
+
+WORKDIR /api-gateway-build
+# Copy the Go Modules manifests
+COPY go.mod go.mod
+COPY go.sum go.sum
+# cache deps before building and copying source so that we don't need to re-download as much
+# and so that source changes don't invalidate our downloaded layer
+RUN go mod download
+
+# Copy the go source
+COPY main.go main.go
+COPY apis/ apis/
+COPY controllers/ controllers/
+COPY internal/ internal/
+COPY manifests/ manifests/
+
+# Build
+# the GOARCH has not a default value to allow the binary be built according to the host where the command
+# was called. For example, if we call make docker-build in a local env which has the Apple Silicon M1 SO
+# the docker BUILDPLATFORM arg will be linux/arm64 when for Apple x86 it will be linux/amd64. Therefore,
+# by leaving it empty we can ensure that the container and binary shipped on it will have the same platform.
+RUN \
+  go install github.com/go-delve/delve/cmd/dlv@latest && \
+  CGO_ENABLED=0 go build -tags ${GO_BUILD_TAGS} -gcflags="all=-N -l" -ldflags="-X 'github.com/kyma-project/api-gateway/internal/version.version=${VERSION:-}'" -o manager main.go
+
+
+# Use distroless as minimal base image to package the manager binary
+# Refer to https://github.com/GoogleContainerTools/distroless for more details
+FROM gcr.io/distroless/static:nonroot
+WORKDIR /
+COPY --from=builder /go/bin/dlv /dlv
+COPY --from=builder /api-gateway-build/manager .
+COPY --from=builder /api-gateway-build/manifests/ manifests
+
+USER 65532:65532
+EXPOSE 40000
+
+ENTRYPOINT ["/dlv", "--listen=:40000", "--headless=true", "--api-version=2", "--log", "exec", "/manager", "--"]


### PR DESCRIPTION
This Dockerfile contains configuration for remote debugging session for the module.

It's only meant for running locally.
To use the feature
1. Build using `docker build`
2. Load to the cluster using `kind load image` or `k3d image import`
3. Change the image in the `containers` section to yor debug tag
4. Remove commands field from manager deployment
5. kubectl port-forward -n kyma-system {manager pod} 40000:40000 8000:8000
