### PR TITLE
Change maxSurge to 1 for oathkeeper deployment

### DIFF
--- a/internal/reconciliations/oathkeeper/deployment.yaml
+++ b/internal/reconciliations/oathkeeper/deployment.yaml
@@ -16,7 +16,7 @@ spec:
       app.kubernetes.io/name: oathkeeper
   strategy:
     rollingUpdate:
-      maxSurge: 50%
+      maxSurge: 1
       maxUnavailable: 0%
     type: RollingUpdate
   template:

--- a/internal/reconciliations/oathkeeper/deployment_light.yaml
+++ b/internal/reconciliations/oathkeeper/deployment_light.yaml
@@ -16,7 +16,7 @@ spec:
       app.kubernetes.io/name: oathkeeper
   strategy:
     rollingUpdate:
-      maxSurge: 50%
+      maxSurge: 1
       maxUnavailable: 0%
     type: RollingUpdate
   template:


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Change the `rollingUpdate.maxSurge` in the oathkeeper deployment from 50% to the absolute number 1 based on the [comment here](https://github.tools.sap/kyma/backlog/issues/6502#issuecomment-10536550).
as for `maxSurge`, [the value cannot be 0 if MaxUnavailable is 0](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#max-surge), now the `MaxUnavailable` is 0, so `maxSurge` as 1 is the minimal extra pod number during the rolling update.

