### PR TITLE
fix: update APIRule references in zero-downtime migration test

### DIFF
--- a/tests/integration/scripts/test-zero-downtime.sh
+++ b/tests/integration/scripts/test-zero-downtime.sh
@@ -41,11 +41,11 @@ run_zero_downtime_requests() {
   wait_for_api_rule_to_exist
   echo "zero-downtime: APIRule found, waiting for status OK"
 
-  kubectl wait --for='jsonpath={.status.APIRuleStatus.code}=OK' --timeout=5m apirules -A -l test=v1beta1-migration
+  kubectl wait --for='jsonpath={.status.APIRuleStatus.code}=OK' --timeout=5m apirules.v1beta1.gateway.kyma-project.io -A -l test=v1beta1-migration
   echo "zero-downtime: APIRule status is OK"
 
   # Get the host set in the APIRule
-  exposed_host=$(kubectl get apirules -A -l test=v1beta1-migration -o jsonpath='{.items[0].spec.host}')
+  exposed_host=$(kubectl get apirules.v1beta1.gateway.kyma-project.io -A -l test=v1beta1-migration -o jsonpath='{.items[0].spec.host}')
   echo "zero-downtime: APIRule host is ${exposed_host}"
 
   local url_under_test="https://${exposed_host}/headers"
@@ -111,7 +111,7 @@ wait_for_api_rule_to_exist() {
   echo "zero-downtime: Waiting for the APIRule to exist"
   # Wait for 5min
   while [[ $attempts -le 300 ]] ; do
-    apirule=$(kubectl get apirules -A -l test=v1beta1-migration --ignore-not-found) && kubectl_exit_code=$? || kubectl_exit_code=$?
+    apirule=$(kubectl get apirules.v1beta1.gateway.kyma-project.io -A -l test=v1beta1-migration --ignore-not-found) && kubectl_exit_code=$? || kubectl_exit_code=$?
     if [ "${kubectl_exit_code}" -ne 0 ]; then
         echo "zero-downtime: kubectl failed when listing apirules, exit code: $kubectl_exit_code"
         exit 2
@@ -177,7 +177,7 @@ send_requests() {
       # Let's sleep here few seconds to avoid the race condition - when the APIRule still exists, but is being deleted
       # (so it is not effective anymore)
       sleep 2
-      if kubectl get apirules -A -l test=v1beta1-migration --ignore-not-found | grep -q .; then
+      if kubectl get apirules.v1beta1.gateway.kyma-project.io -A -l test=v1beta1-migration --ignore-not-found | grep -q .; then
         echo "zero-downtime: thread ${thread}, test failed after ${request_count} requests. Canceling requests because of curl exit code ${curl_exit_code}"
         exit 1
       elif [ $request_count -lt 10 ]; then


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:
- enhancement call kubectl execution to rely on specific version of APIRule. This should be written like that from begining.


**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
