### PR TITLE
AuthorizationPolicy adjustments

### DIFF
--- a/docs/release-notes/3.1.0.md
+++ b/docs/release-notes/3.1.0.md
@@ -1,3 +1,3 @@
-# Bug fixes
+# Bug Fixes
 
-- Fix behaviour of in-cluster connectivity when using JWT handler in APIRule. Now in-cluster connectivity is blocked. [#1823](https://github.com/kyma-project/api-gateway/pull/1823)
+- Fix behaviour of in-cluster connectivity when using JWT handler in APIRule. Now, in-cluster connectivity is blocked. [#1823](https://github.com/kyma-project/api-gateway/pull/1823)

--- a/docs/release-notes/3.1.0.md
+++ b/docs/release-notes/3.1.0.md
@@ -1,0 +1,3 @@
+# Bug fixes
+
+- Fix behaviour of in-cluster connectivity when using JWT handler in APIRule. Now in-cluster connectivity is blocked. [#1823](https://github.com/kyma-project/api-gateway/pull/1823)

--- a/internal/builders/istio.go
+++ b/internal/builders/istio.go
@@ -150,10 +150,12 @@ func NewFromBuilder() *FromBuilder {
 }
 
 type FromBuilder struct {
-	value *v1beta1.Rule_From
+	value  *v1beta1.Rule_From
+	source v1beta1.Source
 }
 
 func (rf *FromBuilder) Get() *v1beta1.Rule_From {
+	rf.value.Source = &rf.source
 	return rf.value
 }
 
@@ -175,8 +177,7 @@ func (rf *FromBuilder) WithForcedJWTAuthorization(accessStrategies []*gatewayv1b
 			break
 		}
 	}
-	source := v1beta1.Source{RequestPrincipals: requestPrincipals}
-	rf.value.Source = &source
+	rf.source.RequestPrincipals = append(rf.source.RequestPrincipals, requestPrincipals...)
 	return rf
 }
 
@@ -188,20 +189,17 @@ func (rf *FromBuilder) WithForcedJWTAuthorizationV2alpha1(authentications []*gat
 		requestPrincipals = append(requestPrincipals, fmt.Sprintf("%s/*", authentication.Issuer))
 	}
 
-	source := v1beta1.Source{RequestPrincipals: requestPrincipals}
-	rf.value.Source = &source
+	rf.source.RequestPrincipals = append(rf.source.RequestPrincipals, requestPrincipals...)
 	return rf
 }
 
 func (rf *FromBuilder) WithIngressGatewaySource() *FromBuilder {
-	source := v1beta1.Source{Principals: []string{istioIngressGatewayPrincipal}}
-	rf.value.Source = &source
+	rf.source.Principals = append(rf.source.Principals, istioIngressGatewayPrincipal)
 	return rf
 }
 
 func (rf *FromBuilder) WithOathkeeperProxySource() *FromBuilder {
-	source := v1beta1.Source{Principals: []string{oathkeeperMaesterAccountPrincipal}}
-	rf.value.Source = &source
+	rf.source.Principals = append(rf.source.Principals, oathkeeperMaesterAccountPrincipal)
 	return rf
 }
 

--- a/internal/builders/istio.go
+++ b/internal/builders/istio.go
@@ -3,6 +3,7 @@ package builders
 import (
 	"encoding/json"
 	"fmt"
+
 	gatewayv1beta1 "github.com/kyma-project/api-gateway/apis/gateway/v1beta1"
 	gatewayv2alpha1 "github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
 
@@ -233,6 +234,11 @@ func NewOperationBuilder() *OperationBuilder {
 
 type OperationBuilder struct {
 	value *v1beta1.Operation
+}
+
+func (o *OperationBuilder) Hosts(hosts ...string) *OperationBuilder {
+	o.value.Hosts = append(o.value.Hosts, hosts...)
+	return o
 }
 
 func (o *OperationBuilder) Get() *v1beta1.Operation {

--- a/internal/processing/processors/istio/authorization_policy_processor.go
+++ b/internal/processing/processors/istio/authorization_policy_processor.go
@@ -3,6 +3,7 @@ package istio
 import (
 	"context"
 	"fmt"
+
 	gatewayv1beta1 "github.com/kyma-project/api-gateway/apis/gateway/v1beta1"
 
 	"github.com/go-logr/logr"
@@ -160,17 +161,14 @@ func generateAuthorizationPolicySpec(ctx context.Context, client client.Client, 
 func withTo(b *builders.RuleBuilder, rule gatewayv1beta1.Rule) *builders.RuleBuilder {
 	// APIRule and VirtualService supported a regex match. Since AuthorizationPolicy supports only prefix, suffix and wildcard
 	// and we have clusters with "/.*" in APIRule, we need special handling of this case.
+	path := rule.Path
 	if rule.Path == "/.*" {
-		return b.WithTo(
-			builders.NewToBuilder().
-				WithOperation(builders.NewOperationBuilder().
-					WithMethods(rule.Methods).WithPath("/*").Get()).
-				Get())
+		path = "/*"
 	}
 	return b.WithTo(
 		builders.NewToBuilder().
 			WithOperation(builders.NewOperationBuilder().
-				WithMethods(rule.Methods).WithPath(rule.Path).Get()).
+				WithMethods(rule.Methods).WithPath(path).Get()).
 			Get())
 }
 

--- a/internal/processing/processors/migration/processors.go
+++ b/internal/processing/processors/migration/processors.go
@@ -26,6 +26,7 @@ func NewMigrationProcessors(apiRuleV2alpha1 *gatewayv2alpha1.APIRule, apiRuleV1b
 		processors = append(processors, virtualservice.NewVirtualServiceProcessor(config, apiRuleV2alpha1, nil))
 		fallthrough // We want to also use the processors from the previous steps
 	case applyIstioAuthorizationMigrationStep: // Step 1
+		// When short host is used in the APIRule we pull it from the gateway, in the future we should refactor it so that only gateway host is passed
 		processors = append(processors, authorizationpolicy.NewMigrationProcessor(log, apiRuleV2alpha1, step != removeOryRule, gateway))
 		processors = append(processors, requestauthentication.NewProcessor(apiRuleV2alpha1))
 	}

--- a/internal/processing/processors/migration/processors_test.go
+++ b/internal/processing/processors/migration/processors_test.go
@@ -10,6 +10,8 @@ import (
 	v2alpha1VirtualService "github.com/kyma-project/api-gateway/internal/processing/processors/v2alpha1/virtualservice"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	networkingv1alpha3 "istio.io/api/networking/v1alpha3"
+	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -31,7 +33,15 @@ var _ = Describe("NewMigrationProcessors", func() {
 			},
 		}
 
-		processors := NewMigrationProcessors(apirule, apiruleBeta, config, &log)
+		gateway := &networkingv1beta1.Gateway{
+			Spec: networkingv1alpha3.Gateway{
+				Servers: []*networkingv1alpha3.Server{
+					{Hosts: []string{"*"}},
+				},
+			},
+		}
+
+		processors := NewMigrationProcessors(apirule, apiruleBeta, gateway, config, &log)
 		Expect(processors).To(HaveLen(2))
 		Expect(processors[0]).To(BeAssignableToTypeOf(authorizationpolicy.Processor{}))
 		Expect(processors[1]).To(BeAssignableToTypeOf(requestauthentication.Processor{}))
@@ -53,7 +63,15 @@ var _ = Describe("NewMigrationProcessors", func() {
 				},
 			},
 		}
-		processors := NewMigrationProcessors(apirule, apiruleBeta, config, &log)
+		gateway := &networkingv1beta1.Gateway{
+			Spec: networkingv1alpha3.Gateway{
+				Servers: []*networkingv1alpha3.Server{
+					{Hosts: []string{"*"}},
+				},
+			},
+		}
+
+		processors := NewMigrationProcessors(apirule, apiruleBeta, gateway, config, &log)
 		// then
 		Expect(len(processors)).To(Equal(len(expectedProcessors)))
 		for i, processor := range expectedProcessors {

--- a/internal/processing/processors/v2alpha1/authorizationpolicy/audience_test.go
+++ b/internal/processing/processors/v2alpha1/authorizationpolicy/audience_test.go
@@ -22,10 +22,10 @@ var _ = Describe("JwtAuthorization Policy Processor", func() {
 		apiRule := newAPIRuleBuilderWithDummyData().
 			withRules(rule).
 			build()
-
 		svc := newServiceBuilderWithDummyData().build()
+		gateway := newGatewayBuilderWithDummyData().build()
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule, gateway)
 
 		// when
 		result, err := processor.EvaluateReconciliation(context.Background(), client)
@@ -53,8 +53,9 @@ var _ = Describe("JwtAuthorization Policy Processor", func() {
 			withRules(rule).
 			build()
 		svc := newServiceBuilderWithDummyData().build()
+		gateway := newGatewayBuilderWithDummyData().build()
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule, gateway)
 
 		// when
 		result, err := processor.EvaluateReconciliation(context.Background(), client)

--- a/internal/processing/processors/v2alpha1/authorizationpolicy/creator.go
+++ b/internal/processing/processors/v2alpha1/authorizationpolicy/creator.go
@@ -219,6 +219,7 @@ func (r creator) generateAuthorizationPolicySpec(ctx context.Context, client cli
 
 	authorizationPolicySpecBuilder := builders.NewAuthorizationPolicySpecBuilder().
 		WithSelector(podSelector.Selector)
+	// When short host is used in the APIRule we pull it from the gateway, in the future we should refactor it so that only gateway host is passed from the processors.go
 	var hosts []string
 	gatewayDomain := ""
 	for _, h := range api.Spec.Hosts {
@@ -300,7 +301,6 @@ func withFrom(b *builders.RuleBuilder, rule gatewayv2alpha1.Rule, oryPassthrough
 	if oryPassthrough {
 		b.WithFrom(builders.NewFromBuilder().
 			WithOathkeeperProxySource().
-			WithIngressGatewaySource().
 			Get())
 	}
 	return b.WithFrom(builders.NewFromBuilder().

--- a/internal/processing/processors/v2alpha1/authorizationpolicy/ext_auth_test.go
+++ b/internal/processing/processors/v2alpha1/authorizationpolicy/ext_auth_test.go
@@ -32,8 +32,9 @@ var _ = Describe("Processing ExtAuth rules", func() {
 			build()
 
 		svc := newServiceBuilderWithDummyData().build()
+		gateway := newGatewayBuilderWithDummyData().build()
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule, gateway)
 
 		// when
 		results, err := processor.EvaluateReconciliation(context.Background(), client)
@@ -83,8 +84,9 @@ var _ = Describe("Processing ExtAuth rules", func() {
 			withRules(ruleJwt).
 			build()
 		svc := newServiceBuilderWithDummyData().build()
+		gateway := newGatewayBuilderWithDummyData().build()
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule, gateway)
 
 		// when
 		results, err := processor.EvaluateReconciliation(context.Background(), client)

--- a/internal/processing/processors/v2alpha1/authorizationpolicy/jwt_rules_test.go
+++ b/internal/processing/processors/v2alpha1/authorizationpolicy/jwt_rules_test.go
@@ -32,9 +32,10 @@ var _ = Describe("Processing JWT rules", func() {
 			withRules(ruleJwt, ruleJwt2).
 			build()
 		svc := newServiceBuilderWithDummyData().build()
+		gateway := newGatewayBuilderWithDummyData().build()
 
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule, gateway)
 
 		// when
 		result, err := processor.EvaluateReconciliation(context.Background(), client)
@@ -105,8 +106,9 @@ var _ = Describe("Processing JWT rules", func() {
 
 		apiRule := newAPIRuleBuilderWithDummyData().withRules(jwtRule).build()
 		svc := newServiceBuilderWithDummyData().build()
+		gateway := newGatewayBuilderWithDummyData().build()
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule, gateway)
 
 		// when
 		result, err := processor.EvaluateReconciliation(context.Background(), client)
@@ -174,8 +176,9 @@ var _ = Describe("Processing JWT rules", func() {
 
 		apiRule := newAPIRuleBuilderWithDummyData().withRules(ruleJwt).build()
 		svc := newServiceBuilderWithDummyData().build()
+		gateway := newGatewayBuilderWithDummyData().build()
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule, gateway)
 
 		// when
 		result, err := processor.EvaluateReconciliation(context.Background(), client)
@@ -218,8 +221,8 @@ var _ = Describe("Processing JWT rules", func() {
 	When("Two AP for different services with JWT handler exist", func() {
 		It("should update APs and update principal when handler changed for one of the AP to noAuth", func() {
 			// given: Cluster state
-			beingUpdatedAp := getAuthorizationPolicy("being-updated-ap", apiRuleNamespace, "test-service", []string{http.MethodGet, http.MethodPost})
-			jwtSecuredAp := getAuthorizationPolicy("jwt-secured-ap", apiRuleNamespace, "jwt-secured-service", []string{http.MethodGet, http.MethodPost})
+			beingUpdatedAp := getAuthorizationPolicy("being-updated-ap", apiRuleNamespace, "test-service", []string{"example-host.example.com"}, []string{http.MethodGet, http.MethodPost})
+			jwtSecuredAp := getAuthorizationPolicy("jwt-secured-ap", apiRuleNamespace, "jwt-secured-service", []string{"example-host.example.com"}, []string{http.MethodGet, http.MethodPost})
 			svc1 := newServiceBuilder().
 				withName("test-service").
 				withNamespace("example-namespace").
@@ -256,7 +259,8 @@ var _ = Describe("Processing JWT rules", func() {
 				withRules(rules...).
 				build()
 
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			gateway := newGatewayBuilderWithDummyData().build()
+			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule, gateway)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)
@@ -277,7 +281,7 @@ var _ = Describe("Processing JWT rules", func() {
 			// given: Cluster state
 			serviceName := "test-service"
 
-			ap1 := getAuthorizationPolicy("ap1", apiRuleNamespace, serviceName, []string{"GET"})
+			ap1 := getAuthorizationPolicy("ap1", apiRuleNamespace, serviceName, []string{"example-host.example.com"}, []string{"GET"})
 			ap1.Spec.Rules[0].When = []*v1beta1.Condition{
 				{
 					Key:    "request.auth.claims[aud]",
@@ -285,7 +289,7 @@ var _ = Describe("Processing JWT rules", func() {
 				},
 			}
 
-			ap2 := getAuthorizationPolicy("ap2", apiRuleNamespace, serviceName, []string{"GET"})
+			ap2 := getAuthorizationPolicy("ap2", apiRuleNamespace, serviceName, []string{"example-host.example.com"}, []string{"GET"})
 			ap2.Spec.Rules[0].When = []*v1beta1.Condition{
 				{
 					Key:    "request.auth.claims[aud]",
@@ -313,7 +317,8 @@ var _ = Describe("Processing JWT rules", func() {
 			apiRule := newAPIRuleBuilderWithDummyData().
 				withServiceName(serviceName).
 				withRules(jwtRule).build()
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			gateway := newGatewayBuilderWithDummyData().build()
+			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule, gateway)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)
@@ -334,7 +339,7 @@ var _ = Describe("Processing JWT rules", func() {
 			// given: Cluster state
 			serviceName := "test-service"
 
-			ap1 := getAuthorizationPolicy("ap1", apiRuleNamespace, serviceName, []string{"GET"})
+			ap1 := getAuthorizationPolicy("ap1", apiRuleNamespace, serviceName, []string{"example-host.example.com"}, []string{"GET"})
 			ap1.Spec.Rules[0].When = []*v1beta1.Condition{
 				{
 					Key:    "request.auth.claims[aud]",
@@ -342,7 +347,7 @@ var _ = Describe("Processing JWT rules", func() {
 				},
 			}
 
-			ap2 := getAuthorizationPolicy("ap2", apiRuleNamespace, serviceName, []string{"GET"})
+			ap2 := getAuthorizationPolicy("ap2", apiRuleNamespace, serviceName, []string{"example-host.example.com"}, []string{"GET"})
 			ap2.Spec.Rules[0].When = []*v1beta1.Condition{
 				{
 					Key:    "request.auth.claims[aud]",
@@ -369,7 +374,8 @@ var _ = Describe("Processing JWT rules", func() {
 				build()
 
 			apiRule := newAPIRuleBuilderWithDummyData().withRules(jwtRule).build()
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			gateway := newGatewayBuilderWithDummyData().build()
+			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule, gateway)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)
@@ -391,7 +397,7 @@ var _ = Describe("Processing JWT rules", func() {
 			// given: Cluster state
 			serviceName := "test-service"
 
-			ap1 := getAuthorizationPolicy("ap1", apiRuleNamespace, serviceName, []string{"GET"})
+			ap1 := getAuthorizationPolicy("ap1", apiRuleNamespace, serviceName, []string{"example-host.example.com"}, []string{"GET"})
 			ap1.Spec.Rules[0].When = []*v1beta1.Condition{
 				{
 					Key:    "request.auth.claims[aud]",
@@ -399,7 +405,7 @@ var _ = Describe("Processing JWT rules", func() {
 				},
 			}
 
-			ap2 := getAuthorizationPolicy("ap2", apiRuleNamespace, serviceName, []string{"GET"})
+			ap2 := getAuthorizationPolicy("ap2", apiRuleNamespace, serviceName, []string{"example-host.example.com"}, []string{"GET"})
 			ap2.Spec.Rules[0].When = []*v1beta1.Condition{
 				{
 					Key:    "request.auth.claims[aud]",
@@ -424,7 +430,8 @@ var _ = Describe("Processing JWT rules", func() {
 				build()
 
 			apiRule := newAPIRuleBuilderWithDummyData().withRules(jwtRule).build()
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			gateway := newGatewayBuilderWithDummyData().build()
+			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule, gateway)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)
@@ -447,7 +454,7 @@ var _ = Describe("Processing JWT rules", func() {
 			// given: Cluster state
 			serviceName := "test-service"
 
-			ap1 := getAuthorizationPolicy("ap1", apiRuleNamespace, serviceName, []string{"GET"})
+			ap1 := getAuthorizationPolicy("ap1", apiRuleNamespace, serviceName, []string{"example-host.example.com"}, []string{"GET"})
 			ap1.Spec.Rules[0].When = []*v1beta1.Condition{
 				{
 					Key:    "request.auth.claims[aud]",
@@ -455,7 +462,7 @@ var _ = Describe("Processing JWT rules", func() {
 				},
 			}
 
-			ap2 := getAuthorizationPolicy("ap2", apiRuleNamespace, serviceName, []string{"GET"})
+			ap2 := getAuthorizationPolicy("ap2", apiRuleNamespace, serviceName, []string{"example-host.example.com"}, []string{"GET"})
 			ap2.Spec.Rules[0].When = []*v1beta1.Condition{
 				{
 					Key:    "request.auth.claims[aud]",
@@ -465,7 +472,7 @@ var _ = Describe("Processing JWT rules", func() {
 			// We need to set the index to 1 as this is expected to be the second authorization configured in the rule.
 			ap2.Labels["gateway.kyma-project.io/index"] = "1"
 
-			ap3 := getAuthorizationPolicy("ap3", apiRuleNamespace, serviceName, []string{"GET"})
+			ap3 := getAuthorizationPolicy("ap3", apiRuleNamespace, serviceName, []string{"example-host.example.com"}, []string{"GET"})
 			ap3.Spec.Rules[0].When = []*v1beta1.Condition{
 				{
 					Key:    "request.auth.claims[aud]",
@@ -491,7 +498,8 @@ var _ = Describe("Processing JWT rules", func() {
 				build()
 
 			apiRule := newAPIRuleBuilderWithDummyData().withRules(jwtRule).build()
-			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+			gateway := newGatewayBuilderWithDummyData().build()
+			processor := authorizationpolicy.NewProcessor(&testLogger, apiRule, gateway)
 
 			// when
 			result, err := processor.EvaluateReconciliation(context.Background(), ctrlClient)

--- a/internal/processing/processors/v2alpha1/authorizationpolicy/no_auth_rules_test.go
+++ b/internal/processing/processors/v2alpha1/authorizationpolicy/no_auth_rules_test.go
@@ -30,8 +30,9 @@ var _ = Describe("Processing NoAuth rules", func() {
 			withRules(ruleNoAuth, ruleJwt).
 			build()
 		svc := newServiceBuilderWithDummyData().build()
+		gateway := newGatewayBuilderWithDummyData().build()
 		client := getFakeClient(svc)
-		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule)
+		processor := authorizationpolicy.NewProcessor(&testLogger, apiRule, gateway)
 
 		// when
 		results, err := processor.EvaluateReconciliation(context.Background(), client)

--- a/internal/processing/processors/v2alpha1/authorizationpolicy/processor.go
+++ b/internal/processing/processors/v2alpha1/authorizationpolicy/processor.go
@@ -2,7 +2,9 @@ package authorizationpolicy
 
 import (
 	"context"
+
 	gatewayv2alpha1 "github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
+	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 
 	"github.com/go-logr/logr"
 	"github.com/kyma-project/api-gateway/internal/processing"
@@ -12,20 +14,21 @@ import (
 )
 
 // NewProcessor returns a Processor with the desired state handling for AuthorizationPolicy.
-func NewProcessor(log *logr.Logger, rule *gatewayv2alpha1.APIRule) Processor {
+func NewProcessor(log *logr.Logger, rule *gatewayv2alpha1.APIRule, gateway *networkingv1beta1.Gateway) Processor {
 	return Processor{
 		apiRule: rule,
-		creator: creator{},
+		creator: creator{gateway: gateway},
 		Log:     log,
 	}
 }
 
 // NewMigrationProcessor returns a Processor with the desired state handling for AuthorizationPolicy when in the migration process from v1beta1 to v2alpha1.
-func NewMigrationProcessor(log *logr.Logger, rule *gatewayv2alpha1.APIRule, oryPassthrough bool) Processor {
+func NewMigrationProcessor(log *logr.Logger, rule *gatewayv2alpha1.APIRule, oryPassthrough bool, gateway *networkingv1beta1.Gateway) Processor {
 	return Processor{
 		apiRule: rule,
 		creator: creator{
 			oryPassthrough: oryPassthrough,
+			gateway:        gateway,
 		},
 		Log: log,
 	}

--- a/internal/processing/processors/v2alpha1/authorizationpolicy/suite_test.go
+++ b/internal/processing/processors/v2alpha1/authorizationpolicy/suite_test.go
@@ -2,6 +2,8 @@ package authorizationpolicy_test
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/kyma-project/api-gateway/internal/processing"
 	"github.com/kyma-project/api-gateway/internal/processing/hashbasedstate"
 	"github.com/kyma-project/api-gateway/tests"
@@ -16,7 +18,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-	"testing"
 
 	. "github.com/onsi/ginkgo/v2"
 	ginkgotypes "github.com/onsi/ginkgo/v2/types"
@@ -40,7 +41,7 @@ var serviceName = "example-service"
 var testLogger = ctrl.Log.WithName("istio-test")
 var testExpectedScopeKeys = []string{"request.auth.claims[scp]", "request.auth.claims[scope]", "request.auth.claims[scopes]"}
 
-var getAuthorizationPolicy = func(name string, namespace string, serviceName string, methods []string) *securityv1beta1.AuthorizationPolicy {
+var getAuthorizationPolicy = func(name string, namespace string, serviceName string, hosts, methods []string) *securityv1beta1.AuthorizationPolicy {
 	ap := securityv1beta1.AuthorizationPolicy{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -67,6 +68,7 @@ var getAuthorizationPolicy = func(name string, namespace string, serviceName str
 					To: []*v1beta1.Rule_To{
 						{
 							Operation: &v1beta1.Operation{
+								Hosts:   hosts,
 								Methods: methods,
 								Paths:   []string{"/"},
 							},

--- a/internal/processing/processors/v2alpha1/authorizationpolicy/test_builders_test.go
+++ b/internal/processing/processors/v2alpha1/authorizationpolicy/test_builders_test.go
@@ -1,11 +1,14 @@
 package authorizationpolicy_test
 
 import (
+	"net/http"
+
 	gatewayv2alpha1 "github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
+	"istio.io/api/networking/v1alpha3"
+	"istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/utils/ptr"
-	"net/http"
 )
 
 type ruleBuilder struct {
@@ -313,4 +316,43 @@ func newServiceBuilderWithDummyData() *serviceBuilder {
 		withNamespace("example-namespace").
 		addSelector("app", "example-service")
 
+}
+
+type gatewayBuilder struct {
+	gateway *v1beta1.Gateway
+	hosts   []string
+}
+
+func newGatewayBuilder() *gatewayBuilder {
+	return &gatewayBuilder{
+		gateway: &v1beta1.Gateway{
+			Spec: v1alpha3.Gateway{
+				Servers: []*v1alpha3.Server{},
+			},
+		},
+	}
+}
+
+func (g *gatewayBuilder) withHost(host string) *gatewayBuilder {
+	g.hosts = append(g.hosts, host)
+	return g
+}
+
+func (g *gatewayBuilder) build() *v1beta1.Gateway {
+	var server v1alpha3.Server
+	if len(g.hosts) > 0 {
+		server.Hosts = g.hosts
+	}
+	g.gateway.Spec.Servers = append(g.gateway.Spec.Servers, &server)
+	return g.gateway
+}
+
+/*
+newGatewayBuilderWithDummyData returns a gatewayBuilder pre-filled with placeholder data:
+
+Host: example-host.example.com
+*/
+func newGatewayBuilderWithDummyData() *gatewayBuilder {
+	return newGatewayBuilder().
+		withHost("example-host.example.com")
 }

--- a/internal/processing/processors/v2alpha1/reconciliation.go
+++ b/internal/processing/processors/v2alpha1/reconciliation.go
@@ -54,10 +54,10 @@ func NewReconciliation(apiRuleV2alpha1 *gatewayv2alpha1.APIRule, apiRuleV1beta1 
 	var processors []processing.ReconciliationProcessor
 	if needsMigration {
 		log.Info("APIRule needs migration")
-		processors = append(processors, migration.NewMigrationProcessors(apiRuleV2alpha1, apiRuleV1beta1, config, log)...)
+		processors = append(processors, migration.NewMigrationProcessors(apiRuleV2alpha1, apiRuleV1beta1, gateway, config, log)...)
 	} else {
 		processors = append(processors, v2alpha1VirtualService.NewVirtualServiceProcessor(config, apiRuleV2alpha1, gateway))
-		processors = append(processors, authorizationpolicy.NewProcessor(log, apiRuleV2alpha1))
+		processors = append(processors, authorizationpolicy.NewProcessor(log, apiRuleV2alpha1, gateway))
 		processors = append(processors, requestauthentication.NewProcessor(apiRuleV2alpha1))
 	}
 

--- a/tests/integration/testsuites/v2/features/jwt.feature
+++ b/tests/integration/testsuites/v2/features/jwt.feature
@@ -99,5 +99,5 @@ Feature: Exposing endpoints with JWT
     And There is a httpbin service
     And There is an endpoint secured with JWT on path "/*"
     When The APIRule is applied
-    Then In-cluster calling the "/status/200" endpoint with a valid "JWT" token should succeed
-    And In-cluster calling the "/headers" endpoint with a valid "JWT" token should succeed
+    Then In-cluster calling the "/status/200" endpoint with a valid "JWT" token should fail
+    And In-cluster calling the "/headers" endpoint with a valid "JWT" token should fail

--- a/tests/integration/testsuites/v2/scenario.go
+++ b/tests/integration/testsuites/v2/scenario.go
@@ -211,7 +211,7 @@ func (s *scenario) inClusterCallingTheEndpointWithoutTokenShouldFail(path string
 	return fmt.Errorf("%s, %s", "Request should fail, but it succeeded", log)
 }
 
-func (s *scenario) inClusterCallingTheEndpointWithTokenShouldSucceed(path, tokenType string) error {
+func (s *scenario) inClusterCallingTheEndpointWithTokenShouldFail(path, tokenType string) error {
 	var headers string
 	switch tokenType {
 	case "JWT":
@@ -229,10 +229,10 @@ func (s *scenario) inClusterCallingTheEndpointWithTokenShouldSucceed(path, token
 
 	log, err := helpers.RunCurlInPod(s.Namespace, curlCommand)
 	if err != nil {
-		return fmt.Errorf("%s, %s", err, log)
+		return nil
 	}
 
-	return nil
+	return fmt.Errorf("%s, %s", "Request should fail, but it succeeded", log)
 }
 
 func (s *scenario) callingShortHostWithoutTokenShouldResultInStatusBetween(host, path string, lower, higher int) error {

--- a/tests/integration/testsuites/v2/scenario_initializers.go
+++ b/tests/integration/testsuites/v2/scenario_initializers.go
@@ -31,7 +31,7 @@ func initScenario(ctx *godog.ScenarioContext, ts *testsuite) {
 	ctx.Step(`^Calling the "([^"]*)" endpoint with header "([^"]*)" with value "([^"]*)" should result in status between (\d+) and (\d+)$`, scenario.callingTheEndpointWithHeader)
 	ctx.Step(`^Calling the "([^"]*)" endpoint without a token should result in status between (\d+) and (\d+)$`, scenario.callingTheEndpointWithoutTokenShouldResultInStatusBetween)
 	ctx.Step(`^In-cluster calling the "([^"]*)" endpoint without a token should fail$`, scenario.inClusterCallingTheEndpointWithoutTokenShouldFail)
-	ctx.Step(`^In-cluster calling the "([^"]*)" endpoint with a valid "([^"]*)" token should succeed$`, scenario.inClusterCallingTheEndpointWithTokenShouldSucceed)
+	ctx.Step(`^In-cluster calling the "([^"]*)" endpoint with a valid "([^"]*)" token should fail$`, scenario.inClusterCallingTheEndpointWithTokenShouldFail)
 	ctx.Step(`^Preflight calling the "([^"]*)" endpoint with header Origin:"([^"]*)" should result in status code (\d+) and no response header "([^"]*)"$`, scenario.preflightEndpointCallNoResponseHeader)
 	ctx.Step(`^Preflight calling the "([^"]*)" endpoint with header Origin:"([^"]*)" should result in status code (\d+) and response header "([^"]*)" with value "([^"]*)"$`, scenario.preflightEndpointCallResponseHeaders)
 	ctx.Step(`^Specifies custom Gateway "([^"]*)"/"([^"]*)"`, scenario.specifiesCustomGateway)


### PR DESCRIPTION
- add host handling to authorizationPolicy
- adjust unit tests with adding a host
- copy over the code from virtualservice processor with a comment
- adjust in-cluster connectivity test to pass if in-cluster connectivity is blocked

Things that have not been changed:
- the sources for ory passthorugh APs since it's a special case during migration
- ExtAuth APs are not covered, because it requires additional work needed around lifecycle of the subresources

#1800 