### PR TITLE
Enable watch for istio-ingressgateway service (#1759)

### DIFF
--- a/apis/operator/v1alpha1/apigateway_types.go
+++ b/apis/operator/v1alpha1/apigateway_types.go
@@ -85,3 +85,15 @@ func (a *APIGateway) IsInDeletion() bool {
 func (a *APIGateway) HasFinalizer() bool {
 	return len(a.Finalizers) > 0
 }
+
+func GetOldestAPIGatewayCR(apigatewayCRs *APIGatewayList) *APIGateway {
+	oldest := apigatewayCRs.Items[0]
+	for _, item := range apigatewayCRs.Items {
+		timestamp := &item.CreationTimestamp
+		if !(oldest.CreationTimestamp.Before(timestamp)) {
+			oldest = item
+		}
+	}
+
+	return &oldest
+}

--- a/controllers/gateway/ratelimit/ratelimit_controller.go
+++ b/controllers/gateway/ratelimit/ratelimit_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	ratelimitv1alpha1 "github.com/kyma-project/api-gateway/apis/gateway/ratelimit/v1alpha1"
+	operatorv1alpha1 "github.com/kyma-project/api-gateway/apis/operator/v1alpha1"
 	"github.com/kyma-project/api-gateway/controllers"
 	"github.com/kyma-project/api-gateway/internal/builders/envoyfilter"
 	"github.com/kyma-project/api-gateway/internal/dependencies"
@@ -70,6 +71,31 @@ func (r *RateLimitReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 		if err := r.Status().Update(ctx, &rl); err != nil {
 			return ctrl.Result{}, err
 		}
+		return ctrl.Result{}, err
+	}
+
+	existingAPIGateways := &operatorv1alpha1.APIGatewayList{}
+	if err := r.Client.List(ctx, existingAPIGateways); err != nil {
+		l.Info("Unable to list APIGateway CRs")
+		return ctrl.Result{}, err
+	}
+
+	if len(existingAPIGateways.Items) < 1 {
+		rl.Status.Warning(fmt.Errorf("failed to reconcile RateLimit CR because of missing APIGateway CR in the cluster"))
+		if err := r.Status().Update(ctx, &rl); err != nil {
+			return ctrl.Result{}, err
+		}
+		err := fmt.Errorf("no APIGateway CR in the cluster")
+		return ctrl.Result{}, err
+	}
+
+	latestCr := operatorv1alpha1.GetOldestAPIGatewayCR(existingAPIGateways)
+	if latestCr.Status.State != operatorv1alpha1.Ready {
+		rl.Status.Warning(fmt.Errorf("failed to create RateLimit CR because APIGateway CR is in %s state", latestCr.Status.State))
+		if err := r.Status().Update(ctx, &rl); err != nil {
+			return ctrl.Result{}, err
+		}
+		err := fmt.Errorf("APIGateway CR %s/%s is in %s state", latestCr.Namespace, latestCr.Name, latestCr.Status.State)
 		return ctrl.Result{}, err
 	}
 

--- a/controllers/gateway/ratelimit/ratelimit_controller_integration_test.go
+++ b/controllers/gateway/ratelimit/ratelimit_controller_integration_test.go
@@ -3,6 +3,7 @@ package ratelimit_test
 import (
 	"context"
 	ratelimitv1alpha1 "github.com/kyma-project/api-gateway/apis/gateway/ratelimit/v1alpha1"
+	apigatewayv1alpha1 "github.com/kyma-project/api-gateway/apis/operator/v1alpha1"
 	"github.com/kyma-project/api-gateway/controllers"
 	"github.com/kyma-project/api-gateway/controllers/gateway/ratelimit"
 	. "github.com/onsi/ginkgo/v2"
@@ -78,230 +79,47 @@ var _ = AfterSuite(func() {
 })
 var _ = Describe("Rate Limit Controller", func() {
 	var ns *corev1.Namespace
+	var apigateway *apigatewayv1alpha1.APIGateway
+
+	apigatewayGenerateName := "custom-apigateway-"
+	nsGenerateName := "ratelimit-test-"
+
 	BeforeEach(func() {
+		apigateway = &apigatewayv1alpha1.APIGateway{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: apigatewayGenerateName,
+			},
+		}
+
 		ns = &corev1.Namespace{
 			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "ratelimit-test-",
+				GenerateName: nsGenerateName,
 			},
 		}
+
 		Expect(c.Create(ctx, ns)).Should(Succeed())
 		Expect(ns.Name).ToNot(BeEmpty())
-	})
-	It("should reconcile RateLimit Status to Error state when validation fails", func() {
-		By("Creating RateLimit resource without matching pods")
-		namespace := ns.Name
-		rl := &ratelimitv1alpha1.RateLimit{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "rate-limit-",
-				Namespace:    namespace,
-			},
-			Spec: ratelimitv1alpha1.RateLimitSpec{
-				EnableResponseHeaders: true,
-				SelectorLabels:        map[string]string{"app": "test"},
-				Local: ratelimitv1alpha1.LocalConfig{
-					DefaultBucket: ratelimitv1alpha1.BucketSpec{
-						MaxTokens:     20,
-						TokensPerFill: 20,
-						FillInterval:  &metav1.Duration{Duration: time.Minute * 5},
-					},
-				},
-			}}
-		Expect(c.Create(ctx, rl)).Should(Succeed())
-		Expect(rl.Name).ShouldNot(BeEmpty())
-		Eventually(func() string {
-			Expect(c.Get(ctx, ctrlclient.ObjectKeyFromObject(rl), rl)).Should(Succeed())
-			return rl.Status.State
-		}).Should(Equal("Error"))
-	})
-	It("should reconcile RateLimit Status to Ready state when resource is created", func() {
-		namespace := ns.Name
-		By("Creating test pod")
-		pod := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-pod",
-				Namespace: namespace,
-				Annotations: map[string]string{
-					"sidecar.istio.io/status": "",
-				},
-				Labels: map[string]string{
-					"app": "test",
-				},
-			},
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name:  "test",
-						Image: "busybox",
-					},
-				}}}
-		Expect(c.Create(ctx, pod)).Should(Succeed())
 
-		By("Creating RateLimit resource")
-		rl := &ratelimitv1alpha1.RateLimit{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "rate-limit-",
-				Namespace:    namespace,
-			},
-			Spec: ratelimitv1alpha1.RateLimitSpec{
-				EnableResponseHeaders: true,
-				SelectorLabels:        map[string]string{"app": "test"},
-				Local: ratelimitv1alpha1.LocalConfig{
-					DefaultBucket: ratelimitv1alpha1.BucketSpec{
-						MaxTokens:     20,
-						TokensPerFill: 20,
-						FillInterval:  &metav1.Duration{Duration: time.Minute * 5},
-					},
-				},
-			}}
-		Expect(c.Create(ctx, rl)).Should(Succeed())
-		Expect(rl.Name).ShouldNot(BeEmpty())
-		Eventually(func() string {
-			Expect(c.Get(ctx, ctrlclient.ObjectKeyFromObject(rl), rl)).Should(Succeed())
-			return rl.Status.State
-		}).Should(Equal("Ready"))
+		Expect(c.Create(ctx, apigateway)).Should(Succeed())
+		Expect(apigateway.Name).ToNot(BeEmpty())
 
-		By("Checking that EnvoyFilter got created")
-		ef := &networkingv1alpha3.EnvoyFilter{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      rl.Name,
-				Namespace: rl.Namespace,
-			},
-		}
-		Eventually(c.Get(ctx, ctrlclient.ObjectKeyFromObject(ef), ef)).Should(Succeed())
-		By("Checking the OwnerReference of EnvoyFilter")
-		expectedOwnerReference := metav1.OwnerReference{
-			Kind:               "RateLimit",
-			Name:               rl.Name,
-			UID:                rl.UID,
-			APIVersion:         "gateway.kyma-project.io/v1alpha1",
-			Controller:         ptr.To(true),
-			BlockOwnerDeletion: ptr.To(true),
-		}
-		Expect(ef.OwnerReferences).To(ContainElement(expectedOwnerReference))
+		apigateway.Status.State = apigatewayv1alpha1.Ready
+		Expect(c.Status().Update(ctx, apigateway)).Should(Succeed())
+		Expect(apigateway.Status.State).Should(Equal(apigatewayv1alpha1.Ready))
+	})
 
-	})
-	It("should reconcile state to Ready when RateLimit is modified with new configuration", func() {
-		namespace := ns.Name
-		By("Creating test pod")
-		pod := &corev1.Pod{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-pod",
-				Namespace: namespace,
-				Annotations: map[string]string{
-					"sidecar.istio.io/status": "",
-				},
-				Labels: map[string]string{
-					"app": "test",
-				},
-			},
-			Spec: corev1.PodSpec{
-				Containers: []corev1.Container{
-					{
-						Name:  "test",
-						Image: "busybox",
-					},
-				}}}
-		Expect(c.Create(ctx, pod)).Should(Succeed())
-		By("Creating RateLimit resource")
-		rl := &ratelimitv1alpha1.RateLimit{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "rate-limit-",
-				Namespace:    ns.Name,
-			},
-			Spec: ratelimitv1alpha1.RateLimitSpec{
-				EnableResponseHeaders: false,
-				SelectorLabels:        map[string]string{"app": "test"},
-				Local: ratelimitv1alpha1.LocalConfig{
-					DefaultBucket: ratelimitv1alpha1.BucketSpec{
-						MaxTokens:     20,
-						TokensPerFill: 20,
-						FillInterval:  &metav1.Duration{Duration: time.Minute * 5},
-					},
-				},
-			}}
-		Expect(c.Create(ctx, rl)).Should(Succeed())
-		Expect(rl.Name).ShouldNot(BeEmpty())
-		Eventually(func() string {
-			Expect(c.Get(ctx, ctrlclient.ObjectKeyFromObject(rl), rl)).Should(Succeed())
-			return rl.Status.State
-		}).Should(Equal("Ready"))
-		By("Checking that EnvoyFilter got created")
-		ef := &networkingv1alpha3.EnvoyFilter{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      rl.Name,
-				Namespace: rl.Namespace,
-			},
-		}
-		Eventually(c.Get(ctx, ctrlclient.ObjectKeyFromObject(ef), ef)).Should(Succeed())
-		observedGeneration := ef.Generation
-		By("Modifying RateLimit with 'enableResponseHeaders' set to true")
-		rl.Spec.EnableResponseHeaders = true
-		Expect(c.Update(ctx, rl)).Should(Succeed())
-		Eventually(func() string {
-			Expect(c.Get(ctx, ctrlclient.ObjectKeyFromObject(rl), rl)).Should(Succeed())
-			return rl.Status.State
-		}).Should(Equal("Ready"))
-		By("Checking that EnvoyFilter got updated")
-		Eventually(func() bool {
-			Expect(c.Get(ctx, ctrlclient.ObjectKeyFromObject(ef), ef)).Should(Succeed())
-			return ef.Generation > observedGeneration
-		}).Should(BeTrue())
-	})
-	Context("RateLimit CRD validation", func() {
-		It("should fail if path and headers are empty", func() {
-			namespace := ns.Name
-			By("Creating test pod")
-			pod := &corev1.Pod{
-				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-pod",
-					Namespace: namespace,
-					Annotations: map[string]string{
-						"sidecar.istio.io/status": "",
-					},
-					Labels: map[string]string{
-						"app": "test",
-					},
-				},
-				Spec: corev1.PodSpec{
-					Containers: []corev1.Container{
-						{
-							Name:  "test",
-							Image: "busybox",
-						},
-					}}}
-			Expect(c.Create(ctx, pod)).Should(Succeed())
-			By("Creating RateLimit resource")
-			rl := &ratelimitv1alpha1.RateLimit{
-				ObjectMeta: metav1.ObjectMeta{
-					GenerateName: "rate-limit-",
-					Namespace:    ns.Name,
-				},
-				Spec: ratelimitv1alpha1.RateLimitSpec{
-					EnableResponseHeaders: false,
-					SelectorLabels:        map[string]string{"app": "test"},
-					Local: ratelimitv1alpha1.LocalConfig{
-						DefaultBucket: ratelimitv1alpha1.BucketSpec{
-							MaxTokens:     20,
-							TokensPerFill: 20,
-							FillInterval:  &metav1.Duration{Duration: time.Minute * 5},
-						},
-						Buckets: []ratelimitv1alpha1.BucketConfig{
-							{
-								Bucket: ratelimitv1alpha1.BucketSpec{
-									MaxTokens:     20,
-									TokensPerFill: 20,
-									FillInterval:  &metav1.Duration{Duration: time.Minute * 5},
-								},
-							},
-						},
-					},
-				}}
-			err := c.Create(ctx, rl)
-			Expect(err).ShouldNot(Succeed())
-			Expect(err.Error()).To(ContainSubstring("At least one of 'path' or 'headers' must be set"))
+	When("APIGatewayCR is missing", func() {
+		AfterEach(func() {
+			Expect(c.Delete(ctx, apigateway)).Should(Not(Succeed()))
+
+			Expect(c.Delete(ctx, ns)).Should(Succeed())
 		})
-		It("should pass if path and headers are defined", func() {
+
+		It("should reconcile RateLimitCR Status to Error state when APIGatewayCR is not in the cluster", func() {
 			namespace := ns.Name
+			err := c.Delete(ctx, apigateway)
+			Expect(err).ToNot(HaveOccurred())
+
 			By("Creating test pod")
 			pod := &corev1.Pod{
 				ObjectMeta: metav1.ObjectMeta{
@@ -322,39 +140,144 @@ var _ = Describe("Rate Limit Controller", func() {
 						},
 					}}}
 			Expect(c.Create(ctx, pod)).Should(Succeed())
+
 			By("Creating RateLimit resource")
 			rl := &ratelimitv1alpha1.RateLimit{
 				ObjectMeta: metav1.ObjectMeta{
 					GenerateName: "rate-limit-",
-					Namespace:    ns.Name,
+					Namespace:    namespace,
 				},
 				Spec: ratelimitv1alpha1.RateLimitSpec{
-					EnableResponseHeaders: false,
+					EnableResponseHeaders: true,
 					SelectorLabels:        map[string]string{"app": "test"},
 					Local: ratelimitv1alpha1.LocalConfig{
 						DefaultBucket: ratelimitv1alpha1.BucketSpec{
 							MaxTokens:     20,
 							TokensPerFill: 20,
 							FillInterval:  &metav1.Duration{Duration: time.Minute * 5},
-						},
-						Buckets: []ratelimitv1alpha1.BucketConfig{
-							{
-								Path: "/anything",
-								Headers: map[string]string{
-									"X-Foo": "bar",
-								},
-								Bucket: ratelimitv1alpha1.BucketSpec{
-									MaxTokens:     20,
-									TokensPerFill: 20,
-									FillInterval:  &metav1.Duration{Duration: time.Minute * 5},
-								},
-							},
 						},
 					},
 				}}
 			Expect(c.Create(ctx, rl)).Should(Succeed())
+			Expect(rl.Name).ShouldNot(BeEmpty())
+			Eventually(func() string {
+				Expect(c.Get(ctx, ctrlclient.ObjectKeyFromObject(rl), rl)).Should(Succeed())
+				return rl.Status.State
+			}).Should(Equal("Warning"))
+
+			By("Checking that EnvoyFilter is not created")
+			ef := &networkingv1alpha3.EnvoyFilter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      rl.Name,
+					Namespace: rl.Namespace,
+				},
+			}
+			Eventually(c.Get(ctx, ctrlclient.ObjectKeyFromObject(ef), ef)).Should(Not(Succeed()))
+
 		})
-		It("should pass if only path is defined", func() {
+	})
+
+	When("APIGatewayCR is not missing", func() {
+		AfterEach(func() {
+			Expect(c.Delete(ctx, apigateway)).Should(Succeed())
+
+			Expect(c.Delete(ctx, ns)).Should(Succeed())
+		})
+
+		It("should reconcile RateLimit Status to Error state when validation fails", func() {
+			By("Creating RateLimit resource without matching pods")
+			namespace := ns.Name
+			rl := &ratelimitv1alpha1.RateLimit{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "rate-limit-",
+					Namespace:    namespace,
+				},
+				Spec: ratelimitv1alpha1.RateLimitSpec{
+					EnableResponseHeaders: true,
+					SelectorLabels:        map[string]string{"app": "test"},
+					Local: ratelimitv1alpha1.LocalConfig{
+						DefaultBucket: ratelimitv1alpha1.BucketSpec{
+							MaxTokens:     20,
+							TokensPerFill: 20,
+							FillInterval:  &metav1.Duration{Duration: time.Minute * 5},
+						},
+					},
+				}}
+			Expect(c.Create(ctx, rl)).Should(Succeed())
+			Expect(rl.Name).ShouldNot(BeEmpty())
+			Eventually(func() string {
+				Expect(c.Get(ctx, ctrlclient.ObjectKeyFromObject(rl), rl)).Should(Succeed())
+				return rl.Status.State
+			}).Should(Equal("Error"))
+		})
+		It("should reconcile RateLimit Status to Ready state when resource is created", func() {
+			namespace := ns.Name
+			By("Creating test pod")
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-pod",
+					Namespace: namespace,
+					Annotations: map[string]string{
+						"sidecar.istio.io/status": "",
+					},
+					Labels: map[string]string{
+						"app": "test",
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  "test",
+							Image: "busybox",
+						},
+					}}}
+			Expect(c.Create(ctx, pod)).Should(Succeed())
+
+			By("Creating RateLimit resource")
+			rl := &ratelimitv1alpha1.RateLimit{
+				ObjectMeta: metav1.ObjectMeta{
+					GenerateName: "rate-limit-",
+					Namespace:    namespace,
+				},
+				Spec: ratelimitv1alpha1.RateLimitSpec{
+					EnableResponseHeaders: true,
+					SelectorLabels:        map[string]string{"app": "test"},
+					Local: ratelimitv1alpha1.LocalConfig{
+						DefaultBucket: ratelimitv1alpha1.BucketSpec{
+							MaxTokens:     20,
+							TokensPerFill: 20,
+							FillInterval:  &metav1.Duration{Duration: time.Minute * 5},
+						},
+					},
+				}}
+			Expect(c.Create(ctx, rl)).Should(Succeed())
+			Expect(rl.Name).ShouldNot(BeEmpty())
+			Eventually(func() string {
+				Expect(c.Get(ctx, ctrlclient.ObjectKeyFromObject(rl), rl)).Should(Succeed())
+				return rl.Status.State
+			}).Should(Equal("Ready"))
+
+			By("Checking that EnvoyFilter got created")
+			ef := &networkingv1alpha3.EnvoyFilter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      rl.Name,
+					Namespace: rl.Namespace,
+				},
+			}
+			Eventually(c.Get(ctx, ctrlclient.ObjectKeyFromObject(ef), ef)).Should(Succeed())
+			By("Checking the OwnerReference of EnvoyFilter")
+			expectedOwnerReference := metav1.OwnerReference{
+				Kind:               "RateLimit",
+				Name:               rl.Name,
+				UID:                rl.UID,
+				APIVersion:         "gateway.kyma-project.io/v1alpha1",
+				Controller:         ptr.To(true),
+				BlockOwnerDeletion: ptr.To(true),
+			}
+			Expect(ef.OwnerReferences).To(ContainElement(expectedOwnerReference))
+
+		})
+		It("should reconcile state to Ready when RateLimit is modified with new configuration", func() {
 			namespace := ns.Name
 			By("Creating test pod")
 			pod := &corev1.Pod{
@@ -391,19 +314,194 @@ var _ = Describe("Rate Limit Controller", func() {
 							TokensPerFill: 20,
 							FillInterval:  &metav1.Duration{Duration: time.Minute * 5},
 						},
-						Buckets: []ratelimitv1alpha1.BucketConfig{
-							{
-								Path: "/anything",
-								Bucket: ratelimitv1alpha1.BucketSpec{
-									MaxTokens:     20,
-									TokensPerFill: 20,
-									FillInterval:  &metav1.Duration{Duration: time.Minute * 5},
-								},
-							},
-						},
 					},
 				}}
 			Expect(c.Create(ctx, rl)).Should(Succeed())
+			Expect(rl.Name).ShouldNot(BeEmpty())
+			Eventually(func() string {
+				Expect(c.Get(ctx, ctrlclient.ObjectKeyFromObject(rl), rl)).Should(Succeed())
+				return rl.Status.State
+			}).Should(Equal("Ready"))
+			By("Checking that EnvoyFilter got created")
+			ef := &networkingv1alpha3.EnvoyFilter{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      rl.Name,
+					Namespace: rl.Namespace,
+				},
+			}
+			Eventually(c.Get(ctx, ctrlclient.ObjectKeyFromObject(ef), ef)).Should(Succeed())
+			observedGeneration := ef.Generation
+			By("Modifying RateLimit with 'enableResponseHeaders' set to true")
+			rl.Spec.EnableResponseHeaders = true
+			Expect(c.Update(ctx, rl)).Should(Succeed())
+			Eventually(func() string {
+				Expect(c.Get(ctx, ctrlclient.ObjectKeyFromObject(rl), rl)).Should(Succeed())
+				return rl.Status.State
+			}).Should(Equal("Ready"))
+			By("Checking that EnvoyFilter got updated")
+			Eventually(func() bool {
+				Expect(c.Get(ctx, ctrlclient.ObjectKeyFromObject(ef), ef)).Should(Succeed())
+				return ef.Generation > observedGeneration
+			}).Should(BeTrue())
+		})
+		Context("RateLimit CRD validation", func() {
+			It("should fail if path and headers are empty", func() {
+				namespace := ns.Name
+				By("Creating test pod")
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: namespace,
+						Annotations: map[string]string{
+							"sidecar.istio.io/status": "",
+						},
+						Labels: map[string]string{
+							"app": "test",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "test",
+								Image: "busybox",
+							},
+						}}}
+				Expect(c.Create(ctx, pod)).Should(Succeed())
+				By("Creating RateLimit resource")
+				rl := &ratelimitv1alpha1.RateLimit{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "rate-limit-",
+						Namespace:    ns.Name,
+					},
+					Spec: ratelimitv1alpha1.RateLimitSpec{
+						EnableResponseHeaders: false,
+						SelectorLabels:        map[string]string{"app": "test"},
+						Local: ratelimitv1alpha1.LocalConfig{
+							DefaultBucket: ratelimitv1alpha1.BucketSpec{
+								MaxTokens:     20,
+								TokensPerFill: 20,
+								FillInterval:  &metav1.Duration{Duration: time.Minute * 5},
+							},
+							Buckets: []ratelimitv1alpha1.BucketConfig{
+								{
+									Bucket: ratelimitv1alpha1.BucketSpec{
+										MaxTokens:     20,
+										TokensPerFill: 20,
+										FillInterval:  &metav1.Duration{Duration: time.Minute * 5},
+									},
+								},
+							},
+						},
+					}}
+				err := c.Create(ctx, rl)
+				Expect(err).ShouldNot(Succeed())
+				Expect(err.Error()).To(ContainSubstring("At least one of 'path' or 'headers' must be set"))
+			})
+			It("should pass if path and headers are defined", func() {
+				namespace := ns.Name
+				By("Creating test pod")
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: namespace,
+						Annotations: map[string]string{
+							"sidecar.istio.io/status": "",
+						},
+						Labels: map[string]string{
+							"app": "test",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "test",
+								Image: "busybox",
+							},
+						}}}
+				Expect(c.Create(ctx, pod)).Should(Succeed())
+				By("Creating RateLimit resource")
+				rl := &ratelimitv1alpha1.RateLimit{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "rate-limit-",
+						Namespace:    ns.Name,
+					},
+					Spec: ratelimitv1alpha1.RateLimitSpec{
+						EnableResponseHeaders: false,
+						SelectorLabels:        map[string]string{"app": "test"},
+						Local: ratelimitv1alpha1.LocalConfig{
+							DefaultBucket: ratelimitv1alpha1.BucketSpec{
+								MaxTokens:     20,
+								TokensPerFill: 20,
+								FillInterval:  &metav1.Duration{Duration: time.Minute * 5},
+							},
+							Buckets: []ratelimitv1alpha1.BucketConfig{
+								{
+									Path: "/anything",
+									Headers: map[string]string{
+										"X-Foo": "bar",
+									},
+									Bucket: ratelimitv1alpha1.BucketSpec{
+										MaxTokens:     20,
+										TokensPerFill: 20,
+										FillInterval:  &metav1.Duration{Duration: time.Minute * 5},
+									},
+								},
+							},
+						},
+					}}
+				Expect(c.Create(ctx, rl)).Should(Succeed())
+			})
+			It("should pass if only path is defined", func() {
+				namespace := ns.Name
+				By("Creating test pod")
+				pod := &corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-pod",
+						Namespace: namespace,
+						Annotations: map[string]string{
+							"sidecar.istio.io/status": "",
+						},
+						Labels: map[string]string{
+							"app": "test",
+						},
+					},
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:  "test",
+								Image: "busybox",
+							},
+						}}}
+				Expect(c.Create(ctx, pod)).Should(Succeed())
+				By("Creating RateLimit resource")
+				rl := &ratelimitv1alpha1.RateLimit{
+					ObjectMeta: metav1.ObjectMeta{
+						GenerateName: "rate-limit-",
+						Namespace:    ns.Name,
+					},
+					Spec: ratelimitv1alpha1.RateLimitSpec{
+						EnableResponseHeaders: false,
+						SelectorLabels:        map[string]string{"app": "test"},
+						Local: ratelimitv1alpha1.LocalConfig{
+							DefaultBucket: ratelimitv1alpha1.BucketSpec{
+								MaxTokens:     20,
+								TokensPerFill: 20,
+								FillInterval:  &metav1.Duration{Duration: time.Minute * 5},
+							},
+							Buckets: []ratelimitv1alpha1.BucketConfig{
+								{
+									Path: "/anything",
+									Bucket: ratelimitv1alpha1.BucketSpec{
+										MaxTokens:     20,
+										TokensPerFill: 20,
+										FillInterval:  &metav1.Duration{Duration: time.Minute * 5},
+									},
+								},
+							},
+						},
+					}}
+				Expect(c.Create(ctx, rl)).Should(Succeed())
+			})
 		})
 	})
 })
@@ -414,6 +512,7 @@ func getTestScheme() *runtime.Scheme {
 	Expect(apiextensionsv1.AddToScheme(s)).Should(Succeed())
 	Expect(networkingv1alpha3.AddToScheme(s)).Should(Succeed())
 	Expect(ratelimitv1alpha1.AddToScheme(s)).Should(Succeed())
+	Expect(apigatewayv1alpha1.AddToScheme(s)).Should(Succeed())
 	return s
 }
 

--- a/controllers/operator/apigateway_controller.go
+++ b/controllers/operator/apigateway_controller.go
@@ -103,7 +103,8 @@ func (r *APIGatewayReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	if len(existingAPIGateways.Items) > 1 {
-		oldestCr := r.getOldestCR(existingAPIGateways)
+		oldestCr := operatorv1alpha1.GetOldestAPIGatewayCR(existingAPIGateways)
+
 		if apiGatewayCR.GetUID() != oldestCr.GetUID() {
 			err := fmt.Errorf("stopped APIGateway CR reconciliation: only APIGateway CR %s reconciles the module", oldestCr.GetName())
 			return r.terminateReconciliation(ctx, apiGatewayCR, controllers.WarningStatus(err, err.Error(), conditions.OlderCRExists.Condition()))
@@ -352,16 +353,4 @@ func removeFinalizer(ctx context.Context, apiClient client.Client, apiGatewayCR 
 		ctrl.Log.Info("Successfully removed API-Gateway CR finalizer")
 		return nil
 	})
-}
-
-func (r *APIGatewayReconciler) getOldestCR(apigatewayCRs *operatorv1alpha1.APIGatewayList) *operatorv1alpha1.APIGateway {
-	oldest := apigatewayCRs.Items[0]
-	for _, item := range apigatewayCRs.Items {
-		timestamp := &item.CreationTimestamp
-		if !(oldest.CreationTimestamp.Before(timestamp)) {
-			oldest = item
-		}
-	}
-
-	return &oldest
 }

--- a/controllers/operator/apigateway_controller.go
+++ b/controllers/operator/apigateway_controller.go
@@ -19,10 +19,15 @@ package operator
 import (
 	"context"
 	"fmt"
-	"github.com/kyma-project/api-gateway/internal/conditions"
-	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"strings"
 	"time"
+
+	"github.com/kyma-project/api-gateway/internal/conditions"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
 
 	oryv1alpha1 "github.com/ory/oathkeeper-maester/api/v1alpha1"
 
@@ -38,6 +43,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -46,9 +52,11 @@ import (
 )
 
 const (
-	APIGatewayResourceListDefaultPath       = "manifests/controlled_resources_list.yaml"
-	ApiGatewayFinalizer                     = "gateways.operator.kyma-project.io/api-gateway"
-	defaultApiGatewayReconciliationInterval = time.Hour * 10
+	APIGatewayResourceListDefaultPath = "manifests/controlled_resources_list.yaml"
+	ApiGatewayFinalizer               = "gateways.operator.kyma-project.io/api-gateway"
+	//defaultApiGatewayReconciliationInterval = time.Hour * 10
+	// Temporarily reduced the interval to 1 hour to make sure that NLB migration does
+	defaultApiGatewayReconciliationInterval = time.Hour
 )
 
 func NewAPIGatewayReconciler(mgr manager.Manager, oathkeeperReconciler ReadyVerifyingReconciler) *APIGatewayReconciler {
@@ -149,8 +157,28 @@ func handleDependenciesError(name string, err error) controllers.Status {
 // SetupWithManager sets up the controller with the Manager.
 func (r *APIGatewayReconciler) SetupWithManager(mgr ctrl.Manager, c controllers.RateLimiterConfig) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&operatorv1alpha1.APIGateway{}).
-		WithEventFilter(predicate.GenerationChangedPredicate{}).
+		For(&operatorv1alpha1.APIGateway{}, builder.WithPredicates(predicate.GenerationChangedPredicate{})).
+		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+			if obj.GetNamespace() != "istio-system" {
+				return nil
+			}
+
+			if obj.GetName() != "istio-ingressgateway" {
+				return nil
+			}
+
+			apiGatewayList := &operatorv1alpha1.APIGatewayList{}
+			if err := r.Client.List(ctx, apiGatewayList); err != nil {
+				return nil
+			}
+
+			apiGateway := operatorv1alpha1.GetOldestAPIGatewayCR(apiGatewayList)
+			if apiGateway == nil {
+				return nil
+			}
+
+			return []reconcile.Request{{NamespacedName: types.NamespacedName{Namespace: apiGateway.Namespace, Name: apiGateway.Name}}}
+		})).
 		WithOptions(controller.Options{
 			RateLimiter: controllers.NewRateLimiter(c),
 		}).

--- a/sec-scanners-config.yaml
+++ b/sec-scanners-config.yaml
@@ -1,6 +1,6 @@
 module-name: api-gateway
 protecode:
-  - europe-docker.pkg.dev/kyma-project/prod/api-gateway/releases/api-gateway-manager:2.11.2
+  - europe-docker.pkg.dev/kyma-project/prod/api-gateway/releases/api-gateway-manager:2.11.3
   - europe-docker.pkg.dev/kyma-project/prod/external/oryd/oathkeeper:v0.38.25-beta.1
   - europe-docker.pkg.dev/kyma-project/prod/external/oryd/oathkeeper-maester:v0.1.5
 whitesource:


### PR DESCRIPTION
* Enable watch for istio-ingressgateway service

* Move api gateway fetch to else

* Fix issue with re-reconcile

* Schedule api-gateway reconcile in predicate

* Delete controllers/operator/ingress_gateway_watch.go

* Add unit test

* Adjust test to check dns entry adjustment

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Cherry pick https://github.com/kyma-project/api-gateway/pull/1759

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
