### PR TITLE
feat: enhance APIRule v1beta1 conversion with original version annotations, alternative version

### DIFF
--- a/apis/gateway/v2/apirule_conversion.go
+++ b/apis/gateway/v2/apirule_conversion.go
@@ -214,11 +214,7 @@ func (apiRule *APIRule) ConvertFrom(hub conversion.Hub) error {
 		}
 	}
 
-	err := convertOverJson(apiRuleBeta1.Spec.Rules, &apiRule.Spec.Rules)
-	if err != nil {
-		return err
-	}
-	err = convertOverJson(apiRuleBeta1.Spec.Gateway, &apiRule.Spec.Gateway)
+	err := convertOverJson(apiRuleBeta1.Spec.Gateway, &apiRule.Spec.Gateway)
 	if err != nil {
 		return err
 	}

--- a/apis/gateway/v2/apirule_conversion.go
+++ b/apis/gateway/v2/apirule_conversion.go
@@ -195,8 +195,8 @@ func (apiRule *APIRule) ConvertFrom(hub conversion.Hub) error {
 
 	// if "v2", "v2alpha1" we are sure that resource is v2
 	if !isV2OriginalVersion(apiRuleBeta1) {
-		if apiRuleBeta1.Annotations == nil {
-			apiRuleBeta1.Annotations = make(map[string]string)
+		if apiRule.Annotations == nil {
+			apiRule.Annotations = make(map[string]string)
 		}
 		marshaledSpec, err := json.Marshal(apiRuleBeta1.Spec)
 		if err != nil {

--- a/apis/gateway/v2/apirule_conversion.go
+++ b/apis/gateway/v2/apirule_conversion.go
@@ -322,6 +322,9 @@ func (apiRule *APIRule) ConvertFrom(hub conversion.Hub) error {
 }
 
 func isV2OriginalVersion(apiRule *v1beta1.APIRule) bool {
+	if apiRule.Annotations == nil {
+		return false
+	}
 	if originalVersion, ok := apiRule.Annotations[originalVersionAnnotationKey]; ok && slices.Contains([]string{"v2alpha1", "v2"}, originalVersion) {
 		return true
 	}

--- a/apis/gateway/v2/apirule_conversion.go
+++ b/apis/gateway/v2/apirule_conversion.go
@@ -3,7 +3,6 @@ package v2
 import (
 	"encoding/json"
 
-	"regexp"
 	"slices"
 	"time"
 
@@ -371,10 +370,4 @@ func isFullConversionPossible(apiRule *v1beta1.APIRule) (bool, error) {
 	}
 
 	return true, nil
-}
-
-func isConvertiblePath(path string) bool {
-	validIstioPathPattern := `^((\/([A-Za-z0-9-._~!$&'()+,;=:@]|%[0-9a-fA-F]{2})*)|(\/\{\*{1,2}\}))+$|^\/\*$`
-	validPathRegex := regexp.MustCompile(validIstioPathPattern)
-	return validPathRegex.MatchString(path)
 }

--- a/apis/gateway/v2/apirule_conversion.go
+++ b/apis/gateway/v2/apirule_conversion.go
@@ -210,7 +210,7 @@ func (apiRule *APIRule) ConvertFrom(hub conversion.Hub) error {
 			return err
 		}
 		if !conversionPossible {
-			// if conversion is not possible, we end conversion with an empty spec, this will not
+			// if conversion is not possible, we end conversion with an empty spec
 			return nil
 		}
 	}

--- a/apis/gateway/v2/apirule_conversion.go
+++ b/apis/gateway/v2/apirule_conversion.go
@@ -253,15 +253,20 @@ func (apiRule *APIRule) ConvertFrom(hub conversion.Hub) error {
 		apiRule.Spec.Hosts = []*Host{new(Host)}
 		*apiRule.Spec.Hosts[0] = Host(*apiRuleBeta1.Spec.Host)
 	}
+	if apiRuleBeta1.Annotations != nil {
+		if annotation, ok := apiRuleBeta1.Annotations[v2RulesAnnotationKey]; ok {
 
-	if annotation, ok := apiRuleBeta1.Annotations[v2RulesAnnotationKey]; ok {
-		var v2Rules []Rule
-		err := json.Unmarshal([]byte(annotation), &v2Rules)
-		if err != nil {
-			return err
+			var v2Rules []Rule
+			err := json.Unmarshal([]byte(annotation), &v2Rules)
+			if err != nil {
+				return err
+			}
+
+			apiRule.Spec.Rules = v2Rules
+			return nil
 		}
-		apiRule.Spec.Rules = v2Rules
-	} else if len(apiRuleBeta1.Spec.Rules) > 0 {
+	}
+	if len(apiRuleBeta1.Spec.Rules) > 0 {
 		apiRule.Spec.Rules = []Rule{}
 		for _, ruleBeta1 := range apiRuleBeta1.Spec.Rules {
 			ruleV1Alpha2 := Rule{}

--- a/apis/gateway/v2/apirule_conversion_test.go
+++ b/apis/gateway/v2/apirule_conversion_test.go
@@ -435,6 +435,7 @@ var _ = Describe("APIRule Conversion", func() {
 					Host: &host1string,
 					Rules: []v1beta1.Rule{
 						{
+							Path: "/path1",
 							AccessStrategies: []*v1beta1.Authenticator{
 								{
 									Handler: &v1beta1.Handler{
@@ -455,6 +456,34 @@ var _ = Describe("APIRule Conversion", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(apiRuleV2.Spec.Rules).To(HaveLen(1))
 			Expect(*apiRuleV2.Spec.Rules[0].NoAuth).To(BeTrue())
+		})
+		It("should not convert NoAuth to v2 when path is regex", func() {
+			// given
+			apiRuleBeta1 := v1beta1.APIRule{
+				Spec: v1beta1.APIRuleSpec{
+					Host: &host1string,
+					Rules: []v1beta1.Rule{
+						{
+							Path: "/.*",
+							AccessStrategies: []*v1beta1.Authenticator{
+								{
+									Handler: &v1beta1.Handler{
+										Name: "no_auth",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			apiRuleV2 := v2.APIRule{}
+
+			// when
+			err := apiRuleV2.ConvertFrom(&apiRuleBeta1)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(apiRuleV2.Spec.Rules).To(HaveLen(0))
 		})
 
 		It("should convert rule with nested data to v2", func() {
@@ -501,6 +530,7 @@ var _ = Describe("APIRule Conversion", func() {
 					Host: &host1string,
 					Rules: []v1beta1.Rule{
 						{
+							Path: "/path1",
 							AccessStrategies: []*v1beta1.Authenticator{
 								{
 									Handler: &v1beta1.Handler{
@@ -510,6 +540,7 @@ var _ = Describe("APIRule Conversion", func() {
 							},
 						},
 						{
+							Path: "/path2",
 							AccessStrategies: []*v1beta1.Authenticator{
 								{
 									Handler: &v1beta1.Handler{
@@ -574,6 +605,7 @@ var _ = Describe("APIRule Conversion", func() {
 						Host: &host1string,
 						Rules: []v1beta1.Rule{
 							{
+								Path: "/path1",
 								AccessStrategies: []*v1beta1.Authenticator{
 									{
 										Handler: &v1beta1.Handler{
@@ -623,6 +655,7 @@ var _ = Describe("APIRule Conversion", func() {
 						Host: &host1string,
 						Rules: []v1beta1.Rule{
 							{
+								Path: "/path1",
 								AccessStrategies: []*v1beta1.Authenticator{
 									{
 										Handler: &v1beta1.Handler{
@@ -666,6 +699,7 @@ var _ = Describe("APIRule Conversion", func() {
 						Host: &host1string,
 						Rules: []v1beta1.Rule{
 							{
+								Path: "/path1",
 								AccessStrategies: []*v1beta1.Authenticator{
 									{
 										Handler: &v1beta1.Handler{
@@ -723,6 +757,7 @@ var _ = Describe("APIRule Conversion", func() {
 						Host: &host1string,
 						Rules: []v1beta1.Rule{
 							{
+								Path: "/path1",
 								AccessStrategies: []*v1beta1.Authenticator{
 									{
 										Handler: &v1beta1.Handler{

--- a/apis/gateway/v2/path_conversion.go
+++ b/apis/gateway/v2/path_conversion.go
@@ -1,0 +1,12 @@
+package v2
+
+import "regexp"
+
+const istioValidPathRegex = `^((\/([A-Za-z0-9-._~!$&'()+,;=:@]|%[0-9a-fA-F]{2})*)|(\/\{\*{1,2}\}))+$|^\/\*$`
+
+// isConvertiblePath checks if the path is convertible to Istio VirtualService path compatible format
+// this regex allows one exception: /* which is translated in module to be equal /{**}
+func isConvertiblePath(path string) bool {
+	validPathRegex := regexp.MustCompile(istioValidPathRegex)
+	return validPathRegex.MatchString(path)
+}

--- a/apis/gateway/v2/path_conversion.go
+++ b/apis/gateway/v2/path_conversion.go
@@ -4,9 +4,10 @@ import "regexp"
 
 const istioValidPathRegex = `^((\/([A-Za-z0-9-._~!$&'()+,;=:@]|%[0-9a-fA-F]{2})*)|(\/\{\*{1,2}\}))+$|^\/\*$`
 
+var validPathRegex = regexp.MustCompile(istioValidPathRegex)
+
 // isConvertiblePath checks if the path is convertible to Istio VirtualService path compatible format
 // this regex allows one exception: /* which is translated in module to be equal /{**}
 func isConvertiblePath(path string) bool {
-	validPathRegex := regexp.MustCompile(istioValidPathRegex)
 	return validPathRegex.MatchString(path)
 }

--- a/apis/gateway/v2alpha1/apirule_conversion.go
+++ b/apis/gateway/v2alpha1/apirule_conversion.go
@@ -194,8 +194,8 @@ func (apiRuleV2Alpha1 *APIRule) ConvertFrom(hub conversion.Hub) error {
 
 	// if "v2", "v2alpha1" we are sure that resource is v2
 	if !isV2OriginalVersion(apiRuleBeta1) {
-		if apiRuleBeta1.Annotations == nil {
-			apiRuleBeta1.Annotations = make(map[string]string)
+		if apiRuleV2Alpha1.Annotations == nil {
+			apiRuleV2Alpha1.Annotations = make(map[string]string)
 		}
 		marshaledSpec, err := json.Marshal(apiRuleBeta1.Spec)
 		if err != nil {

--- a/apis/gateway/v2alpha1/apirule_conversion.go
+++ b/apis/gateway/v2alpha1/apirule_conversion.go
@@ -2,7 +2,6 @@ package v2alpha1
 
 import (
 	"encoding/json"
-	"regexp"
 	"slices"
 	"time"
 
@@ -367,10 +366,4 @@ func isFullConversionPossible(apiRule *v1beta1.APIRule) (bool, error) {
 	}
 
 	return true, nil
-}
-
-func isConvertiblePath(path string) bool {
-	validIstioPathPattern := `^((\/([A-Za-z0-9-._~!$&'()+,;=:@]|%[0-9a-fA-F]{2})*)|(\/\{\*{1,2}\}))+$|^\/\*$`
-	validPathRegex := regexp.MustCompile(validIstioPathPattern)
-	return validPathRegex.MatchString(path)
 }

--- a/apis/gateway/v2alpha1/apirule_conversion.go
+++ b/apis/gateway/v2alpha1/apirule_conversion.go
@@ -208,7 +208,7 @@ func (apiRuleV2Alpha1 *APIRule) ConvertFrom(hub conversion.Hub) error {
 			return err
 		}
 		if !conversionPossible {
-			// if conversion is not possible, we end conversion with an empty spec, this will not
+			// if conversion is not possible, we end conversion with an empty spec
 			return nil
 		}
 	}

--- a/apis/gateway/v2alpha1/apirule_conversion.go
+++ b/apis/gateway/v2alpha1/apirule_conversion.go
@@ -323,6 +323,9 @@ func (apiRuleV2Alpha1 *APIRule) ConvertFrom(hub conversion.Hub) error {
 }
 
 func isV2OriginalVersion(apiRule *v1beta1.APIRule) bool {
+	if apiRule.Annotations == nil {
+		return false
+	}
 	if originalVersion, ok := apiRule.Annotations[originalVersionAnnotationKey]; ok && slices.Contains([]string{"v2alpha1", "v2"}, originalVersion) {
 		return true
 	}

--- a/apis/gateway/v2alpha1/apirule_conversion.go
+++ b/apis/gateway/v2alpha1/apirule_conversion.go
@@ -249,15 +249,20 @@ func (apiRuleV2Alpha1 *APIRule) ConvertFrom(hub conversion.Hub) error {
 		*apiRuleV2Alpha1.Spec.Hosts[0] = Host(*apiRuleBeta1.Spec.Host)
 	}
 	// is v2alpha1 or v2
-	if annotation, ok := apiRuleBeta1.Annotations[v2alpha1RulesAnnotationKey]; ok {
-		var v2alpha1Rules []Rule
-		err := json.Unmarshal([]byte(annotation), &v2alpha1Rules)
-		if err != nil {
-			return err
-		}
+	if apiRuleBeta1.Annotations != nil {
+		if annotation, ok := apiRuleBeta1.Annotations[v2alpha1RulesAnnotationKey]; ok {
 
-		apiRuleV2Alpha1.Spec.Rules = v2alpha1Rules
-	} else if len(apiRuleBeta1.Spec.Rules) > 0 {
+			var v2alpha1Rules []Rule
+			err := json.Unmarshal([]byte(annotation), &v2alpha1Rules)
+			if err != nil {
+				return err
+			}
+
+			apiRuleV2Alpha1.Spec.Rules = v2alpha1Rules
+			return nil
+		}
+	}
+	if len(apiRuleBeta1.Spec.Rules) > 0 {
 		// is v1beta1 and is convertible
 		apiRuleV2Alpha1.Spec.Rules = []Rule{}
 		for _, ruleBeta1 := range apiRuleBeta1.Spec.Rules {

--- a/apis/gateway/v2alpha1/apirule_conversion.go
+++ b/apis/gateway/v2alpha1/apirule_conversion.go
@@ -2,11 +2,13 @@ package v2alpha1
 
 import (
 	"encoding/json"
-	"k8s.io/apimachinery/pkg/runtime"
+	"regexp"
+	"slices"
 	"time"
 
 	"github.com/kyma-project/api-gateway/apis/gateway/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/conversion"
 )
@@ -32,7 +34,11 @@ func convertMap(m map[v1beta1.StatusCode]State) map[State]v1beta1.StatusCode {
 // The 2 => 1 map is generated automatically based on 1 => 2 map
 var alpha1to1beta1statusConversionMap = convertMap(beta1toV2alpha1StatusConversionMap)
 
-const v2alpha1RulesAnnotationKey = "gateway.kyma-project.io/v2alpha1-rules"
+const (
+	v2alpha1RulesAnnotationKey   = "gateway.kyma-project.io/v2alpha1-rules"
+	originalVersionAnnotationKey = "gateway.kyma-project.io/original-version"
+	v1beta1SpecAnnotationKey     = "gateway.kyma-project.io/v1beta1-spec"
+)
 
 // ConvertTo Converts this ApiRule (v2alpha1) to the Hub version (v1beta1)
 func (apiRuleV2Alpha1 *APIRule) ConvertTo(hub conversion.Hub) error {
@@ -42,7 +48,7 @@ func (apiRuleV2Alpha1 *APIRule) ConvertTo(hub conversion.Hub) error {
 	if apiRuleBeta1.Annotations == nil {
 		apiRuleBeta1.Annotations = make(map[string]string)
 	}
-	apiRuleBeta1.Annotations["gateway.kyma-project.io/original-version"] = "v2alpha1"
+	apiRuleBeta1.Annotations[originalVersionAnnotationKey] = "v2alpha1"
 
 	err := convertOverJson(apiRuleV2Alpha1.Spec.Rules, &apiRuleBeta1.Spec.Rules)
 	if err != nil {
@@ -172,7 +178,7 @@ func (apiRuleV2Alpha1 *APIRule) ConvertTo(hub conversion.Hub) error {
 	return nil
 }
 
-// Converts from the Hub version (v1beta1) into this ApiRule (v2alpha1)
+// ConvertFrom Converts from the Hub version (v1beta1) into this ApiRule (v2alpha1)
 func (apiRuleV2Alpha1 *APIRule) ConvertFrom(hub conversion.Hub) error {
 	apiRuleBeta1 := hub.(*v1beta1.APIRule)
 
@@ -186,20 +192,29 @@ func (apiRuleV2Alpha1 *APIRule) ConvertFrom(hub conversion.Hub) error {
 		}
 	}
 
-	conversionPossible, err := isFullConversionPossible(apiRuleBeta1)
-	if err != nil {
-		return err
-	}
-	if !conversionPossible {
-		// We have to stop the conversion here, because we want to return an empty Spec in case we cannot fully convert the APIRule.
-		return nil
+	// if "v2", "v2alpha1" we are sure that resource is v2
+	if !isV2OriginalVersion(apiRuleBeta1) {
+		if apiRuleBeta1.Annotations == nil {
+			apiRuleBeta1.Annotations = make(map[string]string)
+		}
+		marshaledSpec, err := json.Marshal(apiRuleBeta1.Spec)
+		if err != nil {
+			return err
+		}
+		// we set the original version to v1beta1 to indicate that this APIRule is v1beta1
+		apiRuleV2Alpha1.Annotations[originalVersionAnnotationKey] = "v1beta1"
+		apiRuleV2Alpha1.Annotations[v1beta1SpecAnnotationKey] = string(marshaledSpec)
+		conversionPossible, err := isFullConversionPossible(apiRuleBeta1)
+		if err != nil {
+			return err
+		}
+		if !conversionPossible {
+			// if conversion is not possible, we end conversion with an empty spec, this will not
+			return nil
+		}
 	}
 
-	err = convertOverJson(apiRuleBeta1.Spec.Rules, &apiRuleV2Alpha1.Spec.Rules)
-	if err != nil {
-		return err
-	}
-	err = convertOverJson(apiRuleBeta1.Spec.Gateway, &apiRuleV2Alpha1.Spec.Gateway)
+	err := convertOverJson(apiRuleBeta1.Spec.Gateway, &apiRuleV2Alpha1.Spec.Gateway)
 	if err != nil {
 		return err
 	}
@@ -234,7 +249,7 @@ func (apiRuleV2Alpha1 *APIRule) ConvertFrom(hub conversion.Hub) error {
 		apiRuleV2Alpha1.Spec.Hosts = []*Host{new(Host)}
 		*apiRuleV2Alpha1.Spec.Hosts[0] = Host(*apiRuleBeta1.Spec.Host)
 	}
-
+	// is v2alpha1 or v2
 	if annotation, ok := apiRuleBeta1.Annotations[v2alpha1RulesAnnotationKey]; ok {
 		var v2alpha1Rules []Rule
 		err := json.Unmarshal([]byte(annotation), &v2alpha1Rules)
@@ -244,16 +259,17 @@ func (apiRuleV2Alpha1 *APIRule) ConvertFrom(hub conversion.Hub) error {
 
 		apiRuleV2Alpha1.Spec.Rules = v2alpha1Rules
 	} else if len(apiRuleBeta1.Spec.Rules) > 0 {
+		// is v1beta1 and is convertible
 		apiRuleV2Alpha1.Spec.Rules = []Rule{}
 		for _, ruleBeta1 := range apiRuleBeta1.Spec.Rules {
-			ruleV1Alpha2 := Rule{}
-			err = convertOverJson(ruleBeta1, &ruleV1Alpha2)
+			ruleV2Alpha1 := Rule{}
+			err = convertOverJson(ruleBeta1, &ruleV2Alpha1)
 			if err != nil {
 				return err
 			}
 			for _, accessStrategy := range ruleBeta1.AccessStrategies {
 				if accessStrategy.Name == v1beta1.AccessStrategyNoAuth {
-					ruleV1Alpha2.NoAuth = ptr.To(true)
+					ruleV2Alpha1.NoAuth = ptr.To(true)
 				}
 
 				if accessStrategy.Name == v1beta1.AccessStrategyJwt {
@@ -261,7 +277,7 @@ func (apiRuleV2Alpha1 *APIRule) ConvertFrom(hub conversion.Hub) error {
 					if err != nil {
 						return err
 					}
-					err = convertOverJson(jwtConfig, &ruleV1Alpha2.Jwt)
+					err = convertOverJson(jwtConfig, &ruleV2Alpha1.Jwt)
 					if err != nil {
 						return err
 					}
@@ -269,7 +285,7 @@ func (apiRuleV2Alpha1 *APIRule) ConvertFrom(hub conversion.Hub) error {
 			}
 
 			if ruleBeta1.Mutators != nil {
-				ruleV1Alpha2.Request = &Request{}
+				ruleV2Alpha1.Request = &Request{}
 			}
 
 			for _, mutator := range ruleBeta1.Mutators {
@@ -282,7 +298,7 @@ func (apiRuleV2Alpha1 *APIRule) ConvertFrom(hub conversion.Hub) error {
 						return err
 					}
 
-					ruleV1Alpha2.Request.Headers = configStruct
+					ruleV2Alpha1.Request.Headers = configStruct
 				case v1beta1.CookieMutator:
 					var configStruct map[string]string
 
@@ -291,15 +307,22 @@ func (apiRuleV2Alpha1 *APIRule) ConvertFrom(hub conversion.Hub) error {
 						return err
 					}
 
-					ruleV1Alpha2.Request.Cookies = configStruct
+					ruleV2Alpha1.Request.Cookies = configStruct
 				}
 			}
-			apiRuleV2Alpha1.Spec.Rules = append(apiRuleV2Alpha1.Spec.Rules, ruleV1Alpha2)
+			apiRuleV2Alpha1.Spec.Rules = append(apiRuleV2Alpha1.Spec.Rules, ruleV2Alpha1)
 		}
 
 	}
 
 	return nil
+}
+
+func isV2OriginalVersion(apiRule *v1beta1.APIRule) bool {
+	if originalVersion, ok := apiRule.Annotations[originalVersionAnnotationKey]; ok && slices.Contains([]string{"v2alpha1", "v2"}, originalVersion) {
+		return true
+	}
+	return false
 }
 
 func convertOverJson(src any, dst any) error {
@@ -316,9 +339,12 @@ func convertOverJson(src any, dst any) error {
 	return nil
 }
 
-// isFullConversionPossible checks if the APIRule can be fully converted to v2alpha1 by evaluating the access strategies.
+// isFullConversionPossible checks if the APIRule can be fully converted to v2alpha1 by evaluating the access strategies and path.
 func isFullConversionPossible(apiRule *v1beta1.APIRule) (bool, error) {
 	for _, rule := range apiRule.Spec.Rules {
+		if !isConvertiblePath(rule.Path) {
+			return false, nil
+		}
 		for _, accessStrategy := range rule.AccessStrategies {
 
 			if accessStrategy.Name == v1beta1.AccessStrategyNoAuth || accessStrategy.Name == "ext-auth" {
@@ -341,4 +367,10 @@ func isFullConversionPossible(apiRule *v1beta1.APIRule) (bool, error) {
 	}
 
 	return true, nil
+}
+
+func isConvertiblePath(path string) bool {
+	validIstioPathPattern := `^((\/([A-Za-z0-9-._~!$&'()+,;=:@]|%[0-9a-fA-F]{2})*)|(\/\{\*{1,2}\}))+$|^\/\*$`
+	validPathRegex := regexp.MustCompile(validIstioPathPattern)
+	return validPathRegex.MatchString(path)
 }

--- a/apis/gateway/v2alpha1/apirule_conversion_test.go
+++ b/apis/gateway/v2alpha1/apirule_conversion_test.go
@@ -435,6 +435,7 @@ var _ = Describe("APIRule Conversion", func() {
 					Host: &host1string,
 					Rules: []v1beta1.Rule{
 						{
+							Path: "/path1",
 							AccessStrategies: []*v1beta1.Authenticator{
 								{
 									Handler: &v1beta1.Handler{
@@ -455,6 +456,35 @@ var _ = Describe("APIRule Conversion", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(apiRuleV2Alpha1.Spec.Rules).To(HaveLen(1))
 			Expect(*apiRuleV2Alpha1.Spec.Rules[0].NoAuth).To(BeTrue())
+		})
+
+		It("should not convert NoAuth to v2 when path is regex", func() {
+			// given
+			apiRuleBeta1 := v1beta1.APIRule{
+				Spec: v1beta1.APIRuleSpec{
+					Host: &host1string,
+					Rules: []v1beta1.Rule{
+						{
+							Path: "/.*",
+							AccessStrategies: []*v1beta1.Authenticator{
+								{
+									Handler: &v1beta1.Handler{
+										Name: "no_auth",
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+			apiRuleV2 := v2alpha1.APIRule{}
+
+			// when
+			err := apiRuleV2.ConvertFrom(&apiRuleBeta1)
+
+			// then
+			Expect(err).ToNot(HaveOccurred())
+			Expect(apiRuleV2.Spec.Rules).To(HaveLen(0))
 		})
 
 		It("should convert rule with nested data to v2alpha1", func() {
@@ -501,6 +531,7 @@ var _ = Describe("APIRule Conversion", func() {
 					Host: &host1string,
 					Rules: []v1beta1.Rule{
 						{
+							Path: "/path1",
 							AccessStrategies: []*v1beta1.Authenticator{
 								{
 									Handler: &v1beta1.Handler{
@@ -510,6 +541,7 @@ var _ = Describe("APIRule Conversion", func() {
 							},
 						},
 						{
+							Path: "/path2",
 							AccessStrategies: []*v1beta1.Authenticator{
 								{
 									Handler: &v1beta1.Handler{
@@ -574,6 +606,7 @@ var _ = Describe("APIRule Conversion", func() {
 						Host: &host1string,
 						Rules: []v1beta1.Rule{
 							{
+								Path: "/secured",
 								AccessStrategies: []*v1beta1.Authenticator{
 									{
 										Handler: &v1beta1.Handler{
@@ -623,6 +656,7 @@ var _ = Describe("APIRule Conversion", func() {
 						Host: &host1string,
 						Rules: []v1beta1.Rule{
 							{
+								Path: "/path1",
 								AccessStrategies: []*v1beta1.Authenticator{
 									{
 										Handler: &v1beta1.Handler{
@@ -666,6 +700,7 @@ var _ = Describe("APIRule Conversion", func() {
 						Host: &host1string,
 						Rules: []v1beta1.Rule{
 							{
+								Path: "/path1",
 								AccessStrategies: []*v1beta1.Authenticator{
 									{
 										Handler: &v1beta1.Handler{
@@ -723,6 +758,7 @@ var _ = Describe("APIRule Conversion", func() {
 						Host: &host1string,
 						Rules: []v1beta1.Rule{
 							{
+								Path: "/path1",
 								AccessStrategies: []*v1beta1.Authenticator{
 									{
 										Handler: &v1beta1.Handler{

--- a/apis/gateway/v2alpha1/path_conversion.go
+++ b/apis/gateway/v2alpha1/path_conversion.go
@@ -1,0 +1,12 @@
+package v2alpha1
+
+import "regexp"
+
+const istioValidPathRegex = `^((\/([A-Za-z0-9-._~!$&'()+,;=:@]|%[0-9a-fA-F]{2})*)|(\/\{\*{1,2}\}))+$|^\/\*$`
+
+// isConvertiblePath checks if the path is convertible to Istio VirtualService path compatible format
+// this regex allows one exception: /* which is translated in module to be equal /{**}
+func isConvertiblePath(path string) bool {
+	validPathRegex := regexp.MustCompile(istioValidPathRegex)
+	return validPathRegex.MatchString(path)
+}

--- a/apis/gateway/v2alpha1/path_conversion.go
+++ b/apis/gateway/v2alpha1/path_conversion.go
@@ -4,9 +4,10 @@ import "regexp"
 
 const istioValidPathRegex = `^((\/([A-Za-z0-9-._~!$&'()+,;=:@]|%[0-9a-fA-F]{2})*)|(\/\{\*{1,2}\}))+$|^\/\*$`
 
+var validPathRegex = regexp.MustCompile(istioValidPathRegex)
+
 // isConvertiblePath checks if the path is convertible to Istio VirtualService path compatible format
 // this regex allows one exception: /* which is translated in module to be equal /{**}
 func isConvertiblePath(path string) bool {
-	validPathRegex := regexp.MustCompile(istioValidPathRegex)
 	return validPathRegex.MatchString(path)
 }


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
To mitigate problem with race condition during update stored version and usage of data from v1beta1 API Rules introduce adding backup spec data to annotation is highly needed

**Changes proposed in this pull request:**
- save original-version annotation without converting `no_auth` and compatible `jwt`  specs to empty spec 
- introduce path compatibility check 

**Pre-Merge Checklist**
- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
#1845  - this PR introduce path compatibility check 

<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
