### PR TITLE
fix: prevent overwriting original version annotation in APIRule v1bet…

### DIFF
--- a/apis/gateway/v2/apirule_conversion.go
+++ b/apis/gateway/v2/apirule_conversion.go
@@ -206,10 +206,11 @@ func (apiRule *APIRule) ConvertFrom(hub conversion.Hub) error {
 			if err != nil {
 				return err
 			}
+			// we set the original version to v1beta1 to indicate that this APIRule is v1beta1
 			apiRule.Annotations[originalVersionAnnotationKey] = "v1beta1"
 			apiRule.Annotations[v1beta1SpecAnnotationKey] = string(marshaledSpec)
 		}
-		// we set the original version to v1beta1 to indicate that this APIRule is v1beta1
+
 		conversionPossible, err := isFullConversionPossible(apiRuleBeta1)
 		if err != nil {
 			return err

--- a/apis/gateway/v2alpha1/apirule_conversion.go
+++ b/apis/gateway/v2alpha1/apirule_conversion.go
@@ -97,6 +97,14 @@ func (apiRuleV2Alpha1 *APIRule) ConvertTo(hub conversion.Hub) error {
 		apiRuleBeta1.Spec.Host = &strHost
 	}
 
+	if _, ok := apiRuleV2Alpha1.Annotations[v1beta1SpecAnnotationKey]; ok && len(apiRuleV2Alpha1.Spec.Rules) == 0 {
+		err = json.Unmarshal([]byte(apiRuleV2Alpha1.Annotations[v1beta1SpecAnnotationKey]), &apiRuleBeta1.Spec)
+		if err != nil {
+			return err
+		}
+		return nil
+	}
+
 	if len(apiRuleV2Alpha1.Spec.Rules) > 0 {
 		marshaledApiRules, err := json.Marshal(apiRuleV2Alpha1.Spec.Rules)
 		if err != nil {

--- a/apis/gateway/v2alpha1/apirule_conversion.go
+++ b/apis/gateway/v2alpha1/apirule_conversion.go
@@ -198,13 +198,16 @@ func (apiRuleV2Alpha1 *APIRule) ConvertFrom(hub conversion.Hub) error {
 		if apiRuleV2Alpha1.Annotations == nil {
 			apiRuleV2Alpha1.Annotations = make(map[string]string)
 		}
-		marshaledSpec, err := json.Marshal(apiRuleBeta1.Spec)
-		if err != nil {
-			return err
+
+		if len(apiRuleBeta1.Spec.Rules) != 0 {
+			marshaledSpec, err := json.Marshal(apiRuleBeta1.Spec)
+			if err != nil {
+				return err
+			}
+			apiRuleV2Alpha1.Annotations[originalVersionAnnotationKey] = "v1beta1"
+			apiRuleV2Alpha1.Annotations[v1beta1SpecAnnotationKey] = string(marshaledSpec)
 		}
 		// we set the original version to v1beta1 to indicate that this APIRule is v1beta1
-		apiRuleV2Alpha1.Annotations[originalVersionAnnotationKey] = "v1beta1"
-		apiRuleV2Alpha1.Annotations[v1beta1SpecAnnotationKey] = string(marshaledSpec)
 		conversionPossible, err := isFullConversionPossible(apiRuleBeta1)
 		if err != nil {
 			return err

--- a/apis/gateway/v2alpha1/apirule_conversion.go
+++ b/apis/gateway/v2alpha1/apirule_conversion.go
@@ -47,7 +47,9 @@ func (apiRuleV2Alpha1 *APIRule) ConvertTo(hub conversion.Hub) error {
 	if apiRuleBeta1.Annotations == nil {
 		apiRuleBeta1.Annotations = make(map[string]string)
 	}
-	apiRuleBeta1.Annotations[originalVersionAnnotationKey] = "v2alpha1"
+	if _, ok := apiRuleBeta1.Annotations[originalVersionAnnotationKey]; !ok {
+		apiRuleBeta1.Annotations[originalVersionAnnotationKey] = "v2alpha1"
+	}
 
 	err := convertOverJson(apiRuleV2Alpha1.Spec.Rules, &apiRuleBeta1.Spec.Rules)
 	if err != nil {

--- a/apis/gateway/v2alpha1/apirule_conversion.go
+++ b/apis/gateway/v2alpha1/apirule_conversion.go
@@ -212,10 +212,11 @@ func (apiRuleV2Alpha1 *APIRule) ConvertFrom(hub conversion.Hub) error {
 			if err != nil {
 				return err
 			}
+			// we set the original version to v1beta1 to indicate that this APIRule is v1beta1
 			apiRuleV2Alpha1.Annotations[originalVersionAnnotationKey] = "v1beta1"
 			apiRuleV2Alpha1.Annotations[v1beta1SpecAnnotationKey] = string(marshaledSpec)
 		}
-		// we set the original version to v1beta1 to indicate that this APIRule is v1beta1
+
 		conversionPossible, err := isFullConversionPossible(apiRuleBeta1)
 		if err != nil {
 			return err


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
This pull request introduces improvements to the conversion logic for `APIRule` objects in the `v2` and `v2alpha1` APIs. The changes ensure proper handling of annotations and improve compatibility during conversions between API versions. 

### Changes to `v2` API Conversion Logic:
* **Annotation Initialization in `ConvertTo`:** Added logic to set the `originalVersionAnnotationKey` annotation to `"v2"` if it is not already present. 
* **Conditional Handling in `ConvertFrom`:** Added a check to ensure that marshaling and setting of annotations only occur if `Spec.Rules` is not empty. 

### Changes to `v2alpha1` API Conversion Logic:
* **Annotation Initialization in `ConvertTo`:** Added logic to set the `originalVersionAnnotationKey` annotation to `"v2alpha1"` if it is not already present. 

* **Backward Compatibility in `ConvertTo`:** Added logic to unmarshal the `v1beta1SpecAnnotationKey` annotation into `Spec` if `Spec.Rules` is empty, ensuring backward compatibility. 

* **Conditional Handling in `ConvertFrom`:** Added a check to ensure that marshaling and setting of annotations only occur if `Spec.Rules` is not empty. 

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
