### PR TITLE
fix: introduce service informer for v2alpha1

### DIFF
--- a/apis/gateway/v2/apirule_conversion.go
+++ b/apis/gateway/v2/apirule_conversion.go
@@ -8,6 +8,8 @@ import (
 	"github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
 )
 
+const OriginalVersionAnnotation = "gateway.kyma-project.io/original-version"
+
 // ConvertTo Converts this ApiRule (v2) to the Hub version (v2alpha1)
 func (ruleV2 *APIRule) ConvertTo(hub conversion.Hub) error {
 	ruleV2alpha1 := hub.(*v2alpha1.APIRule)
@@ -20,7 +22,7 @@ func (ruleV2 *APIRule) ConvertTo(hub conversion.Hub) error {
 		ruleV2alpha1.Annotations = make(map[string]string)
 	}
 
-	ruleV2alpha1.Annotations["gateway.kyma-project.io/original-version"] = "v2"
+	ruleV2alpha1.Annotations[OriginalVersionAnnotation] = "v2"
 
 	err = convertOverJson(ruleV2.Spec, &ruleV2alpha1.Spec)
 	if err != nil {

--- a/controllers/gateway/apirule_controller.go
+++ b/controllers/gateway/apirule_controller.go
@@ -20,9 +20,16 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"strings"
 	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	rulev1alpha1 "github.com/ory/oathkeeper-maester/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	gatewayv1beta1 "github.com/kyma-project/api-gateway/apis/gateway/v1beta1"
 	gatewayv2alpha1 "github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
@@ -34,12 +41,6 @@ import (
 	v2alpha1Processing "github.com/kyma-project/api-gateway/internal/processing/processors/v2alpha1"
 	"github.com/kyma-project/api-gateway/internal/processing/status"
 	"github.com/kyma-project/api-gateway/internal/validation/v2alpha1"
-	rulev1alpha1 "github.com/ory/oathkeeper-maester/api/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 
@@ -48,13 +49,14 @@ import (
 	"github.com/kyma-project/api-gateway/internal/validation"
 
 	"github.com/go-logr/logr"
-	"github.com/kyma-project/api-gateway/internal/processing"
 	networkingv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	apierrs "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+
+	"github.com/kyma-project/api-gateway/internal/processing"
 )
 
 const (
@@ -345,63 +347,13 @@ func (r *APIRuleReconciler) getV2Alpha1Reconciliation(apiRulev1beta1 *gatewayv1b
 func (r *APIRuleReconciler) SetupWithManager(mgr ctrl.Manager, c controllers.RateLimiterConfig) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		// We need to filter for generation changes, because we had an issue that on Azure clusters the APIRules were constantly reconciled.
-		For(&gatewayv1beta1.APIRule{}, builder.WithPredicates(
+		For(&gatewayv2alpha1.APIRule{}, builder.WithPredicates(
 			predicate.Or(
 				predicate.GenerationChangedPredicate{},
 				predicate.AnnotationChangedPredicate{},
 			))).
 		Watches(&corev1.ConfigMap{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(&isApiGatewayConfigMapPredicate{Log: r.Log})).
-		Watches(&corev1.Service{}, handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
-			var apiRules gatewayv1beta1.APIRuleList
-			if err := r.Client.List(ctx, &apiRules); err != nil {
-				return nil
-			}
-
-			if len(apiRules.Items) == 0 {
-				return nil
-			}
-
-			var requests []reconcile.Request
-
-			for _, apiRule := range apiRules.Items {
-				// match if service is exposed by an APIRule
-				// and add APIRule to the reconciliation queue
-				matches := func(target *gatewayv1beta1.Service) bool {
-					if target == nil {
-						return false
-					}
-
-					matchesNs := apiRule.Namespace == obj.GetNamespace()
-					if target.Namespace != nil {
-						matchesNs = *target.Namespace == obj.GetNamespace()
-					}
-
-					var matchesName bool
-					if target.Name != nil {
-						matchesName = *target.Name == obj.GetName()
-					}
-
-					return matchesNs && matchesName
-				}
-				if matches(apiRule.Spec.Service) {
-					requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
-						Namespace: apiRule.Namespace,
-						Name:      apiRule.Name,
-					}})
-					continue
-				}
-				for _, rule := range apiRule.Spec.Rules {
-					if matches(rule.Service) {
-						requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
-							Namespace: apiRule.Namespace,
-							Name:      apiRule.Name,
-						}})
-						continue
-					}
-				}
-			}
-			return requests
-		})).
+		Watches(&corev1.Service{}, NewServiceInformer(r)).
 		WithOptions(controller.Options{
 			RateLimiter: controllers.NewRateLimiter(c),
 		}).

--- a/controllers/gateway/informers.go
+++ b/controllers/gateway/informers.go
@@ -17,7 +17,7 @@ import (
 func NewServiceInformer(r *APIRuleReconciler) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
 		var apiRules gatewayv2alpha1.APIRuleList
-		if err := r.Client.List(ctx, &apiRules); err != nil {
+		if err := r.List(ctx, &apiRules); err != nil {
 			return nil
 		}
 

--- a/controllers/gateway/informers.go
+++ b/controllers/gateway/informers.go
@@ -1,0 +1,137 @@
+package gateway
+
+import (
+	"context"
+	"slices"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	gatewayv1beta1 "github.com/kyma-project/api-gateway/apis/gateway/v1beta1"
+	gatewayv2 "github.com/kyma-project/api-gateway/apis/gateway/v2"
+	gatewayv2alpha1 "github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
+)
+
+func NewServiceInformer(r *APIRuleReconciler) handler.EventHandler {
+	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+		var apiRules gatewayv2alpha1.APIRuleList
+		if err := r.Client.List(ctx, &apiRules); err != nil {
+			return nil
+		}
+
+		if len(apiRules.Items) == 0 {
+			return nil
+		}
+
+		var apiRulesV2alpha1 []gatewayv2alpha1.APIRule
+		var apiRulesV1beta1 []gatewayv1beta1.APIRule
+
+		for _, apiRuleV2 := range apiRules.Items {
+			if apiRuleV2.Annotations == nil {
+				continue
+			}
+			originalVersion, ok := apiRuleV2.Annotations[gatewayv2.OriginalVersionAnnotation]
+			if !ok || slices.Contains([]string{"v2", "v2alpha1"}, originalVersion) {
+				apiRulesV2alpha1 = append(apiRulesV2alpha1, apiRuleV2)
+			}
+			if originalVersion == "v1beta1" {
+				converted := gatewayv1beta1.APIRule{}
+				if err := converted.ConvertFrom(&apiRuleV2); err != nil {
+					r.Log.Error(err, "Failed to convert APIRule v2alpha1 to v1beta1", "name", apiRuleV2.Name, "namespace", apiRuleV2.Namespace)
+					continue
+				}
+				apiRulesV1beta1 = append(apiRulesV1beta1, converted)
+			}
+		}
+
+		requests := matchAPIRulesV1WithChangedService(apiRulesV1beta1, obj)
+		requests = append(requests, matchAPIRulesV2WithChangedService(apiRulesV2alpha1, obj)...)
+		return requests
+	})
+}
+
+func matchAPIRulesV1WithChangedService(apiRulesV1beta1 []gatewayv1beta1.APIRule, obj client.Object) []reconcile.Request {
+	var requests []reconcile.Request
+	for _, apiRule := range apiRulesV1beta1 {
+		// match if service is exposed by an APIRule
+		// and add APIRule to the reconciliation queue
+		matches := func(target *gatewayv1beta1.Service) bool {
+			if target == nil {
+				return false
+			}
+
+			matchesNs := apiRule.Namespace == obj.GetNamespace()
+			if target.Namespace != nil {
+				matchesNs = *target.Namespace == obj.GetNamespace()
+			}
+
+			var matchesName bool
+			if target.Name != nil {
+				matchesName = *target.Name == obj.GetName()
+			}
+
+			return matchesNs && matchesName
+		}
+		if matches(apiRule.Spec.Service) {
+			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+				Namespace: apiRule.Namespace,
+				Name:      apiRule.Name,
+			}})
+			continue
+		}
+		for _, rule := range apiRule.Spec.Rules {
+			if matches(rule.Service) {
+				requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+					Namespace: apiRule.Namespace,
+					Name:      apiRule.Name,
+				}})
+				continue
+			}
+		}
+	}
+	return requests
+}
+
+func matchAPIRulesV2WithChangedService(apiRules []gatewayv2alpha1.APIRule, obj client.Object) []reconcile.Request {
+	var requests []reconcile.Request
+	for _, apiRule := range apiRules {
+		// match if service is exposed by an APIRule
+		// and add APIRule to the reconciliation queue
+		matches := func(target *gatewayv2alpha1.Service) bool {
+			if target == nil {
+				return false
+			}
+
+			matchesNs := apiRule.Namespace == obj.GetNamespace()
+			if target.Namespace != nil {
+				matchesNs = *target.Namespace == obj.GetNamespace()
+			}
+
+			var matchesName bool
+			if target.Name != nil {
+				matchesName = *target.Name == obj.GetName()
+			}
+
+			return matchesNs && matchesName
+		}
+		if matches(apiRule.Spec.Service) {
+			requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+				Namespace: apiRule.Namespace,
+				Name:      apiRule.Name,
+			}})
+			continue
+		}
+		for _, rule := range apiRule.Spec.Rules {
+			if matches(rule.Service) {
+				requests = append(requests, reconcile.Request{NamespacedName: types.NamespacedName{
+					Namespace: apiRule.Namespace,
+					Name:      apiRule.Name,
+				}})
+				continue
+			}
+		}
+	}
+	return requests
+}

--- a/controllers/gateway/suite_test.go
+++ b/controllers/gateway/suite_test.go
@@ -50,7 +50,7 @@ import (
 )
 
 const (
-	eventuallyTimeout    = time.Second * 30
+	eventuallyTimeout    = time.Second * 5
 	testNamespace        = "atgo-system"
 	testGatewayURL       = "kyma-system/kyma-gateway"
 	testOathkeeperSvcURL = "oathkeeper.kyma-system.svc.cluster.local"

--- a/controllers/gateway/suite_test.go
+++ b/controllers/gateway/suite_test.go
@@ -50,7 +50,7 @@ import (
 )
 
 const (
-	eventuallyTimeout    = time.Second * 5
+	eventuallyTimeout    = time.Second * 10
 	testNamespace        = "atgo-system"
 	testGatewayURL       = "kyma-system/kyma-gateway"
 	testOathkeeperSvcURL = "oathkeeper.kyma-system.svc.cluster.local"
@@ -80,9 +80,9 @@ var (
 	TestAllowHeaders = []string{"header1", "header2"}
 
 	defaultCorsPolicy = builders.CorsPolicy().
-				AllowHeaders(TestAllowHeaders...).
-				AllowMethods(TestAllowMethods...).
-				AllowOrigins(TestAllowOrigins...)
+		AllowHeaders(TestAllowHeaders...).
+		AllowMethods(TestAllowMethods...).
+		AllowOrigins(TestAllowOrigins...)
 )
 
 func TestAPIs(t *testing.T) {


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
This PR fixing bug regarding not working service informer for v2alpha1 and v2 versions of APIRule. This was caused by empty spec in v1beta1 version. 
First occurrence was captured in integration tests on v2alpha1 stored version but increasing timeout fixed it (it was only bypassing it)


Changes proposed in this pull request:
- implement service informer for v2alpha1 and v2 
- code cleanup around informer 
- reduce timeout in integration tests, checking proper behavior of informer scheduled by informer not next reconciliation

**Pre-Merge Checklist**

- [ ] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
