### PR TITLE
feat: extend migration e2e tests

### DIFF
--- a/tests/integration/scripts/test-zero-downtime.sh
+++ b/tests/integration/scripts/test-zero-downtime.sh
@@ -200,7 +200,8 @@ start() {
 
   echo "zero-downtime: Starting integration test scenario for handler '$handler'"
 
-  go test -count=1 -timeout 15m ./tests/integration -v -race -run "TestOryJwt/Migrate_v1beta1_APIRule_with_${handler}_handler" && test_exit_code=$? || test_exit_code=$?
+# pin the zero downtime tests to v2alpha1 scenarios. Otherwise, too many scenarios with similar names are run
+  go test -count=1 -timeout 15m ./tests/integration -v -race -run "TestOryJwt/Migrate_v1beta1_APIRule_with_${handler}_handler_that_is_(.*)_in_v2alpha1" && test_exit_code=$? || test_exit_code=$?
   if [ "${test_exit_code}" -ne 0 ]; then
     echo "zero-downtime: Test execution failed"
     return 1

--- a/tests/integration/testsuites/ory/features/apply_update.feature
+++ b/tests/integration/testsuites/ory/features/apply_update.feature
@@ -1,0 +1,24 @@
+Feature: Apply and update APIRules v1beta1
+# apply v1beta1 (noAuth)
+  Scenario: Creating APIRule v1beta1 (noAuth)
+    Given applyUpdateNoAuthV1beta1: There is a httpbin service with Istio injection enabled
+    When applyUpdateNoAuthV1beta1: The APIRule is applied
+    And applyUpdateNoAuthV1beta1: APIRule has status "OK"
+    Then applyUpdateNoAuthV1beta1: Calling the "/anything" endpoint without a token should result in status between 200 and 200
+    And applyUpdateNoAuthV1beta1: The APIRule contains original-version annotation set to "v1beta1"
+    And applyUpdateNoAuthV1beta1: APIRule has status "OK"
+    And applyUpdateNoAuthV1beta1: Resource of Kind "Rule" owned by APIRule exists
+    And applyUpdateNoAuthV1beta1: Teardown httpbin service
+
+# update v1beta1 (noAuth)
+  Scenario: Updating an APIRule and calling a httpbin endpoint "/ip" (noAuth)
+    Given applyUpdateNoAuthV1beta1: There is a httpbin service with Istio injection enabled
+    And applyUpdateNoAuthV1beta1: The APIRule is applied
+    And applyUpdateNoAuthV1beta1: APIRule has status "OK"
+    And applyUpdateNoAuthV1beta1: The APIRule contains original-version annotation set to "v1beta1"
+    When applyUpdateNoAuthV1beta1: The APIRule is updated using manifest "v1beta1-noop-updated.yaml"
+    Then applyUpdateNoAuthV1beta1: Calling the "/ip" endpoint without a token should result in status between 200 and 200
+    And applyUpdateNoAuthV1beta1: The APIRule contains original-version annotation set to "v1beta1"
+    And applyUpdateNoAuthV1beta1: APIRule has status "OK"
+    And applyUpdateNoAuthV1beta1: Resource of Kind "Rule" owned by APIRule exists
+    And applyUpdateNoAuthV1beta1: Teardown httpbin service

--- a/tests/integration/testsuites/ory/features/v2alpha1_conversion.feature
+++ b/tests/integration/testsuites/ory/features/v2alpha1_conversion.feature
@@ -1,37 +1,85 @@
 Feature: APIRules v2alpha1 conversion
 
+# v1beta1 (allow) -> v2alpha1 (allow)
   Scenario: Migrate v1beta1 APIRule with allow handler that is unsupported in v2alpha1
     Given migrationAllowV1beta1: There is a httpbin service with Istio injection enabled
     And migrationAllowV1beta1: The APIRule is applied
     And migrationAllowV1beta1: APIRule has status "OK"
+    And migrationAllowV1beta1: The APIRule contains original-version annotation set to "v1beta1"
     And migrationAllowV1beta1: Calling the "/headers" endpoint without a token should result in status between 200 and 200
     When migrationAllowV1beta1: The APIRule is updated using manifest "migration-allow-v2alpha1.yaml"
     And migrationAllowV1beta1: Resource of Kind "AuthorizationPolicy" owned by APIRule exists
     Then migrationAllowV1beta1: APIRule has status "OK"
+    And migrationAllowV1beta1: The APIRule contains original-version annotation set to "v2alpha1"
 
+# v1beta1 (allow) -> v2 (allow)
+  Scenario: Migrate v1beta1 APIRule with allow handler that is unsupported in v2
+    Given migrationAllowV1beta1: There is a httpbin service with Istio injection enabled
+    And migrationAllowV1beta1: The APIRule is applied
+    And migrationAllowV1beta1: APIRule has status "OK"
+    And migrationAllowV1beta1: The APIRule contains original-version annotation set to "v1beta1"
+    And migrationAllowV1beta1: Calling the "/headers" endpoint without a token should result in status between 200 and 200
+    When migrationAllowV1beta1: The APIRule is updated using manifest "migration-allow-v2.yaml"
+    And migrationAllowV1beta1: Resource of Kind "AuthorizationPolicy" owned by APIRule exists
+    Then migrationAllowV1beta1: APIRule has status "OK"
+    And migrationAllowV1beta1: The APIRule contains original-version annotation set to "v2"
+
+# v1beta1 (no_auth) -> v2alpha1 (no_auth)
   Scenario: Migrate v1beta1 APIRule with no_auth handler that is supported in v2alpha1
     Given migrationNoAuthV1beta1: There is a httpbin service with Istio injection enabled
     And migrationNoAuthV1beta1: The APIRule is applied
     And migrationNoAuthV1beta1: APIRule has status "OK"
+    And migrationNoAuthV1beta1: The APIRule contains original-version annotation set to "v1beta1"
     And migrationNoAuthV1beta1: Calling the "/headers" endpoint without a token should result in status between 200 and 200
     When migrationNoAuthV1beta1: The APIRule is updated using manifest "migration-noauth-v2alpha1.yaml"
     And migrationNoAuthV1beta1: Resource of Kind "AuthorizationPolicy" owned by APIRule exists
     Then migrationNoAuthV1beta1: APIRule has status "OK"
+    And migrationNoAuthV1beta1: The APIRule contains original-version annotation set to "v2alpha1"
 
+# v1beta1 (no_auth) -> v2 (no_auth)
+  Scenario: Migrate v1beta1 APIRule with no_auth handler that is supported in v2
+    Given migrationNoAuthV1beta1: There is a httpbin service with Istio injection enabled
+    And migrationNoAuthV1beta1: The APIRule is applied
+    And migrationNoAuthV1beta1: APIRule has status "OK"
+    And migrationNoAuthV1beta1: The APIRule contains original-version annotation set to "v1beta1"
+    And migrationNoAuthV1beta1: Calling the "/headers" endpoint without a token should result in status between 200 and 200
+    When migrationNoAuthV1beta1: The APIRule is updated using manifest "migration-noauth-v2.yaml"
+    And migrationNoAuthV1beta1: Resource of Kind "AuthorizationPolicy" owned by APIRule exists
+    Then migrationNoAuthV1beta1: APIRule has status "OK"
+    And migrationNoAuthV1beta1: The APIRule contains original-version annotation set to "v2"
+
+# v1beta1 (noop) -> v2alpha1 (noop)
   Scenario: Migrate v1beta1 APIRule with noop handler that is unsupported in v2alpha1
     Given migrationNoopV1beta1: There is a httpbin service with Istio injection enabled
     And migrationNoopV1beta1: The APIRule is applied
     And migrationNoopV1beta1: APIRule has status "OK"
+    And migrationNoopV1beta1: The APIRule contains original-version annotation set to "v1beta1"
     And migrationNoopV1beta1: Calling the "/headers" endpoint without a token should result in status between 200 and 200
     When migrationNoopV1beta1: The APIRule is updated using manifest "migration-noop-v2alpha1.yaml"
     And migrationNoopV1beta1: Resource of Kind "AuthorizationPolicy" owned by APIRule exists
     And migrationNoopV1beta1: Resource of Kind "Rule" owned by APIRule does not exist
     Then migrationNoopV1beta1: APIRule has status "OK"
+    And migrationNoopV1beta1: The APIRule contains original-version annotation set to "v2alpha1"
 
+# v1beta1 (noop) -> v2 (noop)
+  Scenario: Migrate v1beta1 APIRule with noop handler that is unsupported in v2
+    Given migrationNoopV1beta1: There is a httpbin service with Istio injection enabled
+    And migrationNoopV1beta1: The APIRule is applied
+    And migrationNoopV1beta1: APIRule has status "OK"
+    And migrationNoopV1beta1: The APIRule contains original-version annotation set to "v1beta1"
+    And migrationNoopV1beta1: Calling the "/headers" endpoint without a token should result in status between 200 and 200
+    When migrationNoopV1beta1: The APIRule is updated using manifest "migration-noop-v2.yaml"
+    And migrationNoopV1beta1: Resource of Kind "AuthorizationPolicy" owned by APIRule exists
+    And migrationNoopV1beta1: Resource of Kind "Rule" owned by APIRule does not exist
+    Then migrationNoopV1beta1: APIRule has status "OK"
+    And migrationNoopV1beta1: The APIRule contains original-version annotation set to "v2"
+
+# v1beta1 (jwt) -> v2alpha1 (jwt)
   Scenario: Migrate v1beta1 APIRule with jwt handler that is supported in v2alpha1
     Given migrationJwtV1beta1: There is a httpbin service with Istio injection enabled
     And migrationJwtV1beta1: The APIRule is applied
     And migrationJwtV1beta1: APIRule has status "OK"
+    And migrationJwtV1beta1: The APIRule contains original-version annotation set to "v1beta1"
     And migrationJwtV1beta1: Calling the "/headers" endpoint with a valid "JWT" token should result in status between 200 and 200
     When migrationJwtV1beta1: The APIRule is updated using manifest "migration-jwt-v2alpha1.yaml"
     And migrationJwtV1beta1: Resource of Kind "RequestAuthentication" owned by APIRule exists
@@ -39,11 +87,29 @@ Feature: APIRules v2alpha1 conversion
     And migrationJwtV1beta1: VirtualService owned by APIRule has httpbin service as destination
     And migrationJwtV1beta1: Resource of Kind "Rule" owned by APIRule does not exist
     Then migrationJwtV1beta1: APIRule has status "OK"
+    And migrationJwtV1beta1: The APIRule contains original-version annotation set to "v2alpha1"
 
+# v1beta1 (jwt) -> v2 (jwt)
+  Scenario: Migrate v1beta1 APIRule with jwt handler that is supported in v2
+    Given migrationJwtV1beta1: There is a httpbin service with Istio injection enabled
+    And migrationJwtV1beta1: The APIRule is applied
+    And migrationJwtV1beta1: APIRule has status "OK"
+    And migrationJwtV1beta1: The APIRule contains original-version annotation set to "v1beta1"
+    And migrationJwtV1beta1: Calling the "/headers" endpoint with a valid "JWT" token should result in status between 200 and 200
+    When migrationJwtV1beta1: The APIRule is updated using manifest "migration-jwt-v2.yaml"
+    And migrationJwtV1beta1: Resource of Kind "RequestAuthentication" owned by APIRule exists
+    And migrationJwtV1beta1: Resource of Kind "AuthorizationPolicy" owned by APIRule exists
+    And migrationJwtV1beta1: VirtualService owned by APIRule has httpbin service as destination
+    And migrationJwtV1beta1: Resource of Kind "Rule" owned by APIRule does not exist
+    Then migrationJwtV1beta1: APIRule has status "OK"
+    And migrationJwtV1beta1: The APIRule contains original-version annotation set to "v2"
+
+# v1beta1 (extauth) -> v2alpha1 (extauth)
   Scenario: Migrate v1beta1 APIRule with oauth2_introspection handler that is unsupported in v2alpha1
     Given migrationOAuth2IntrospectionJwtV1beta1: There is a httpbin service with Istio injection enabled
     And migrationOAuth2IntrospectionJwtV1beta1: The APIRule is applied
     And migrationOAuth2IntrospectionJwtV1beta1: APIRule has status "OK"
+    And migrationOAuth2IntrospectionJwtV1beta1: The APIRule contains original-version annotation set to "v1beta1"
     And migrationOAuth2IntrospectionJwtV1beta1: Calling the "/headers" endpoint with a valid "JWT" token should result in status between 200 and 200
     When migrationOAuth2IntrospectionJwtV1beta1: The APIRule is updated using manifest "migration-oauth2-introspection-v2alpha1.yaml"
     And migrationOAuth2IntrospectionJwtV1beta1: Resource of Kind "RequestAuthentication" owned by APIRule exists
@@ -51,39 +117,103 @@ Feature: APIRules v2alpha1 conversion
     And migrationOAuth2IntrospectionJwtV1beta1: VirtualService owned by APIRule has httpbin service as destination
     And migrationOAuth2IntrospectionJwtV1beta1: Resource of Kind "Rule" owned by APIRule does not exist
     Then migrationOAuth2IntrospectionJwtV1beta1: APIRule has status "OK"
+    And migrationOAuth2IntrospectionJwtV1beta1: The APIRule contains original-version annotation set to "v2alpha1"
 
+# v1beta1 (extauth) -> v2 (extauth)
+  Scenario: Migrate v1beta1 APIRule with oauth2_introspection handler that is unsupported in v2
+    Given migrationOAuth2IntrospectionJwtV1beta1: There is a httpbin service with Istio injection enabled
+    And migrationOAuth2IntrospectionJwtV1beta1: The APIRule is applied
+    And migrationOAuth2IntrospectionJwtV1beta1: APIRule has status "OK"
+    And migrationOAuth2IntrospectionJwtV1beta1: The APIRule contains original-version annotation set to "v1beta1"
+    And migrationOAuth2IntrospectionJwtV1beta1: Calling the "/headers" endpoint with a valid "JWT" token should result in status between 200 and 200
+    When migrationOAuth2IntrospectionJwtV1beta1: The APIRule is updated using manifest "migration-oauth2-introspection-v2.yaml"
+    And migrationOAuth2IntrospectionJwtV1beta1: Resource of Kind "RequestAuthentication" owned by APIRule exists
+    And migrationOAuth2IntrospectionJwtV1beta1: Resource of Kind "AuthorizationPolicy" owned by APIRule exists
+    And migrationOAuth2IntrospectionJwtV1beta1: VirtualService owned by APIRule has httpbin service as destination
+    And migrationOAuth2IntrospectionJwtV1beta1: Resource of Kind "Rule" owned by APIRule does not exist
+    Then migrationOAuth2IntrospectionJwtV1beta1: APIRule has status "OK"
+    And migrationOAuth2IntrospectionJwtV1beta1: The APIRule contains original-version annotation set to "v2"
+
+# v1beta1 (allow) -> v2alpha1 (allow) with annotations
   Scenario: Migrate v1beta1 APIRule with annotations with allow handler that is unsupported in v2alpha1
     Given migrationAllowV1beta1: There is a httpbin service with Istio injection enabled
     And migrationAllowV1beta1: The APIRule is applied
     And migrationAllowV1beta1: APIRule has status "OK"
+    And migrationAllowV1beta1: The APIRule contains original-version annotation set to "v1beta1"
     And migrationAllowV1beta1: Calling the "/headers" endpoint without a token should result in status between 200 and 200
     When migrationAllowV1beta1: The APIRule is updated using manifest "migration-allow-v2alpha1-with-annotations.yaml"
     And migrationAllowV1beta1: Resource of Kind "AuthorizationPolicy" owned by APIRule exists
     Then migrationAllowV1beta1: APIRule has status "OK"
+    And migrationAllowV1beta1: The APIRule contains original-version annotation set to "v2alpha1"
 
+# v1beta1 (allow) -> v2 (allow) with annotations
+  Scenario: Migrate v1beta1 APIRule with annotations with allow handler that is unsupported in v2
+    Given migrationAllowV1beta1: There is a httpbin service with Istio injection enabled
+    And migrationAllowV1beta1: The APIRule is applied
+    And migrationAllowV1beta1: APIRule has status "OK"
+    And migrationAllowV1beta1: The APIRule contains original-version annotation set to "v1beta1"
+    And migrationAllowV1beta1: Calling the "/headers" endpoint without a token should result in status between 200 and 200
+    When migrationAllowV1beta1: The APIRule is updated using manifest "migration-allow-v2-with-annotations.yaml"
+    And migrationAllowV1beta1: Resource of Kind "AuthorizationPolicy" owned by APIRule exists
+    Then migrationAllowV1beta1: APIRule has status "OK"
+    And migrationAllowV1beta1: The APIRule contains original-version annotation set to "v2"
+
+# v1beta1 (no_auth) -> v2alpha1 (no_auth) with annotations
   Scenario: Migrate v1beta1 APIRule with annotations with no_auth handler that is supported in v2alpha1
     Given migrationNoAuthV1beta1: There is a httpbin service with Istio injection enabled
     And migrationNoAuthV1beta1: The APIRule is applied
     And migrationNoAuthV1beta1: APIRule has status "OK"
+    And migrationNoAuthV1beta1: The APIRule contains original-version annotation set to "v1beta1"
     And migrationNoAuthV1beta1: Calling the "/headers" endpoint without a token should result in status between 200 and 200
     When migrationNoAuthV1beta1: The APIRule is updated using manifest "migration-noauth-v2alpha1-with-annotations.yaml"
     And migrationNoAuthV1beta1: Resource of Kind "AuthorizationPolicy" owned by APIRule exists
     Then migrationNoAuthV1beta1: APIRule has status "OK"
+    And migrationNoAuthV1beta1: The APIRule contains original-version annotation set to "v2alpha1"
 
+# v1beta1 (no_auth) -> v2 (no_auth) with annotations
+  Scenario: Migrate v1beta1 APIRule with annotations with no_auth handler that is supported in v2
+    Given migrationNoAuthV1beta1: There is a httpbin service with Istio injection enabled
+    And migrationNoAuthV1beta1: The APIRule is applied
+    And migrationNoAuthV1beta1: APIRule has status "OK"
+    And migrationNoAuthV1beta1: The APIRule contains original-version annotation set to "v1beta1"
+    And migrationNoAuthV1beta1: Calling the "/headers" endpoint without a token should result in status between 200 and 200
+    When migrationNoAuthV1beta1: The APIRule is updated using manifest "migration-noauth-v2-with-annotations.yaml"
+    And migrationNoAuthV1beta1: Resource of Kind "AuthorizationPolicy" owned by APIRule exists
+    Then migrationNoAuthV1beta1: APIRule has status "OK"
+    And migrationNoAuthV1beta1: The APIRule contains original-version annotation set to "v2"
+
+# v1beta1 (noop) -> v2alpha1 (noop) with annotations
   Scenario: Migrate v1beta1 APIRule with annotations with noop handler that is unsupported in v2alpha1
     Given migrationNoopV1beta1: There is a httpbin service with Istio injection enabled
     And migrationNoopV1beta1: The APIRule is applied
     And migrationNoopV1beta1: APIRule has status "OK"
+    And migrationNoopV1beta1: The APIRule contains original-version annotation set to "v1beta1"
     And migrationNoopV1beta1: Calling the "/headers" endpoint without a token should result in status between 200 and 200
     When migrationNoopV1beta1: The APIRule is updated using manifest "migration-noop-v2alpha1-with-annotations.yaml"
     And migrationNoopV1beta1: Resource of Kind "AuthorizationPolicy" owned by APIRule exists
     And migrationNoopV1beta1: Resource of Kind "Rule" owned by APIRule does not exist
     Then migrationNoopV1beta1: APIRule has status "OK"
+    And migrationNoopV1beta1: The APIRule contains original-version annotation set to "v2alpha1"
 
+# v1beta1 (noop) -> v2 (noop) with annotations
+  Scenario: Migrate v1beta1 APIRule with annotations with noop handler that is unsupported in v2
+    Given migrationNoopV1beta1: There is a httpbin service with Istio injection enabled
+    And migrationNoopV1beta1: The APIRule is applied
+    And migrationNoopV1beta1: APIRule has status "OK"
+    And migrationNoopV1beta1: The APIRule contains original-version annotation set to "v1beta1"
+    And migrationNoopV1beta1: Calling the "/headers" endpoint without a token should result in status between 200 and 200
+    When migrationNoopV1beta1: The APIRule is updated using manifest "migration-noop-v2-with-annotations.yaml"
+    And migrationNoopV1beta1: Resource of Kind "AuthorizationPolicy" owned by APIRule exists
+    And migrationNoopV1beta1: Resource of Kind "Rule" owned by APIRule does not exist
+    Then migrationNoopV1beta1: APIRule has status "OK"
+    And migrationNoopV1beta1: The APIRule contains original-version annotation set to "v2"
+
+# v1beta1 (jwt) -> v2alpha1 (jwt) with annotations
   Scenario: Migrate v1beta1 APIRule with annotations with jwt handler that is supported in v2alpha1
     Given migrationJwtV1beta1: There is a httpbin service with Istio injection enabled
     And migrationJwtV1beta1: The APIRule is applied
     And migrationJwtV1beta1: APIRule has status "OK"
+    And migrationJwtV1beta1: The APIRule contains original-version annotation set to "v1beta1"
     And migrationJwtV1beta1: Calling the "/headers" endpoint with a valid "JWT" token should result in status between 200 and 200
     When migrationJwtV1beta1: The APIRule is updated using manifest "migration-jwt-v2alpha1-with-annotations.yaml"
     And migrationJwtV1beta1: Resource of Kind "RequestAuthentication" owned by APIRule exists
@@ -91,11 +221,29 @@ Feature: APIRules v2alpha1 conversion
     And migrationJwtV1beta1: VirtualService owned by APIRule has httpbin service as destination
     And migrationJwtV1beta1: Resource of Kind "Rule" owned by APIRule does not exist
     Then migrationJwtV1beta1: APIRule has status "OK"
+    And migrationJwtV1beta1: The APIRule contains original-version annotation set to "v2alpha1"
 
+    # v1beta1 (jwt) -> v2 (jwt) with annotations
+  Scenario: Migrate v1beta1 APIRule with annotations with jwt handler that is supported in v2
+    Given migrationJwtV1beta1: There is a httpbin service with Istio injection enabled
+    And migrationJwtV1beta1: The APIRule is applied
+    And migrationJwtV1beta1: APIRule has status "OK"
+    And migrationJwtV1beta1: The APIRule contains original-version annotation set to "v1beta1"
+    And migrationJwtV1beta1: Calling the "/headers" endpoint with a valid "JWT" token should result in status between 200 and 200
+    When migrationJwtV1beta1: The APIRule is updated using manifest "migration-jwt-v2-with-annotations.yaml"
+    And migrationJwtV1beta1: Resource of Kind "RequestAuthentication" owned by APIRule exists
+    And migrationJwtV1beta1: Resource of Kind "AuthorizationPolicy" owned by APIRule exists
+    And migrationJwtV1beta1: VirtualService owned by APIRule has httpbin service as destination
+    And migrationJwtV1beta1: Resource of Kind "Rule" owned by APIRule does not exist
+    Then migrationJwtV1beta1: APIRule has status "OK"
+    And migrationJwtV1beta1: The APIRule contains original-version annotation set to "v2"
+
+# v1beta1 (extauth) -> v2alpha1 (extauth) with annotations
   Scenario: Migrate v1beta1 APIRule with annotations with oauth2_introspection handler that is unsupported in v2alpha1
     Given migrationOAuth2IntrospectionJwtV1beta1: There is a httpbin service with Istio injection enabled
     And migrationOAuth2IntrospectionJwtV1beta1: The APIRule is applied
     And migrationOAuth2IntrospectionJwtV1beta1: APIRule has status "OK"
+    And migrationOAuth2IntrospectionJwtV1beta1: The APIRule contains original-version annotation set to "v1beta1"
     And migrationOAuth2IntrospectionJwtV1beta1: Calling the "/headers" endpoint with a valid "JWT" token should result in status between 200 and 200
     When migrationOAuth2IntrospectionJwtV1beta1: The APIRule is updated using manifest "migration-oauth2-introspection-v2alpha1-with-annotations.yaml"
     And migrationOAuth2IntrospectionJwtV1beta1: Resource of Kind "RequestAuthentication" owned by APIRule exists
@@ -103,6 +251,22 @@ Feature: APIRules v2alpha1 conversion
     And migrationOAuth2IntrospectionJwtV1beta1: VirtualService owned by APIRule has httpbin service as destination
     And migrationOAuth2IntrospectionJwtV1beta1: Resource of Kind "Rule" owned by APIRule does not exist
     Then migrationOAuth2IntrospectionJwtV1beta1: APIRule has status "OK"
+    And migrationOAuth2IntrospectionJwtV1beta1: The APIRule contains original-version annotation set to "v2alpha1"
+
+# v1beta1 (extauth) -> v2 (extauth) with annotations
+  Scenario: Migrate v1beta1 APIRule with annotations with oauth2_introspection handler that is unsupported in v2
+    Given migrationOAuth2IntrospectionJwtV1beta1: There is a httpbin service with Istio injection enabled
+    And migrationOAuth2IntrospectionJwtV1beta1: The APIRule is applied
+    And migrationOAuth2IntrospectionJwtV1beta1: APIRule has status "OK"
+    And migrationOAuth2IntrospectionJwtV1beta1: The APIRule contains original-version annotation set to "v1beta1"
+    And migrationOAuth2IntrospectionJwtV1beta1: Calling the "/headers" endpoint with a valid "JWT" token should result in status between 200 and 200
+    When migrationOAuth2IntrospectionJwtV1beta1: The APIRule is updated using manifest "migration-oauth2-introspection-v2-with-annotations.yaml"
+    And migrationOAuth2IntrospectionJwtV1beta1: Resource of Kind "RequestAuthentication" owned by APIRule exists
+    And migrationOAuth2IntrospectionJwtV1beta1: Resource of Kind "AuthorizationPolicy" owned by APIRule exists
+    And migrationOAuth2IntrospectionJwtV1beta1: VirtualService owned by APIRule has httpbin service as destination
+    And migrationOAuth2IntrospectionJwtV1beta1: Resource of Kind "Rule" owned by APIRule does not exist
+    Then migrationOAuth2IntrospectionJwtV1beta1: APIRule has status "OK"
+    And migrationOAuth2IntrospectionJwtV1beta1: The APIRule contains original-version annotation set to "v2"
 
   Scenario: Delete v1beta1 APIRule with handler that is unsupported in v2alpha1
     Given deleteAllowV1beta1: The APIRule is applied

--- a/tests/integration/testsuites/ory/manifests/migration-allow-v2-with-annotations.yaml
+++ b/tests/integration/testsuites/ory/manifests/migration-allow-v2-with-annotations.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.kyma-project.io/v2
+kind: APIRule
+metadata:
+  name: "{{.NamePrefix}}-{{.TestID}}"
+  namespace: "{{.Namespace}}"
+  labels:
+    test: v1beta1-migration
+  annotations:
+    gateway.kyma-project.io/original-version: v1beta1
+spec:
+  service:
+    name: httpbin-{{.TestID}}
+    port: 8000
+  gateway: "{{.GatewayNamespace}}/{{.GatewayName}}"
+  hosts:
+    - "httpbin-{{.TestID}}.{{.Domain}}"
+  rules:
+    - path: /headers
+      methods: ["GET"]
+      noAuth: true

--- a/tests/integration/testsuites/ory/manifests/migration-allow-v2.yaml
+++ b/tests/integration/testsuites/ory/manifests/migration-allow-v2.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.kyma-project.io/v2
+kind: APIRule
+metadata:
+  name: "{{.NamePrefix}}-{{.TestID}}"
+  namespace: "{{.Namespace}}"
+  labels:
+    test: v1beta1-migration
+spec:
+  service:
+    name: httpbin-{{.TestID}}
+    port: 8000
+  gateway: "{{.GatewayNamespace}}/{{.GatewayName}}"
+  hosts:
+    - "httpbin-{{.TestID}}.{{.Domain}}"
+  rules:
+    - path: /headers
+      methods: ["GET"]
+      noAuth: true

--- a/tests/integration/testsuites/ory/manifests/migration-jwt-v2-with-annotations.yaml
+++ b/tests/integration/testsuites/ory/manifests/migration-jwt-v2-with-annotations.yaml
@@ -1,0 +1,23 @@
+apiVersion: gateway.kyma-project.io/v2
+kind: APIRule
+metadata:
+  name: "{{.NamePrefix}}-{{.TestID}}"
+  namespace: "{{.Namespace}}"
+  labels:
+    test: v1beta1-migration
+  annotations:
+    gateway.kyma-project.io/original-version: v1beta1
+spec:
+  service:
+    name: httpbin-{{.TestID}}
+    port: 8000
+  gateway: "{{.GatewayNamespace}}/{{.GatewayName}}"
+  hosts:
+    - "httpbin-{{.TestID}}.{{.Domain}}"
+  rules:
+    - path: /headers
+      methods: ["GET"]
+      jwt:
+        authentications:
+          - issuer: "{{ .IssuerUrl }}"
+            jwksUri: "{{ .IssuerUrl }}/oauth2/certs"

--- a/tests/integration/testsuites/ory/manifests/migration-jwt-v2.yaml
+++ b/tests/integration/testsuites/ory/manifests/migration-jwt-v2.yaml
@@ -1,0 +1,21 @@
+apiVersion: gateway.kyma-project.io/v2
+kind: APIRule
+metadata:
+  name: "{{.NamePrefix}}-{{.TestID}}"
+  namespace: "{{.Namespace}}"
+  labels:
+    test: v1beta1-migration
+spec:
+  service:
+    name: httpbin-{{.TestID}}
+    port: 8000
+  gateway: "{{.GatewayNamespace}}/{{.GatewayName}}"
+  hosts:
+    - "httpbin-{{.TestID}}.{{.Domain}}"
+  rules:
+    - path: /headers
+      methods: ["GET"]
+      jwt:
+        authentications:
+          - issuer: "{{ .IssuerUrl }}"
+            jwksUri: "{{ .IssuerUrl }}/oauth2/certs"

--- a/tests/integration/testsuites/ory/manifests/migration-noauth-v2-with-annotations.yaml
+++ b/tests/integration/testsuites/ory/manifests/migration-noauth-v2-with-annotations.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.kyma-project.io/v2
+kind: APIRule
+metadata:
+  name: "{{.NamePrefix}}-{{.TestID}}"
+  namespace: "{{.Namespace}}"
+  labels:
+    test: v1beta1-migration
+  annotations:
+    gateway.kyma-project.io/original-version: v1beta1
+spec:
+  service:
+    name: httpbin-{{.TestID}}
+    port: 8000
+  gateway: "{{.GatewayNamespace}}/{{.GatewayName}}"
+  hosts:
+    - "httpbin-{{.TestID}}.{{.Domain}}"
+  rules:
+    - path: /headers
+      methods: ["GET"]
+      noAuth: true

--- a/tests/integration/testsuites/ory/manifests/migration-noauth-v2.yaml
+++ b/tests/integration/testsuites/ory/manifests/migration-noauth-v2.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.kyma-project.io/v2
+kind: APIRule
+metadata:
+  name: "{{.NamePrefix}}-{{.TestID}}"
+  namespace: "{{.Namespace}}"
+  labels:
+    test: v1beta1-migration
+spec:
+  service:
+    name: httpbin-{{.TestID}}
+    port: 8000
+  gateway: "{{.GatewayNamespace}}/{{.GatewayName}}"
+  hosts:
+    - "httpbin-{{.TestID}}.{{.Domain}}"
+  rules:
+    - path: /headers
+      methods: ["GET"]
+      noAuth: true

--- a/tests/integration/testsuites/ory/manifests/migration-noop-v2-with-annotations.yaml
+++ b/tests/integration/testsuites/ory/manifests/migration-noop-v2-with-annotations.yaml
@@ -1,0 +1,20 @@
+apiVersion: gateway.kyma-project.io/v2
+kind: APIRule
+metadata:
+  name: "{{.NamePrefix}}-{{.TestID}}"
+  namespace: "{{.Namespace}}"
+  labels:
+    test: v1beta1-migration
+  annotations:
+    gateway.kyma-project.io/original-version: v1beta1
+spec:
+  service:
+    name: httpbin-{{.TestID}}
+    port: 8000
+  gateway: "{{.GatewayNamespace}}/{{.GatewayName}}"
+  hosts:
+    - "httpbin-{{.TestID}}.{{.Domain}}"
+  rules:
+    - path: /headers
+      methods: ["GET"]
+      noAuth: true

--- a/tests/integration/testsuites/ory/manifests/migration-noop-v2.yaml
+++ b/tests/integration/testsuites/ory/manifests/migration-noop-v2.yaml
@@ -1,0 +1,18 @@
+apiVersion: gateway.kyma-project.io/v2
+kind: APIRule
+metadata:
+  name: "{{.NamePrefix}}-{{.TestID}}"
+  namespace: "{{.Namespace}}"
+  labels:
+    test: v1beta1-migration
+spec:
+  service:
+    name: httpbin-{{.TestID}}
+    port: 8000
+  gateway: "{{.GatewayNamespace}}/{{.GatewayName}}"
+  hosts:
+    - "httpbin-{{.TestID}}.{{.Domain}}"
+  rules:
+    - path: /headers
+      methods: ["GET"]
+      noAuth: true

--- a/tests/integration/testsuites/ory/manifests/migration-oauth2-introspection-v2-with-annotations.yaml
+++ b/tests/integration/testsuites/ory/manifests/migration-oauth2-introspection-v2-with-annotations.yaml
@@ -1,0 +1,26 @@
+apiVersion: gateway.kyma-project.io/v2
+kind: APIRule
+metadata:
+  name: "{{.NamePrefix}}-{{.TestID}}"
+  namespace: "{{.Namespace}}"
+  labels:
+    test: v1beta1-migration
+  annotations:
+    gateway.kyma-project.io/original-version: v1beta1
+spec:
+  gateway: "{{.GatewayNamespace}}/{{.GatewayName}}"
+  hosts:
+    - "httpbin-{{.TestID}}.{{.Domain}}"
+  service:
+    name: httpbin-{{.TestID}}
+    port: 8000
+  rules:
+    - path: /headers
+      methods: ["GET"]
+      extAuth:
+        restrictions:
+          authentications:
+            - issuer: "{{ .IssuerUrl }}"
+              jwksUri: "{{ .IssuerUrl }}/oauth2/certs"
+        authorizers:
+          - sample-ext-authz-http

--- a/tests/integration/testsuites/ory/manifests/migration-oauth2-introspection-v2.yaml
+++ b/tests/integration/testsuites/ory/manifests/migration-oauth2-introspection-v2.yaml
@@ -1,0 +1,24 @@
+apiVersion: gateway.kyma-project.io/v2
+kind: APIRule
+metadata:
+  name: "{{.NamePrefix}}-{{.TestID}}"
+  namespace: "{{.Namespace}}"
+  labels:
+    test: v1beta1-migration
+spec:
+  gateway: "{{.GatewayNamespace}}/{{.GatewayName}}"
+  hosts:
+    - "httpbin-{{.TestID}}.{{.Domain}}"
+  service:
+    name: httpbin-{{.TestID}}
+    port: 8000
+  rules:
+    - path: /headers
+      methods: ["GET"]
+      extAuth:
+        restrictions:
+          authentications:
+            - issuer: "{{ .IssuerUrl }}"
+              jwksUri: "{{ .IssuerUrl }}/oauth2/certs"
+        authorizers:
+          - sample-ext-authz-http

--- a/tests/integration/testsuites/ory/manifests/v1beta1-noop-updated.yaml
+++ b/tests/integration/testsuites/ory/manifests/v1beta1-noop-updated.yaml
@@ -10,7 +10,7 @@ spec:
   gateway: "{{.GatewayNamespace}}/{{.GatewayName}}"
   host: "httpbin-{{.TestID}}.{{.Domain}}"
   rules:
-    - path: /anything
+    - path: /ip
       methods: ["GET"]
       accessStrategies:
-        - handler: no_auth
+        - handler: noop

--- a/tests/integration/testsuites/ory/manifests/v1beta1-noop.yaml
+++ b/tests/integration/testsuites/ory/manifests/v1beta1-noop.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.kyma-project.io/v1beta1
+kind: APIRule
+metadata:
+  name: "{{.NamePrefix}}-{{.TestID}}"
+  namespace: "{{.Namespace}}"
+spec:
+  service:
+    name: httpbin-{{.TestID}}
+    port: 8000
+  gateway: "{{.GatewayNamespace}}/{{.GatewayName}}"
+  host: "httpbin-{{.TestID}}.{{.Domain}}"
+  rules:
+    - path: /anything
+      methods: ["GET"]
+      accessStrategies:
+        - handler: noop

--- a/tests/integration/testsuites/ory/scenario_apply_update_noAuth_v1beta1.go
+++ b/tests/integration/testsuites/ory/scenario_apply_update_noAuth_v1beta1.go
@@ -1,0 +1,18 @@
+package ory
+
+import (
+	"github.com/cucumber/godog"
+)
+
+func initApplyUpdatev1beta1(ctx *godog.ScenarioContext, ts *testsuite) {
+	scenario := ts.createScenario("v1beta1-noop.yaml", "v1beta1-noop")
+
+	ctx.Step(`^applyUpdateNoAuthV1beta1: There is a httpbin service with Istio injection enabled$`, scenario.thereIsAHttpbinServiceWithIstioInjection)
+	ctx.Step(`^applyUpdateNoAuthV1beta1: The APIRule is applied$`, scenario.theAPIRuleIsApplied)
+	ctx.Step(`^applyUpdateNoAuthV1beta1: APIRule has status "([^"]*)"$`, scenario.theAPIRuleHasStatus)
+	ctx.Step(`^applyUpdateNoAuthV1beta1: The APIRule contains original-version annotation set to "([^"]*)"$`, scenario.apiRuleContainsOriginalVersionAnnotation)
+	ctx.Step(`^applyUpdateNoAuthV1beta1: Resource of Kind "([^"]*)" owned by APIRule exists$`, scenario.resourceOwnedByApiRuleExists)
+	ctx.Step(`^applyUpdateNoAuthV1beta1: The APIRule is updated using manifest "([^"]*)"$`, scenario.theAPIRuleIsUpdated)
+	ctx.Step(`^applyUpdateNoAuthV1beta1: Teardown httpbin service$`, scenario.teardownHttpbinService)
+	ctx.Step(`^applyUpdateNoAuthV1beta1: Calling the "([^"]*)" endpoint without a token should result in status between (\d+) and (\d+)$`, scenario.callingTheEndpointWithoutTokenShouldResultInStatusBetween)
+}

--- a/tests/integration/testsuites/ory/scenario_migration_allow_v1beta1.go
+++ b/tests/integration/testsuites/ory/scenario_migration_allow_v1beta1.go
@@ -13,4 +13,5 @@ func initMigrationAllowV1beta1(ctx *godog.ScenarioContext, ts *testsuite) {
 	ctx.Step(`^migrationAllowV1beta1: APIRule has status "([^"]*)"$`, scenario.theAPIRuleHasStatus)
 	ctx.Step(`^migrationAllowV1beta1: Calling the "([^"]*)" endpoint without a token should result in status between (\d+) and (\d+)$`, scenario.callingTheEndpointWithoutTokenShouldResultInStatusBetween)
 	ctx.Step(`^migrationAllowV1beta1: Resource of Kind "([^"]*)" owned by APIRule exists$`, scenario.resourceOwnedByApiRuleExists)
+	ctx.Step(`^migrationAllowV1beta1: The APIRule contains original-version annotation set to "([^"]*)"$`, scenario.apiRuleContainsOriginalVersionAnnotation)
 }

--- a/tests/integration/testsuites/ory/scenario_migration_jwt_v1beta1.go
+++ b/tests/integration/testsuites/ory/scenario_migration_jwt_v1beta1.go
@@ -3,6 +3,7 @@ package ory
 import (
 	"context"
 	"fmt"
+
 	"github.com/avast/retry-go/v4"
 	"github.com/cucumber/godog"
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/manifestprocessor"
@@ -24,6 +25,8 @@ func initMigrationJwtV1beta1(ctx *godog.ScenarioContext, ts *testsuite) {
 	ctx.Step(`^migrationJwtV1beta1: Resource of Kind "([^"]*)" owned by APIRule does not exist$`, scenario.resourceOwnedByApiRuleDoesNotExist)
 	ctx.Step(`^migrationJwtV1beta1: Resource of Kind "([^"]*)" owned by APIRule exists$`, scenario.resourceOwnedByApiRuleExists)
 	ctx.Step(`^migrationJwtV1beta1: Calling the "([^"]*)" endpoint with a valid "([^"]*)" token should result in status between (\d+) and (\d+)$`, scenario.callingTheEndpointWithValidTokenShouldResultInStatusBetween)
+	ctx.Step(`^migrationJwtV1beta1: The APIRule contains original-version annotation set to "([^"]*)"$`, scenario.apiRuleContainsOriginalVersionAnnotation)
+
 }
 
 func (s *scenario) thereIsApiRuleVirtualServiceWithHttpbinServiceDestination() error {

--- a/tests/integration/testsuites/ory/scenario_migration_noauth_v1beta1.go
+++ b/tests/integration/testsuites/ory/scenario_migration_noauth_v1beta1.go
@@ -13,4 +13,5 @@ func initMigrationNoAuthV1beta1(ctx *godog.ScenarioContext, ts *testsuite) {
 	ctx.Step(`^migrationNoAuthV1beta1: APIRule has status "([^"]*)"$`, scenario.theAPIRuleHasStatus)
 	ctx.Step(`^migrationNoAuthV1beta1: Calling the "([^"]*)" endpoint without a token should result in status between (\d+) and (\d+)$`, scenario.callingTheEndpointWithoutTokenShouldResultInStatusBetween)
 	ctx.Step(`^migrationNoAuthV1beta1: Resource of Kind "([^"]*)" owned by APIRule exists$`, scenario.resourceOwnedByApiRuleExists)
+	ctx.Step(`^migrationNoAuthV1beta1: The APIRule contains original-version annotation set to "([^"]*)"$`, scenario.apiRuleContainsOriginalVersionAnnotation)
 }

--- a/tests/integration/testsuites/ory/scenario_migration_noop_v1beta1.go
+++ b/tests/integration/testsuites/ory/scenario_migration_noop_v1beta1.go
@@ -14,4 +14,5 @@ func initMigrationNoopV1beta1(ctx *godog.ScenarioContext, ts *testsuite) {
 	ctx.Step(`^migrationNoopV1beta1: Resource of Kind "([^"]*)" owned by APIRule does not exist$`, scenario.resourceOwnedByApiRuleDoesNotExist)
 	ctx.Step(`^migrationNoopV1beta1: Calling the "([^"]*)" endpoint without a token should result in status between (\d+) and (\d+)$`, scenario.callingTheEndpointWithoutTokenShouldResultInStatusBetween)
 	ctx.Step(`^migrationNoopV1beta1: Resource of Kind "([^"]*)" owned by APIRule exists$`, scenario.resourceOwnedByApiRuleExists)
+	ctx.Step(`^migrationNoopV1beta1: The APIRule contains original-version annotation set to "([^"]*)"$`, scenario.apiRuleContainsOriginalVersionAnnotation)
 }

--- a/tests/integration/testsuites/ory/scenario_migration_oauth2_introspection_v1beta1.go
+++ b/tests/integration/testsuites/ory/scenario_migration_oauth2_introspection_v1beta1.go
@@ -15,5 +15,5 @@ func initMigrationOauth2IntrospectionJwtV1beta1(ctx *godog.ScenarioContext, ts *
 	ctx.Step(`^migrationOAuth2IntrospectionJwtV1beta1: Resource of Kind "([^"]*)" owned by APIRule does not exist$`, scenario.resourceOwnedByApiRuleDoesNotExist)
 	ctx.Step(`^migrationOAuth2IntrospectionJwtV1beta1: Resource of Kind "([^"]*)" owned by APIRule exists$`, scenario.resourceOwnedByApiRuleExists)
 	ctx.Step(`^migrationOAuth2IntrospectionJwtV1beta1: Calling the "([^"]*)" endpoint with a valid "([^"]*)" token should result in status between (\d+) and (\d+)$`, scenario.callingTheEndpointWithValidTokenShouldResultInStatusBetween)
-
+	ctx.Step(`^migrationOAuth2IntrospectionJwtV1beta1: The APIRule contains original-version annotation set to "([^"]*)"$`, scenario.apiRuleContainsOriginalVersionAnnotation)
 }

--- a/tests/integration/testsuites/ory/testsuite.go
+++ b/tests/integration/testsuites/ory/testsuite.go
@@ -4,10 +4,11 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"fmt"
-	"github.com/kyma-project/api-gateway/tests/integration/pkg/global"
-	"github.com/kyma-project/api-gateway/tests/integration/pkg/hooks"
 	"log"
 	"path"
+
+	"github.com/kyma-project/api-gateway/tests/integration/pkg/global"
+	"github.com/kyma-project/api-gateway/tests/integration/pkg/hooks"
 
 	"github.com/cucumber/godog"
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/auth"
@@ -85,6 +86,7 @@ func (t *testsuite) InitScenarios(ctx *godog.ScenarioContext) {
 	initMigrationNoopV1beta1(ctx, t)
 	initMigrationJwtV1beta1(ctx, t)
 	initMigrationOauth2IntrospectionJwtV1beta1(ctx, t)
+	initApplyUpdatev1beta1(ctx, t)
 }
 
 func (t *testsuite) FeaturePath() []string {

--- a/tests/integration/testsuites/v2/features/no_auth.feature
+++ b/tests/integration/testsuites/v2/features/no_auth.feature
@@ -1,5 +1,5 @@
 Feature: Exposing endpoints with NoAuth
-
+# apply v2 (noauth)
   Scenario: Calling a httpbin endpoint unsecured on all paths
     Given The APIRule template file is set to "no-auth-wildcard.yaml"
     And There is a httpbin service
@@ -7,6 +7,8 @@ Feature: Exposing endpoints with NoAuth
     Then Calling the "/ip" endpoint without a token should result in status between 200 and 200
     And Calling the "/status/200" endpoint without a token should result in status between 200 and 200
     And Calling the "/headers" endpoint without a token should result in status between 200 and 200
+    And The APIRule contains original-version annotation set to "v2"
+    And Resource of Kind "AuthorizationPolicy" owned by APIRule exists
     And Teardown httpbin service
 
   Scenario: In-cluster calling a httpbin endpoint unsecured
@@ -15,3 +17,17 @@ Feature: Exposing endpoints with NoAuth
     When The APIRule is applied
     Then In-cluster calling the "/status/200" endpoint without a token should fail
     And In-cluster calling the "/headers" endpoint without a token should fail
+
+# update v2 (noAuth)
+  Scenario: Updating an APIRule and calling a httpbin endpoint unsecured on all paths
+    Given The APIRule template file is set to "no-auth-wildcard.yaml"
+    And There is a httpbin service
+    And The APIRule is applied
+    And The APIRule contains original-version annotation set to "v2"
+    When The APIRule is updated using manifest "no-auth-wildcard-updated.yaml"
+    Then Calling the "/ip" endpoint without a token should result in status between 200 and 200
+    And Calling the "/status/200" endpoint without a token should result in status between 200 and 200
+    And Calling the "/headers" endpoint without a token should result in status between 200 and 200
+    And The APIRule contains original-version annotation set to "v2"
+    And Resource of Kind "AuthorizationPolicy" owned by APIRule exists
+    And Teardown httpbin service

--- a/tests/integration/testsuites/v2/manifests/no-auth-wildcard-updated.yaml
+++ b/tests/integration/testsuites/v2/manifests/no-auth-wildcard-updated.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.kyma-project.io/v2
+kind: APIRule
+metadata:
+  name: "{{.NamePrefix}}-{{.TestID}}"
+  namespace: "{{.Namespace}}"
+spec:
+  gateway: "{{.GatewayNamespace}}/{{.GatewayName}}"
+  hosts:
+    - "httpbin-{{.TestID}}.{{.Domain}}"
+  service:
+    name: httpbin-{{.TestID}}
+    port: 8000
+  rules:
+    - path: /{**}
+      methods: ["GET"]
+      noAuth: true

--- a/tests/integration/testsuites/v2/scenario.go
+++ b/tests/integration/testsuites/v2/scenario.go
@@ -1,6 +1,7 @@
 package v2
 
 import (
+	"context"
 	_ "embed"
 	"errors"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/resource"
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/testcontext"
 	"golang.org/x/oauth2/clientcredentials"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/dynamic"
 )
 
@@ -409,4 +411,56 @@ func (s *scenario) callingTheEndpointWithValidTokenShouldResultInBodyContaining(
 		AsHeader: true,
 	}
 	return s.callingEndpointWithMethodAndHeaders(fmt.Sprintf("%s/%s", s.Url, strings.TrimLeft(endpoint, "/")), http.MethodGet, tokenType, asserter, nil, &tokenFrom)
+}
+
+func (s *scenario) apiRuleContainsOriginalVersionAnnotation(version string) error {
+	res, err := manifestprocessor.ParseSingleEntryFromFileWithTemplate(s.ApiResourceManifestPath, s.ApiResourceDirectory, s.ManifestTemplate)
+	if err != nil {
+		return err
+	}
+
+	groupVersionResource, err := resource.GetGvrFromUnstructured(s.resourceManager, res)
+	if err != nil {
+		return err
+	}
+
+	return retry.Do(func() error {
+		apiRule, err := s.resourceManager.GetResource(s.k8sClient, *groupVersionResource, res.GetNamespace(), res.GetName())
+		if err != nil {
+			return fmt.Errorf("failed to get APIRule: %w", err)
+		}
+
+		versionAnnotation := apiRule.GetAnnotations()["gateway.kyma-project.io/original-version"]
+		if versionAnnotation != version {
+			return fmt.Errorf("expected original version annotation to be %s, got %s", version, versionAnnotation)
+		}
+
+		return nil
+	}, testcontext.GetRetryOpts()...)
+}
+
+func (s *scenario) resourceOwnedByApiRuleExists(resourceKind string) error {
+	res := resource.GetResourceGvr(resourceKind)
+	name := s.ManifestTemplate["NamePrefix"]
+	ownerLabelSelector := fmt.Sprintf("apirule.gateway.kyma-project.io/v1beta1=%s-%s.%s", name, s.TestID, s.Namespace)
+	return retry.Do(func() error {
+		list, err := s.k8sClient.Resource(res).Namespace(s.Namespace).List(context.Background(), metav1.ListOptions{LabelSelector: ownerLabelSelector})
+		if err != nil {
+			return err
+		}
+
+		if len(list.Items) == 0 {
+			return fmt.Errorf("expected at least one %s owned by APIRule, got 0", resourceKind)
+		}
+
+		return nil
+	}, testcontext.GetRetryOpts()...)
+}
+
+func (s *scenario) theAPIRuleIsUpdated(manifest string) error {
+	res, err := manifestprocessor.ParseSingleEntryFromFileWithTemplate(manifest, s.ApiResourceDirectory, s.ManifestTemplate)
+	if err != nil {
+		return err
+	}
+	return helpers.UpdateApiRule(s.resourceManager, s.k8sClient, testcontext.GetRetryOpts(), res)
 }

--- a/tests/integration/testsuites/v2/scenario_initializers.go
+++ b/tests/integration/testsuites/v2/scenario_initializers.go
@@ -2,11 +2,12 @@ package v2
 
 import (
 	"fmt"
+	"net/http"
+	"strings"
+
 	"github.com/cucumber/godog"
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/helpers"
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/manifestprocessor"
-	"net/http"
-	"strings"
 )
 
 func initScenario(ctx *godog.ScenarioContext, ts *testsuite) {
@@ -65,6 +66,9 @@ func initScenario(ctx *godog.ScenarioContext, ts *testsuite) {
 	ctx.Step(`^There is an endpoint secured with JWT on path "([^"]*)" with service definition$`, scenario.thereIsAnEndpointWithServiceDefinition)
 	ctx.Step(`^There is an endpoint secured with JWT on path "([^"]*)"$`, scenario.thereIsAnJwtSecuredPath)
 	ctx.Step(`^There is an httpbin service$`, scenario.thereIsAHttpbinService)
+	ctx.Step(`^The APIRule is updated using manifest "([^"]*)"$`, scenario.theAPIRuleIsUpdated)
+	ctx.Step(`^The APIRule contains original-version annotation set to "([^"]*)"$`, scenario.apiRuleContainsOriginalVersionAnnotation)
+	ctx.Step(`^Resource of Kind "([^"]*)" owned by APIRule exists$`, scenario.resourceOwnedByApiRuleExists)
 }
 
 func (s *scenario) applyApiRuleWithCustomCORS(allowOrigins, allowMethods, allowHeaders, allowCredentials, exposeHeaders, maxAge string) error {

--- a/tests/integration/testsuites/v2alpha1/features/no_auth.feature
+++ b/tests/integration/testsuites/v2alpha1/features/no_auth.feature
@@ -1,5 +1,5 @@
 Feature: Exposing endpoints with NoAuth
-
+# apply v2alpha1 (noAuth)
   Scenario: Calling a httpbin endpoint unsecured on all paths
     Given The APIRule template file is set to "no-auth-wildcard.yaml"
     And There is a httpbin service
@@ -7,4 +7,20 @@ Feature: Exposing endpoints with NoAuth
     Then Calling the "/ip" endpoint without a token should result in status between 200 and 200
     And Calling the "/status/200" endpoint without a token should result in status between 200 and 200
     And Calling the "/headers" endpoint without a token should result in status between 200 and 200
+    And The APIRule contains original-version annotation set to "v2alpha1"
+    And Resource of Kind "AuthorizationPolicy" owned by APIRule exists
+    And Teardown httpbin service
+
+# update v2alpha1 (noAuth)
+  Scenario: Updating an APIRule and calling a httpbin endpoint unsecured on all paths
+    Given The APIRule template file is set to "no-auth-wildcard.yaml"
+    And There is a httpbin service
+    And The APIRule is applied
+    And The APIRule contains original-version annotation set to "v2alpha1"
+    When The APIRule is updated using manifest "no-auth-wildcard-updated.yaml"
+    Then Calling the "/ip" endpoint without a token should result in status between 200 and 200
+    And Calling the "/status/200" endpoint without a token should result in status between 200 and 200
+    And Calling the "/headers" endpoint without a token should result in status between 200 and 200
+    And The APIRule contains original-version annotation set to "v2alpha1"
+    And Resource of Kind "AuthorizationPolicy" owned by APIRule exists
     And Teardown httpbin service

--- a/tests/integration/testsuites/v2alpha1/manifests/no-auth-wildcard-updated.yaml
+++ b/tests/integration/testsuites/v2alpha1/manifests/no-auth-wildcard-updated.yaml
@@ -1,0 +1,16 @@
+apiVersion: gateway.kyma-project.io/v2alpha1
+kind: APIRule
+metadata:
+  name: "{{.NamePrefix}}-{{.TestID}}"
+  namespace: "{{.Namespace}}"
+spec:
+  gateway: "{{.GatewayNamespace}}/{{.GatewayName}}"
+  hosts:
+    - "httpbin-{{.TestID}}.{{.Domain}}"
+  service:
+    name: httpbin-{{.TestID}}
+    port: 8000
+  rules:
+    - path: /{**}
+      methods: ["GET"]
+      noAuth: true

--- a/tests/integration/testsuites/v2alpha1/scenario_initializers.go
+++ b/tests/integration/testsuites/v2alpha1/scenario_initializers.go
@@ -2,11 +2,12 @@ package v2alpha1
 
 import (
 	"fmt"
+	"net/http"
+	"strings"
+
 	"github.com/cucumber/godog"
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/helpers"
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/manifestprocessor"
-	"net/http"
-	"strings"
 )
 
 func initScenario(ctx *godog.ScenarioContext, ts *testsuite) {
@@ -64,6 +65,9 @@ func initScenario(ctx *godog.ScenarioContext, ts *testsuite) {
 	ctx.Step(`^There is an endpoint secured with JWT on path "([^"]*)" with service definition$`, scenario.thereIsAnEndpointWithServiceDefinition)
 	ctx.Step(`^There is an endpoint secured with JWT on path "([^"]*)"$`, scenario.thereIsAnJwtSecuredPath)
 	ctx.Step(`^There is an httpbin service$`, scenario.thereIsAHttpbinService)
+	ctx.Step(`^The APIRule contains original-version annotation set to "([^"]*)"$`, scenario.apiRuleContainsOriginalVersionAnnotation)
+	ctx.Step(`^Resource of Kind "([^"]*)" owned by APIRule exists$`, scenario.resourceOwnedByApiRuleExists)
+	ctx.Step(`^The APIRule is updated using manifest "([^"]*)"$`, scenario.theAPIRuleIsUpdated)
 }
 
 func (s *scenario) applyApiRuleWithCustomCORS(allowOrigins, allowMethods, allowHeaders, allowCredentials, exposeHeaders, maxAge string) error {


### PR DESCRIPTION
- Extend ory migration tests to ensure the migration handles changes in reconciliation version properly
- Extend v2 and v2alpha1 to ensure the update and apply handles changes in reconciliation version properly
- Add v1beta1 test to ensure the update and apply handles changes in reconciliation version properly