### PR TITLE
fix upgrade tests and resolve typo in custom-domain tests

### DIFF
--- a/tests/integration/testsuites/custom-domain/manifests/oauth-strategy.yaml
+++ b/tests/integration/testsuites/custom-domain/manifests/oauth-strategy.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   gateway: "{{.GatewayNamespace}}/{{.GatewayName}}"
   hosts:
-    - "httpbin-{{.TestID}}.{{.Domain}}"
+    - "httpbin-{{.TestID}}.{{.Subdomain}}"
   service:
     name: httpbin-{{.TestID}}
     port: 8000

--- a/tests/integration/testsuites/upgrade/manifests/istio-jwt-common.yaml
+++ b/tests/integration/testsuites/upgrade/manifests/istio-jwt-common.yaml
@@ -1,12 +1,19 @@
 apiVersion: gateway.kyma-project.io/v2
 kind: APIRule
 metadata:
-  annotations:
-    gateway.kyma-project.io/original-version: v1beta1
-    gateway.kyma-project.io/v1beta1-spec: '{"host":"httpbin-{{.TestID}}.{{.Domain}}","service":{"name":"httpbin-{{.TestID}}","port":8000},"gateway":"{{.GatewayNamespace}}/{{.GatewayName}}","rules":[{"path":"{{
-      .jwtSecuredPath }}","methods":["GET"],"accessStrategies":[{"handler":"jwt","config":{"authentications":[{"issuer":"{{
-      .IssuerUrl }}","jwksUri":"{{ .IssuerUrl }}/oauth2/certs"}]}}]}]}'
-  creationTimestamp: null
   name: '{{.NamePrefix}}-{{.TestID}}'
   namespace: '{{.Namespace}}'
-spec: {}
+spec:
+  hosts:
+    - "httpbin-{{.TestID}}.{{.Domain}}"
+  service:
+    name: httpbin-{{.TestID}}
+    port: 8000
+  gateway: "{{.GatewayNamespace}}/{{.GatewayName}}"
+  rules:
+    - path: "{{.jwtSecuredPath}}"
+      methods: ["GET"]
+      jwt:
+        authentications:
+          - issuer: "{{ .IssuerUrl }}"
+            jwksUri: "{{ .IssuerUrl }}/oauth2/certs"

--- a/tests/integration/testsuites/upgrade/manifests/istio-jwt-upgrade.yaml
+++ b/tests/integration/testsuites/upgrade/manifests/istio-jwt-upgrade.yaml
@@ -1,12 +1,19 @@
 apiVersion: gateway.kyma-project.io/v2
 kind: APIRule
 metadata:
-  annotations:
-    gateway.kyma-project.io/original-version: v1beta1
-    gateway.kyma-project.io/v1beta1-spec: '{"host":"httpbin-{{.TestID}}.{{.Domain}}","service":{"name":"httpbin-{{.TestID}}","port":8000},"gateway":"{{.GatewayNamespace}}/{{.GatewayName}}","rules":[{"path":"{{
-      .jwtSecuredPath }}","methods":["GET"],"accessStrategies":[{"handler":"jwt","config":{"authentications":[{"issuer":"{{
-      .IssuerUrl }}","jwksUri":"{{ .IssuerUrl }}/oauth2/certs"}]}}]}]}'
-  creationTimestamp: null
   name: '{{.NamePrefix}}-{{.TestID}}'
   namespace: '{{.Namespace}}'
-spec: {}
+spec:
+  hosts:
+    - "httpbin-{{.TestID}}.{{.Domain}}"
+  service:
+    name: httpbin-{{.TestID}}
+    port: 8000
+  gateway: "{{.GatewayNamespace}}/{{.GatewayName}}"
+  rules:
+    - path: "{{.jwtSecuredPath}}"
+      methods: ["GET"]
+      jwt:
+        authentications:
+          - issuer: "{{ .IssuerUrl }}"
+            jwksUri: "{{ .IssuerUrl }}/oauth2/certs"


### PR DESCRIPTION
* rewrite upgrade tests to use apirule v2 natively
* fix typo in custom-domain manifests

#1988 