### PR TITLE
bug: fix assignment of LastProcessedTime field in apirule_controller.go

### DIFF
--- a/controllers/gateway/apirule_controller.go
+++ b/controllers/gateway/apirule_controller.go
@@ -113,16 +113,16 @@ func (r *APIRuleReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		l.Error(err, "Error while getting APIRule v2alpha1")
 		return doneReconcileErrorRequeue(err, errorReconciliationPeriod)
 	}
+
+	// assign LastProcessedTime early to indicate that resource got reconciled
+	apiRuleV2alpha1.Status.LastProcessedTime = metav1.Now()
+
 	apiRule := gatewayv1beta1.APIRule{}
 	err = apiRule.ConvertFrom(apiRuleV2alpha1)
 	if err != nil {
 		l.Error(err, "Error while converting APIRule v2alpha1 to v1beta1")
 		return doneReconcileErrorRequeue(err, errorReconciliationPeriod)
 	}
-
-	// assign LastProcessedTime and ObservedGeneration early to indicate that
-	// resource got reconciled
-	apiRule.Status.LastProcessedTime = metav1.Now()
 	apiRule.Status.ObservedGeneration = apiRule.Generation
 
 	if !apiRule.DeletionTimestamp.IsZero() {
@@ -404,8 +404,8 @@ func (r *APIRuleReconciler) convertAndUpdateStatus(ctx context.Context, l logr.L
 			toUpdate.Status.Description = "Version v1beta1 of APIRule is" +
 				" deprecated and will be removed in future releases. Use version v2 instead."
 		} else {
-			toUpdate.Status.Description = fmt.Sprintf("Version v1beta1 of APIRule is deprecated and will" +
-				" be removed in future releases. " +
+			toUpdate.Status.Description = fmt.Sprintf("Version v1beta1 of APIRule is deprecated and will"+
+				" be removed in future releases. "+
 				"Use version v2 instead.\n\n%s", toUpdate.Status.Description)
 		}
 	}

--- a/tests/integration/pkg/helpers/curl.go
+++ b/tests/integration/pkg/helpers/curl.go
@@ -3,8 +3,9 @@ package helpers
 import (
 	"context"
 	"fmt"
-	"github.com/kyma-project/api-gateway/tests/integration/pkg/client"
 	"time"
+
+	"github.com/kyma-project/api-gateway/tests/integration/pkg/client"
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -44,8 +45,10 @@ func RunCurlInPod(namespace string, command []string) ([]byte, error) {
 			RestartPolicy: corev1.RestartPolicyNever,
 			Containers: []corev1.Container{
 				{
-					Name:    "curl",
-					Image:   "curlimages/curl",
+					Name: "curl",
+					// since curlimages/curl:8.14.1 there is a bug that causes the container to exit with zero exit code
+					// when used with `--fail-with-body` option, so we use 8.13.0 version
+					Image:   "curlimages/curl:8.13.0",
 					Command: command,
 				},
 			},

--- a/tests/integration/testsuites/upgrade/scenario.go
+++ b/tests/integration/testsuites/upgrade/scenario.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/avast/retry-go/v4"
 	"github.com/cucumber/godog"
-	apirulev1beta1 "github.com/kyma-project/api-gateway/apis/gateway/v1beta1"
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/auth"
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/helpers"
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/manifestprocessor"
@@ -30,12 +29,6 @@ var deploymentGVR = schema.GroupVersionResource{
 	Group:    "apps",
 	Version:  "v1",
 	Resource: "deployments",
-}
-
-var apiRuleV1GVR = schema.GroupVersionResource{
-	Group:    apirulev1beta1.GroupVersion.Group,
-	Version:  apirulev1beta1.GroupVersion.Version,
-	Resource: "apirules",
 }
 
 var apiRuleV2Alpha1GVR = schema.GroupVersionResource{
@@ -227,9 +220,9 @@ func (s *scenario) fetchAPIRuleLastProcessedTime() error {
 
 	return retry.Do(func() error {
 		for _, apiRule := range apiRules {
-			var apiRuleStructured apirulev1beta1.APIRule
+			var apiRuleStructured apirulev2.APIRule
 			name := apiRule.GetName()
-			res, err := s.resourceManager.GetResource(s.k8sClient, apiRuleV1GVR, apiRule.GetNamespace(), name, testcontext.GetRetryOpts()...)
+			res, err := s.resourceManager.GetResource(s.k8sClient, apiRuleV2GVR, apiRule.GetNamespace(), name, testcontext.GetRetryOpts()...)
 
 			if err != nil {
 				return err
@@ -254,9 +247,9 @@ func (s *scenario) apiRuleWasReconciledAgain() error {
 
 	return retry.Do(func() error {
 		for _, apiRule := range apiRules {
-			var apiRuleStructured apirulev1beta1.APIRule
+			var apiRuleStructured apirulev2.APIRule
 			name := apiRule.GetName()
-			res, err := s.resourceManager.GetResource(s.k8sClient, apiRuleV1GVR, apiRule.GetNamespace(), name, testcontext.GetRetryOpts()...)
+			res, err := s.resourceManager.GetResource(s.k8sClient, apiRuleV2GVR, apiRule.GetNamespace(), name, testcontext.GetRetryOpts()...)
 
 			if err != nil {
 				return err


### PR DESCRIPTION
* fix assignment of LastProcessedTime field in apirule_controller.go
* pin curl to specific version - 8.14.1 has small regression https://github.com/curl/curl/issues/17554
* adjust upgrade scenario to only use v2(alpha1)

#1988 