### PR TITLE
tests: hack: add patch logic to gardener integration script

### DIFF
--- a/.github/actions/e2e-test-k3d/action.yaml
+++ b/.github/actions/e2e-test-k3d/action.yaml
@@ -47,10 +47,11 @@ runs:
         kubectl config use-context k3d-k3s-default
            
         # hack: apply custom patches to the repo for tests to work
-        for patch in $(find hack/patches/ -name '*.patch'); do
-          echo "Applying patch $patch"
-          git apply --ignore-whitespace $patch || exit 1
-        done
+        find hack/patches/ -name '*.patch' -exec git apply --ignore-whitespace {} \; || {
+          echo "error: could not apply patches, please check them in hack/patches/ directory"
+          exit 1
+        }
+
         
         EXPORT_RESULT=true make install-istio deploy ${{ inputs.test_make_target }}
     - shell: bash

--- a/hack/ci/integration-test-gardener.sh
+++ b/hack/ci/integration-test-gardener.sh
@@ -59,6 +59,12 @@ export IS_GARDENER=true # this variable is used in tests to make decisions based
 # Add pwd to path to be able to use binaries downloaded in scripts
 export PATH="${PATH}:${PWD}"
 
+# hack: apply custom patches to the repo for tests to work
+find hack/patches/ -name '*.patch' -exec git apply --ignore-whitespace {} \; || {
+  echo "error: could not apply patches, please check them in hack/patches/ directory"
+  exit 1
+}
+
 echo "Installing istio"
 make install-istio
 


### PR DESCRIPTION
Add patching to integration-test-gardener.sh.
This should resolve the validation errors in gardener int runs, the same as in K3d

#1988