### PR TITLE
Remove build-engine: buildx

### DIFF
--- a/.github/workflows/post-main-integration.yaml
+++ b/.github/workflows/post-main-integration.yaml
@@ -27,7 +27,6 @@ jobs:
       build-args: |
         VERSION=${{ github.sha }}
       tags: "${{ github.sha }}"
-      build-engine: buildx
 
   unit-tests:
     name: Unit, integration tests & lint

--- a/.github/workflows/release-api-gateway-2.yaml
+++ b/.github/workflows/release-api-gateway-2.yaml
@@ -57,7 +57,6 @@ jobs:
       build-args: |
         VERSION=${{ needs.check-prerequisites.outputs.current_release }}
       tags: "${{ needs.check-prerequisites.outputs.current_release }}"
-      build-engine: buildx
 
   unit-tests:
     uses: ./.github/workflows/call-unit-lint.yaml

--- a/.github/workflows/release-create-release.yaml
+++ b/.github/workflows/release-create-release.yaml
@@ -38,7 +38,6 @@ jobs:
       build-args: |
         VERSION=${{ github.event.inputs.name }}
       tags: "${{ github.event.inputs.name }}"
-      build-engine: buildx
 
   unit-tests:
     uses: ./.github/workflows/call-unit-lint.yaml


### PR DESCRIPTION
This PR removes the deprecated `build-engine: buildx` entry from workflows.