### PR TITLE
Removed after-scenario hook in Rate Limit tests to skip cleanup after test failure

### DIFF
--- a/tests/integration/testsuites/rate-limit/features/local_rate_limit.feature
+++ b/tests/integration/testsuites/rate-limit/features/local_rate_limit.feature
@@ -4,13 +4,19 @@ Feature: Local rate limiting targeting pod
     Given there is a httpbin service
     When RateLimit header-based configuration is applied
     Then calling the "/ip" endpoint with header should result in status code 429 for requests
+    And Teardown RateLimit
+    And Teardown httpbin service
 
   Scenario: Connectivity to pod rate limited by path and header based configuration
     Given there is a httpbin service
     When RateLimit path and header based configuration is applied
     Then calling the "/headers" endpoint with header should result in status code 429 for requests
+    And Teardown RateLimit
+    And Teardown httpbin service
 
   Scenario: Connectivity to pod rate limited by path-based configuration
     Given there is a httpbin service
     When RateLimit path-based configuration is applied
     Then calling the "/ip" endpoint should result in status code 429 for requests
+    And Teardown RateLimit
+    And Teardown httpbin service

--- a/tests/integration/testsuites/rate-limit/features/local_rate_limit_targeting_ingress_gateway.feature
+++ b/tests/integration/testsuites/rate-limit/features/local_rate_limit_targeting_ingress_gateway.feature
@@ -4,13 +4,19 @@ Feature: Local rate limiting targeting Ingress Gateway
     Given there is a httpbin service
     When RateLimit targeting Istio ingress gateway with header-based configuration is applied
     Then calling the "/ip" endpoint with header should result in status code 429 for requests
+    And Teardown RateLimit
+    And Teardown httpbin service
 
   Scenario: Connectivity to ingress rate limited by path and header based configuration
     Given there is a httpbin service
     When RateLimit targeting Istio ingress gateway with path and header based configuration is applied
     Then calling the "/headers" endpoint with header should result in status code 429 for requests
+    And Teardown RateLimit
+    And Teardown httpbin service
 
   Scenario: Connectivity to ingress rate limited by path-based configuration
     Given there is a httpbin service
     When RateLimit targeting Istio ingress gateway with path-based configuration is applied
     Then calling the "/ip" endpoint should result in status code 429 for requests
+    And Teardown RateLimit
+    And Teardown httpbin service

--- a/tests/integration/testsuites/rate-limit/scenario_initializers.go
+++ b/tests/integration/testsuites/rate-limit/scenario_initializers.go
@@ -2,14 +2,10 @@ package ratelimit
 
 import (
 	"github.com/cucumber/godog"
-
-	"github.com/kyma-project/api-gateway/tests/integration/pkg/hooks"
 )
 
 func initScenario(ctx *godog.ScenarioContext, ts *testsuite) {
 	scenario := ts.createScenario()
-
-	ctx.After(hooks.DeleteBlockingResourcesScenarioHook)
 
 	ctx.Step(`^calling the "([^"]*)" endpoint should result in status code (\d+) for requests$`, scenario.callingEndpointNTimesShouldResultWithStatusCode)
 	ctx.Step(`^calling the "([^"]*)" endpoint with header should result in status code (\d+) for requests$`, scenario.callingEndpointWithHeadersNTimesShouldResultWithStatusCode)
@@ -17,7 +13,9 @@ func initScenario(ctx *godog.ScenarioContext, ts *testsuite) {
 	ctx.Step(`^RateLimit header-based configuration is applied$`, scenario.rateLimitWithHeaderBaseConfigurationApplied)
 	ctx.Step(`^RateLimit path and header based configuration is applied$`, scenario.rateLimitWithPathAndHeaderBaseConfigurationApplied)
 	ctx.Step(`^there is a httpbin service$`, scenario.thereIsAHttpbinService)
+	ctx.Step(`^Teardown httpbin service$`, scenario.teardownHttpbinService)
 	ctx.Step(`^RateLimit targeting Istio ingress gateway with path-based configuration is applied$`, scenario.rateLimitTargetingIngressWithPathBaseConfigurationApplied)
 	ctx.Step(`^RateLimit targeting Istio ingress gateway with header-based configuration is applied$`, scenario.rateLimitTargetingIngressWithHeaderBaseConfigurationApplied)
 	ctx.Step(`^RateLimit targeting Istio ingress gateway with path and header based configuration is applied$`, scenario.rateLimitTargetingIngressWithPathAndHeaderBaseConfigurationApplied)
+	ctx.Step(`^Teardown RateLimit`, scenario.tearDownRateLimit)
 }


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- removed after-scenario hook in Rate Limit tests to skip cleanup after test failure; it now also correctly waits for apigateway CR creation
- moved apigateway CR creation/deletion to suite hooks (like in other suites)
- ensured httpbin and rate limit cleanup in feature files (previously rate limit was cleaned by scenario hook and httpbin was not cleaned)

**Pre-Merge Checklist**

- [x] As a PR reviewer, verify code coverage and evaluate if it is acceptable.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
