### PR TITLE
Hash value of namespace into label of AuthorizationPolicy. (#2167)

### DIFF
--- a/docs/release-notes/3.2.1.md
+++ b/docs/release-notes/3.2.1.md
@@ -1,2 +1,3 @@
 ## Bug Fixes
 - We've fixed a bug where APIRules `v2alpha1` and `v2` were set to the `Error` state when the target workload was in the mesh with the Istio proxy running in native sidecar mode. See [#2100](https://github.com/kyma-project/api-gateway/issues/2100).
+- We've fixed a bug that caused AuthorizationPolicy creation to fail for APIRules in namespaces with names longer than 36 characters. Now, namespace names up to 63 characters are supported. [#2143](https://github.com/kyma-project/api-gateway/issues/2143) 

--- a/internal/processing/hashbasedstate/actual.go
+++ b/internal/processing/hashbasedstate/actual.go
@@ -22,7 +22,7 @@ type Actual struct {
 	markedForDeletion []client.Object
 }
 
-// Add the value to the desired state. If the value does not have the hash and index labels, an error is returned.
+// Add the value to the actual state. If the value does not have the hash and index labels, an error is returned.
 func (a *Actual) Add(hashable Hashable) {
 	index, ok := hashable.index()
 	if !ok {


### PR DESCRIPTION
* Hash value of namespace into label of AuthorizationPolicy.

* Add release notes for 3.2.1

* Update AP when hash label in legacy format.

* Update docs/release-notes/3.2.1.md



* Add unit test for legacy hash label format update.

---------

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Hash value of namespace into label of AuthorizationPolicy

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make generate-manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
