### PR TITLE
Fix tabs in multiple namespace tutorial

### DIFF
--- a/docs/user/tutorials/01-40-expose-workload/01-42-expose-workloads-multiple-namespaces.md
+++ b/docs/user/tutorials/01-40-expose-workload/01-42-expose-workloads-multiple-namespaces.md
@@ -60,8 +60,6 @@ Learn how to expose Service endpoints in multiple namespaces.
 
 #### **kubectl**
 
-<!-- tabs:end -->
-
 1. Create a separate namespace for the APIRule CR with enabled Istio sidecar proxy injection.
     ```bash
     export NAMESPACE={NAMESPACE_NAME}
@@ -98,6 +96,7 @@ Learn how to expose Service endpoints in multiple namespaces.
           noAuth: true
     EOF
     ```
+<!-- tabs:end -->
 
 ### Access Your Workloads
 
@@ -108,4 +107,5 @@ To call the endpoints, send `GET` requests to the exposed Services:
 
   curl -ik -X GET https://{SUBDOMAIN}.{DOMAIN_NAME}/get
   ```
+  
 If successful, the calls return the `200 OK` response code.


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Fix tabs in the tutorial [Expose Workloads in Multiple Namespaces With a Single APIRule Definition](https://kyma-project.io/#/api-gateway/user/tutorials/01-40-expose-workload/01-42-expose-workloads-multiple-namespaces?id=expose-workloads-in-multiple-namespaces-with-a-single-apirule-definition)

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make generate-manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
