### PR TITLE
fix: APIRule translate legacy gateway name format to new one "<namespace>/<gateway-name>" (#2120)(cherry-pick)

### DIFF
--- a/apis/gateway/v1beta1/apirule_conversion_test.go
+++ b/apis/gateway/v1beta1/apirule_conversion_test.go
@@ -25,7 +25,8 @@ var _ = Describe("APIRule Conversion", func() {
 		},
 	}
 	testObjectMeta := metav1.ObjectMeta{
-		Name: "test",
+		Name:      "test",
+		Namespace: "test-namespace",
 	}
 
 	noAuthRuleWithConvertablePath := v1beta1.Rule{
@@ -163,7 +164,7 @@ var _ = Describe("APIRule Conversion", func() {
 
 			//then
 			Expect(err).ToNot(HaveOccurred())
-			Expect(*apiRuleV2alpha1.Spec.Gateway).To(Equal("gateway"))
+			Expect(*apiRuleV2alpha1.Spec.Gateway).To(Equal("test-namespace/gateway"))
 			Expect(*apiRuleV2alpha1.Spec.Service.Name).To(Equal("rule-service"))
 			Expect(apiRuleV2alpha1.Spec.Rules).To(HaveLen(1))
 			Expect(apiRuleV2alpha1.Spec.Rules[0].Path).To(Equal("/path1"))
@@ -204,7 +205,7 @@ var _ = Describe("APIRule Conversion", func() {
 				Service: &v2alpha1.Service{
 					Name: ptr.To("rule-service"),
 				},
-				Gateway: ptr.To("gateway"),
+				Gateway: ptr.To("test-namespace/gateway"),
 			}))
 		})
 
@@ -434,6 +435,7 @@ var _ = Describe("APIRule Conversion", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(apiRuleV2alpha1.Annotations["gateway.kyma-project.io/v1beta1-spec"]).To(BeEquivalentTo(`{"host":"host1","service":{"name":"service-test","namespace":"test-namespace","port":8080},"gateway":"gateway-test","rules":[{"path":"/path1","service":{"name":"service","port":null},"methods":["GET","POST"],"accessStrategies":[{"handler":"jwt"}],"mutators":[{"handler":"header","config":{"header1":"value1"}},{"handler":"cookie","config":{"cookie1":"value2"}}]}]}`))
 		})
+
 		It("should convert spec from annotation for v2alpha1 stored in v1beta1", func() {
 			v1alpha1AnnotationRules := `[{"path":"/*","methods":["GET"],"noAuth":true}]`
 

--- a/apis/gateway/v2/apirule_conversion.go
+++ b/apis/gateway/v2/apirule_conversion.go
@@ -8,6 +8,7 @@ import (
 
 	gatewayv1beta1 "github.com/kyma-project/api-gateway/apis/gateway/v1beta1"
 	"github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
+	"github.com/kyma-project/api-gateway/internal/gatewaytranslator"
 )
 
 const (
@@ -62,10 +63,23 @@ func (ruleV2 *APIRule) ConvertFrom(hub conversion.Hub) error {
 			if err != nil {
 				return err
 			}
+
+			if ruleV1.Spec.Gateway != nil && gatewaytranslator.IsOldGatewayNameFormat(*ruleV1.Spec.Gateway) {
+				convertedGatewayName, err := gatewaytranslator.TranslateGatewayNameToNewFormat(*ruleV1.Spec.Gateway, ruleV1.Namespace)
+				if err != nil {
+					ruleV1.Spec.Gateway = nil
+				}
+
+				ruleV1.Spec.Gateway = &convertedGatewayName
+			}
 			err = convertOverJson(ruleV1.Spec.Gateway, &ruleV2.Spec.Gateway)
 			if err != nil {
 				return err
 			}
+			if ruleV2.Spec.Gateway != nil && !gatewaytranslator.IsCorrectNewGatewayNameFormat(*ruleV2.Spec.Gateway) {
+				ruleV2.Spec.Gateway = nil
+			}
+
 			err = convertOverJson(ruleV1.Spec.Service, &ruleV2.Spec.Service)
 			if err != nil {
 				return err
@@ -98,7 +112,6 @@ func (ruleV2 *APIRule) ConvertFrom(hub conversion.Hub) error {
 			}
 		}
 	}
-
 	return nil
 }
 

--- a/apis/gateway/v2alpha1/apirule_types.go
+++ b/apis/gateway/v2alpha1/apirule_types.go
@@ -16,10 +16,11 @@ limitations under the License.
 package v2alpha1
 
 import (
-	"github.com/kyma-project/api-gateway/apis/gateway/versions"
 	"istio.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/kyma-project/api-gateway/apis/gateway/versions"
 )
 
 type State string

--- a/docs/release-notes/3.2.2.md
+++ b/docs/release-notes/3.2.2.md
@@ -1,0 +1,2 @@
+## Bug Fixes
+- The APIRule CR's status is now correctly updated when **spec.gateway** uses the old legacy format. See [#2067](https://github.com/kyma-project/api-gateway/issues/2067).

--- a/internal/gatewaytranslator/gatewaytranslator.go
+++ b/internal/gatewaytranslator/gatewaytranslator.go
@@ -1,0 +1,38 @@
+package gatewaytranslator
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+func TranslateGatewayNameToNewFormat(gatewayName string, namespace string) (string, error) {
+	splitGatewayName := strings.Split(gatewayName, ".")
+	switch len(splitGatewayName) {
+	case 5: // old format with .svc.cluster.local suffix
+		gatewayName = strings.TrimSuffix(gatewayName, ".svc.cluster.local")
+	case 4: // old format with .svc.cluster suffix
+		gatewayName = strings.TrimSuffix(gatewayName, ".svc.cluster")
+	case 3: // old format with .svc suffix
+		gatewayName = strings.TrimSuffix(gatewayName, ".svc")
+	case 2: // old format with no suffix
+		return fmt.Sprintf("%s/%s", splitGatewayName[1], splitGatewayName[0]), nil
+	case 1: // old format without namespace
+		return fmt.Sprintf("%s/%s", namespace, gatewayName), nil
+	}
+	parts := strings.Split(gatewayName, ".")
+	if len(parts) == 2 {
+		return fmt.Sprintf("%s/%s", parts[1], parts[0]), nil
+	}
+	return "", fmt.Errorf("gateway name (%s) is not in old gateway format", gatewayName)
+}
+
+func IsOldGatewayNameFormat(gatewayName string) bool {
+	match, err := regexp.MatchString(`^[0-9a-z-_]+(\/[0-9a-z-_]+|(\.[0-9a-z-_]+)*)$`, gatewayName)
+	return !IsCorrectNewGatewayNameFormat(gatewayName) && err == nil && match
+}
+
+func IsCorrectNewGatewayNameFormat(gatewayName string) bool {
+	match, err := regexp.MatchString(`^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?\/([a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)$`, gatewayName)
+	return err == nil && match
+}

--- a/internal/gatewaytranslator/gatewaytranslator_suite_test.go
+++ b/internal/gatewaytranslator/gatewaytranslator_suite_test.go
@@ -1,0 +1,20 @@
+package gatewaytranslator_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/onsi/ginkgo/v2/types"
+	. "github.com/onsi/gomega"
+
+	"github.com/kyma-project/api-gateway/tests"
+)
+
+func TestGatewayTranslator(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Gateway translator Suite")
+}
+
+var _ = ReportAfterSuite("custom reporter", func(report types.Report) {
+	tests.GenerateGinkgoJunitReport("gatewaytaranslator", report)
+})

--- a/internal/gatewaytranslator/gatewaytranslator_test.go
+++ b/internal/gatewaytranslator/gatewaytranslator_test.go
@@ -1,0 +1,136 @@
+package gatewaytranslator_test
+
+import (
+	"errors"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	"github.com/kyma-project/api-gateway/internal/gatewaytranslator"
+)
+
+var _ = Describe("Gateway translator ", func() {
+	Describe("IsOldGatewayNameFormat", func() {
+		It("should return true for correct old gateway name format", func() {
+			gatewayName := "test-gateway.default.svc.cluster.local"
+			Expect(gatewaytranslator.IsOldGatewayNameFormat(gatewayName)).To(BeTrue())
+		})
+
+		It("should return true for correct shorter old gateway name format ", func() {
+			gatewayName := "test-gateway.default.svc.cluster"
+			Expect(gatewaytranslator.IsOldGatewayNameFormat(gatewayName)).To(BeTrue())
+		})
+
+		It("should return true for correct shorter old gateway name format without full DNS suffix", func() {
+			gatewayName := "test-gateway.default"
+			Expect(gatewaytranslator.IsOldGatewayNameFormat(gatewayName)).To(BeTrue())
+		})
+	})
+
+	Describe("TranslateGatewayNameToNewFormat", func() {
+		It("should correctly translate a gateway name in old format", func() {
+			gatewayName := "test-gateway.default.svc.cluster.local"
+			namespace := "default"
+			expectedNewName := "default/test-gateway"
+
+			newGatewayName, err := gatewaytranslator.TranslateGatewayNameToNewFormat(gatewayName, namespace)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(newGatewayName).To(Equal(expectedNewName))
+		})
+
+		It("should return converted value for old gateway name format with no DNS suffix", func() {
+			gatewayName := "test-gateway.default"
+			namespace := "default"
+			expectedNewName := "default/test-gateway"
+
+			newGatewayName, err := gatewaytranslator.TranslateGatewayNameToNewFormat(gatewayName, namespace)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(newGatewayName).To(Equal(expectedNewName))
+		})
+
+		It("should return an error for incorrect old gateway name format with no namespace", func() {
+			gatewayName := "test-gateway.svc.cluster.local"
+			namespace := "default"
+			expectedError := errors.New("gateway name (test-gateway.svc.cluster.local) is not in old gateway format")
+
+			_, err := gatewaytranslator.TranslateGatewayNameToNewFormat(gatewayName, namespace)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal(expectedError.Error()))
+		})
+
+		It("should return an error for incorrect old gateway name format that is too long", func() {
+			gatewayName := "to-long.test-gateway.default.svc.cluster.local"
+			namespace := "default"
+			expectedError := errors.New("gateway name (to-long.test-gateway.default.svc.cluster.local) is not in old gateway format")
+
+			_, err := gatewaytranslator.TranslateGatewayNameToNewFormat(gatewayName, namespace)
+
+			Expect(err).To(HaveOccurred())
+			Expect(err.Error()).To(Equal(expectedError.Error()))
+		})
+		It("should correctly translate a gateway name in old format with shorter name without .local ", func() {
+			gatewayName := "test-gateway.default.svc.cluster"
+			namespace := "default"
+			expectedNewName := "default/test-gateway"
+
+			newGatewayName, err := gatewaytranslator.TranslateGatewayNameToNewFormat(gatewayName, namespace)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(newGatewayName).To(Equal(expectedNewName))
+		})
+
+		It("should correctly translate a gateway name in old format with shorter name without .cluster.local ", func() {
+			gatewayName := "test-gateway.default.svc"
+			namespace := "default"
+			expectedNewName := "default/test-gateway"
+
+			newGatewayName, err := gatewaytranslator.TranslateGatewayNameToNewFormat(gatewayName, namespace)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(newGatewayName).To(Equal(expectedNewName))
+		})
+
+		It("should correctly translate a gateway name in old format with shorter name without .svc.cluster.local ", func() {
+			gatewayName := "test-gateway.default"
+			namespace := "example-namespace"
+			expectedNewName := "default/test-gateway"
+
+			newGatewayName, err := gatewaytranslator.TranslateGatewayNameToNewFormat(gatewayName, namespace)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(newGatewayName).To(Equal(expectedNewName))
+		})
+		It("should correctly translate a gateway name in old format without namespace specified", func() {
+			gatewayName := "test-gateway"
+			namespace := "example-namespace"
+			expectedNewName := "example-namespace/test-gateway"
+
+			newGatewayName, err := gatewaytranslator.TranslateGatewayNameToNewFormat(gatewayName, namespace)
+
+			Expect(err).ToNot(HaveOccurred())
+			Expect(newGatewayName).To(Equal(expectedNewName))
+		})
+	})
+	Describe("IsCorrectNewGatewayNameFormat", func() {
+		It("should be correct new gateway format", func() {
+
+			Expect(gatewaytranslator.IsCorrectNewGatewayNameFormat("test-1/test-gateway")).To(BeTrue())
+		})
+
+		It("should not be correct new gateway format - missing namespace", func() {
+			Expect(gatewaytranslator.IsCorrectNewGatewayNameFormat("test-gateway")).To(BeFalse())
+		})
+
+		It("should not be correct new gateway format - invalid characters", func() {
+			Expect(gatewaytranslator.IsCorrectNewGatewayNameFormat("test-1/test_gateway")).To(BeFalse())
+		})
+
+		It("should not be correct new gateway format - too long", func() {
+			Expect(gatewaytranslator.IsCorrectNewGatewayNameFormat("this-is-a-very-long-namespace-name-that-exceeds-the-maximum-length/test-gateway")).To(BeFalse())
+		})
+	})
+
+})


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

-  cherry-pick: #2120  

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [x] The code coverage is acceptable.
- [x] Release notes for the introduced changes are created.
- [x] ~~If Kubebuilder changes were made, you ran `make generate-manifests` and committed the changes before the merge.~~
- [x] Pre-existing managed resources are correctly handled.
- [x] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [x] There is no upgrade downtime.
- [x] ~~For infrastructure changes, you checked if the changes affect the hyperscaler's costs.~~
- [x] ~~RBAC settings are as restrictive as possible.~~
- [x] ~~If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.~~
- [x] You checked if this change should be cherry-picked to active release branches.
- [x] The configuration does not introduce any additional latency.

**Related issues**
#2067 
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
