### PR TITLE
fix: APIRule v2alpha1 reconciliation error connected with OryRule CRD removal

### DIFF
--- a/internal/reconciliations/oathkeeper/oathkeeper.go
+++ b/internal/reconciliations/oathkeeper/oathkeeper.go
@@ -5,11 +5,6 @@ import (
 	"errors"
 	"time"
 
-	"github.com/kyma-project/api-gateway/apis/operator/v1alpha1"
-	"github.com/kyma-project/api-gateway/controllers"
-	"github.com/kyma-project/api-gateway/internal/conditions"
-	"github.com/kyma-project/api-gateway/internal/reconciliations"
-	"github.com/kyma-project/api-gateway/internal/reconciliations/oathkeeper/maester"
 	corev1 "k8s.io/api/core/v1"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -18,6 +13,12 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kyma-project/api-gateway/apis/operator/v1alpha1"
+	"github.com/kyma-project/api-gateway/controllers"
+	"github.com/kyma-project/api-gateway/internal/conditions"
+	"github.com/kyma-project/api-gateway/internal/reconciliations"
+	"github.com/kyma-project/api-gateway/internal/reconciliations/oathkeeper/maester"
 )
 
 const (
@@ -113,7 +114,6 @@ func DeleteOathkeeper(ctx context.Context, k8sClient client.Client) controllers.
 	}
 
 	err := errors.Join(
-		deleteCRD(ctx, k8sClient, crdName),
 		maester.DeleteMaester(ctx, k8sClient),
 		deleteSecret(ctx, k8sClient, secretName, reconciliations.Namespace),
 		deleteConfigmap(ctx, k8sClient, configMapName, reconciliations.Namespace),


### PR DESCRIPTION
fix: resolve APIRule v2alpha1 reconciliation issue by removing deleti)of OryRule CRD from cluster. As long as APIRule v1beta1 will have zero-downtime migration, we should have ory rule CRD on cluster, to check if we have part of rule that need migration.

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- ...

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make generate-manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
