### PR TITLE
Cherry pick to 3.2.3 -  fix: stop using app label key to calculate desired state of RequestAuthentication

### DIFF
--- a/docs/release-notes/3.2.1.md
+++ b/docs/release-notes/3.2.1.md
@@ -1,3 +1,3 @@
 ## Bug Fixes
 - We've fixed a bug where APIRules `v2alpha1` and `v2` were set to the `Error` state when the target workload was in the mesh with the Istio proxy running in native sidecar mode. See [#2100](https://github.com/kyma-project/api-gateway/issues/2100).
-- We've fixed a bug that caused AuthorizationPolicy creation to fail for APIRules in namespaces with names longer than 36 characters. Now, namespace names up to 63 characters are supported. [#2143](https://github.com/kyma-project/api-gateway/issues/2143) 
+- We've fixed a bug that caused AuthorizationPolicy creation to fail for APIRules in namespaces with names longer than 36 characters. Now, namespace names up to 63 characters are supported. [#2143](https://github.com/kyma-project/api-gateway/issues/2143)

--- a/docs/release-notes/3.2.3.md
+++ b/docs/release-notes/3.2.3.md
@@ -1,0 +1,2 @@
+## Bug Fixes
+- We've fixed the **jwt** and **ext-auth** setup of RequestAuthentication, which is now created for all workloads, regardless of whether they have the `app` label or not. See [#2237](https://github.com/kyma-project/api-gateway/issues/2237).

--- a/internal/processing/processors/v2alpha1/requestauthentication/service_selector_test.go
+++ b/internal/processing/processors/v2alpha1/requestauthentication/service_selector_test.go
@@ -2,10 +2,12 @@ package requestauthentication_test
 
 import (
 	"context"
-	"github.com/kyma-project/api-gateway/internal/processing/processors/v2alpha1/requestauthentication"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	securityv1beta1 "istio.io/client-go/pkg/apis/security/v1beta1"
+
+	"github.com/kyma-project/api-gateway/internal/processing/processors/v2alpha1/requestauthentication"
 )
 
 var _ = Describe("Service has custom selector", func() {
@@ -105,5 +107,57 @@ var _ = Describe("Service has custom selector", func() {
 		Expect(ra.Spec.Selector.MatchLabels).To(HaveLen(2))
 		Expect(ra.Spec.Selector.MatchLabels).To(HaveKeyWithValue("custom", serviceName))
 		Expect(ra.Spec.Selector.MatchLabels).To(HaveKeyWithValue("second-custom", "foo"))
+	})
+
+	It("should create two RA with selectors without app label from service with multiple selector labels", func() {
+		// given: New resources
+
+		jwtRule1 := newJwtRuleBuilderWithDummyData().
+			withServiceName("example-service-1").
+			withPath("/first").
+			build()
+		jwtRule2 := newJwtRuleBuilderWithDummyData().
+			withServiceName("example-service-2").
+			withPath("/second").
+			build()
+		apiRule := newAPIRuleBuilderWithDummyData().
+			withRules(jwtRule1, jwtRule2).
+			build()
+		svc1 := newServiceBuilder().
+			withName("example-service-1").
+			withNamespace("example-namespace").
+			addSelector("custom", "example-service-1").
+			addSelector("second-custom", "foo-1").
+			build()
+
+		svc2 := newServiceBuilder().
+			withName("example-service-2").
+			withNamespace("example-namespace").
+			addSelector("custom", "example-service-2").
+			addSelector("second-custom", "foo-2").
+			build()
+
+		client := getFakeClient(svc1, svc2)
+
+		processor := requestauthentication.NewProcessor(apiRule)
+
+		// when
+		result, err := processor.EvaluateReconciliation(context.Background(), client)
+
+		// then
+		Expect(err).To(BeNil())
+		Expect(result).To(HaveLen(2))
+
+		ra1 := result[0].Obj.(*securityv1beta1.RequestAuthentication)
+		Expect(ra1).NotTo(BeNil())
+		Expect(ra1.Spec.Selector.MatchLabels).To(HaveLen(2))
+		Expect(ra1.Spec.Selector.MatchLabels).To(HaveKeyWithValue("custom", "example-service-1"))
+		Expect(ra1.Spec.Selector.MatchLabels).To(HaveKeyWithValue("second-custom", "foo-1"))
+
+		ra2 := result[1].Obj.(*securityv1beta1.RequestAuthentication)
+		Expect(ra2).NotTo(BeNil())
+		Expect(ra2.Spec.Selector.MatchLabels).To(HaveLen(2))
+		Expect(ra2.Spec.Selector.MatchLabels).To(HaveKeyWithValue("custom", "example-service-2"))
+		Expect(ra2.Spec.Selector.MatchLabels).To(HaveKeyWithValue("second-custom", "foo-2"))
 	})
 })


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**
cherry-pick: #2239  

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
