### PR TITLE
Add tutorial for zero downtime migration when mixed apirules target o…

### DIFF
--- a/docs/user/_sidebar.md
+++ b/docs/user/_sidebar.md
@@ -30,7 +30,7 @@
   * [RateLimit Custom Resource](/api-gateway/user/custom-resources/ratelimit/04-00-ratelimit.md)
 * [APIRule Migration](/api-gateway/user/apirule-migration/README.md)
   * [Retrieve v1beta1 spec](/api-gateway/user/apirule-migration/01-81-retrieve-v1beta1-spec.md)
-  * [Migrating Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](/api-gateway/user/apirule-migration/01-90-migrate-multiple-apirules-targeting-same-workload.md)
+  * [Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](/api-gateway/user/apirule-migration/01-90-migrate-multiple-apirules-targeting-same-workload.md)
   * [Migrate jwt Handlers](/api-gateway/user/apirule-migration/01-83-migrate-jwt-v1beta1-to-v2.md)
   * [Migrate noop, no_auth, allow Handlers](/api-gateway/user/apirule-migration/01-82-migrate-allow-noop-no_auth-v1beta1-to-v2.md)
   * [Migrate Ory-based Handlers](/api-gateway/user/apirule-migration/01-84-migrate-oauth2-v1beta1-to-v2.md)

--- a/docs/user/_sidebar.ts
+++ b/docs/user/_sidebar.ts
@@ -74,7 +74,7 @@ export default [
   ]},
   { text: 'APIRule Migration', link: './apirule-migration/README.md', collapsed: true, items: [
     { text: 'Retrieve v1beta1 spec', link: './apirule-migration/01-81-retrieve-v1beta1-spec.md' },
-    { text: 'Migrating Multiple APIRules Targeting the Same Workload from v1beta1 to v2', link: './apirule-migration/01-90-migrate-multiple-apirules-targeting-same-workload.md' },
+    { text: 'Migrate Multiple APIRules Targeting the Same Workload from v1beta1 to v2', link: './apirule-migration/01-90-migrate-multiple-apirules-targeting-same-workload.md' },
     { text: 'Migrate jwt Handlers', link: './apirule-migration/01-83-migrate-jwt-v1beta1-to-v2.md' },
     { text: 'Migrate noop, no_auth, allow Handlers', link: './apirule-migration/01-82-migrate-allow-noop-no_auth-v1beta1-to-v2.md' },
     { text: 'Migrate Ory-based Handlers', link: './apirule-migration/01-84-migrate-oauth2-v1beta1-to-v2.md' },

--- a/docs/user/apirule-migration/01-82-migrate-allow-noop-no_auth-v1beta1-to-v2.md
+++ b/docs/user/apirule-migration/01-82-migrate-allow-noop-no_auth-v1beta1-to-v2.md
@@ -25,7 +25,7 @@ The example uses an HTTPBin service, exposing the `/anything`, `/headers`, and `
 This example assumes that the targeted workload is only exposed by a single APIRule in version `v1beta1`.
 
 > [!WARNING]
-> If multiple APIRules target the same workload, you must perform an additional migration step to avoid traffic disruption. This step involves creating an additional, temporary AuthorizationPolicy before applying the first migrated APIRule `v2`. For detailed instructions, refer to the [Migrating Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md) documentation before proceeding.
+> If multiple APIRules target the same workload, you must perform an additional migration step to avoid traffic disruption. This step involves creating an additional, temporary AuthorizationPolicy before applying the first migrated APIRule `v2`. For detailed instructions, refer to the [Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md) documentation before proceeding.
 > 
 
 1. Obtain a configuration of the APIRule in version `v1beta1` and save it for further modifications. 
@@ -154,7 +154,7 @@ This example assumes that the targeted workload is only exposed by a single APIR
    For preflight requests to work correctly, you must explicitly add the `"OPTIONS"` method to the **rules.methods** field of your APIRule `v2`. For guidance, see the [APIRule `v2` examples](../custom-resources/apirule/04-10-apirule-custom-resource.md#sample-custom-resource).
 
 > [!WARNING]
-> If you migrated multiple APIRules that target the same workload, and you applied an additional AuthorizationPolicy to avoid traffic disruption during migration, delete it. For instructions, see the last point of the procedure [Migrating Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md).
+> If you migrated multiple APIRules that target the same workload, and you applied an additional AuthorizationPolicy to avoid traffic disruption during migration, delete it. For instructions, see the last point of the procedure [Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md).
 >
 
 ### Access Your Workload

--- a/docs/user/apirule-migration/01-83-migrate-jwt-v1beta1-to-v2.md
+++ b/docs/user/apirule-migration/01-83-migrate-jwt-v1beta1-to-v2.md
@@ -22,7 +22,7 @@ The example uses an HTTPBin service, exposing the `/anything` and `/.*` endpoint
 This example assumes that the targeted workload is only exposed by a single APIRule in version `v1beta1`.
 
 > [!WARNING]
-> If multiple APIRules target the same workload, you must perform an additional migration step to avoid traffic disruption. This step involves creating an additional, temporary AuthorizationPolicy before applying the first migrated APIRule `v2`. For detailed instructions, refer to the [Migrating Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md) documentation before proceeding.
+> If multiple APIRules target the same workload, you must perform an additional migration step to avoid traffic disruption. This step involves creating an additional, temporary AuthorizationPolicy before applying the first migrated APIRule `v2`. For detailed instructions, refer to the [Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md) documentation before proceeding.
 >
 
 1. Retrieve a configuration of the APIRule in version `v1beta1` and save it for further modifications. For instructions, see [Retrieve the Complete **spec** of an APIRule in Version `v1beta1`](./01-81-retrieve-v1beta1-spec.md). See a sample of the retrieved **spec** in the YAML format:
@@ -152,7 +152,7 @@ This example assumes that the targeted workload is only exposed by a single APIR
    For preflight requests to work correctly, you must explicitly add the `"OPTIONS"` method to the **rules.methods** field of your APIRule `v2`. For guidance, see the [APIRule `v2` examples](../custom-resources/apirule/04-10-apirule-custom-resource.md#sample-custom-resource).
 
 > [!WARNING]
-> If you migrated multiple APIRules that target the same workload, and you applied an additional AuthorizationPolicy to avoid traffic disruption during migration, delete it. For instructions, see the last point of the procedure [Migrating Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md).
+> If you migrated multiple APIRules that target the same workload, and you applied an additional AuthorizationPolicy to avoid traffic disruption during migration, delete it. For instructions, see the last point of the procedure [Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md).
 >
 
 ### Access Your Workload

--- a/docs/user/apirule-migration/01-84-migrate-oauth2-v1beta1-to-v2.md
+++ b/docs/user/apirule-migration/01-84-migrate-oauth2-v1beta1-to-v2.md
@@ -21,7 +21,7 @@ In this example, the APIRule `v1beta1` was created with the **oauth2_introspecti
 This example assumes that the targeted workload is only exposed by a single APIRule in version `v1beta1`.
 
 > [!WARNING]
-> If multiple APIRules target the same workload, you must perform an additional migration step to avoid traffic disruption. This step involves creating an additional, temporary AuthorizationPolicy before applying the first migrated APIRule `v2`. For detailed instructions, refer to the [Migrating Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md) documentation before proceeding.
+> If multiple APIRules target the same workload, you must perform an additional migration step to avoid traffic disruption. This step involves creating an additional, temporary AuthorizationPolicy before applying the first migrated APIRule `v2`. For detailed instructions, refer to the [Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md) documentation before proceeding.
 >
 
 1. Retrieve a configuration of the APIRule in version `v1beta1` and save it for further modifications. For instructions, see [Retrieve the Complete **spec** of an APIRule in Version `v1beta1`](./01-81-retrieve-v1beta1-spec.md). 
@@ -216,7 +216,7 @@ The following APIRule example delegates token validation to the previously confi
     For preflight requests to work correctly, you must explicitly add the `"OPTIONS"` method to the **rules.methods** field of your APIRule `v2`. For guidance, see the [APIRule `v2` examples](../custom-resources/apirule/04-10-apirule-custom-resource.md#sample-custom-resource).
 
 > [!WARNING]
-> If you migrated multiple APIRules that target the same workload, and you applied an additional AuthorizationPolicy to avoid traffic disruption during migration, delete it. For instructions, see the last point of the procedure [Migrating Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md).
+> If you migrated multiple APIRules that target the same workload, and you applied an additional AuthorizationPolicy to avoid traffic disruption during migration, delete it. For instructions, see the last point of the procedure [Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md).
 ### Access Your Workload
 
 - Send a `GET` request to the exposed workload using JWT authentication::

--- a/docs/user/apirule-migration/01-85-apirule-migration-faq.md
+++ b/docs/user/apirule-migration/01-85-apirule-migration-faq.md
@@ -106,7 +106,7 @@ APIRule `v2` does not support regexp in the **spec.rules.path** field of APIRule
 In APIRule `v2`, you must provide the Gateway using the format `namespace/gateway-name`. The legacy formats are not supported.
 
 ### How to migrate multiple APIRules `v1beta1` targeting same workload to version `v2`?
-When multiple APIRules `v1beta1` target the same workload using different host names, you must apply an additional, temporary AuthorizationPolicy in order to have continuous access to endpoints exposed by APIRules `v1beta1` during the migration. For more information, see [Migrating Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md) and [Migration guidelines](./README.md).
+When multiple APIRules `v1beta1` target the same workload using different host names, you must apply an additional, temporary AuthorizationPolicy in order to have continuous access to endpoints exposed by APIRules `v1beta1` during the migration. For more information, see [Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md) and [Migration guidelines](./README.md).
 
 ## Using APIRules `v1beta1`
 

--- a/docs/user/apirule-migration/01-90-migrate-multiple-apirules-targeting-same-workload.md
+++ b/docs/user/apirule-migration/01-90-migrate-multiple-apirules-targeting-same-workload.md
@@ -1,4 +1,4 @@
-# Migrating Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`
+# Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`
 
 Learn how to migrate multiple APIRules `v1beta1` that expose the same workload using different host names. To keep all endpoints available during migration, you must create an additional, temporary AuthorizationPolicy. This ensures that service requests to APIRules `v1beta1` are handled as intended, while another APIRule targeting the same workload has already been migrated to `v2`.
 

--- a/docs/user/apirule-migration/README.md
+++ b/docs/user/apirule-migration/README.md
@@ -14,7 +14,7 @@ To migrate to version v2, follow the steps:
     kubectl get apirules.gateway.kyma-project.io -A -o json | jq '.items[] | select(.metadata.annotations["gateway.kyma-project.io/original-version"] == "v1beta1") | {namespace: .metadata.namespace, name: .metadata.name}'
     ```
 
-2. If two or more of your APIRules target the same workload, apply an additional AuthorizationPolicy to avoid traffic disruption during migration. See [Migrating Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md).
+2. If two or more of your APIRules target the same workload, apply an additional AuthorizationPolicy to avoid traffic disruption during migration. See [Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md).
 
 3. To retrieve the complete **spec** with the rules field of an APIRule in version `v1beta1`, see [Retrieving the Complete **spec** of an APIRule in Version `v1beta1`](./01-81-retrieve-v1beta1-spec.md).
 


### PR DESCRIPTION
Add tutorial for zero downtime migration when mixed apirules target one workload.

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- tutorial migration addition in case when there are multiple APIRules v1beta1 targeting same workload - additional AP is needed in order to maintain uniterrupted traffic by thos apirules v1beta1 

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] ~~The code coverage is acceptable.~~
- [ ] ~~Release notes for the introduced changes are created.~~
- [ ] ~~If Kubebuilder changes were made, you ran `make generate-manifests` and committed the changes before the merge.~~
- [ ] ~~Pre-existing managed resources are correctly handled.~~
- [ ] ~~The change works on all hyperscalers supported by SAP BTP, Kyma runtime.~~
- [ ] ~~There is no upgrade downtime.~~
- [ ] ~~For infrastructure changes, you checked if the changes affect the hyperscaler's costs.~~
- [ ] ~~RBAC settings are as restrictive as possible.~~
- [ ] ~~If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.~~
- [x] You checked if this change should be cherry-picked to active release branches. Needs cp to 3.3
- [ ] ~~The configuration does not introduce any additional latency.~~

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
