### PR TITLE
Add tutorial for multiple apirules target dame workload migration gui…

### DIFF
--- a/docs/user/_sidebar.md
+++ b/docs/user/_sidebar.md
@@ -30,6 +30,7 @@
   * [RateLimit Custom Resource](/api-gateway/user/custom-resources/ratelimit/04-00-ratelimit.md)
 * [APIRule Migration](/api-gateway/user/apirule-migration/README.md)
   * [Retrieve v1beta1 spec](/api-gateway/user/apirule-migration/01-81-retrieve-v1beta1-spec.md)
+  * [Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](/api-gateway/user/apirule-migration/01-90-migrate-multiple-apirules-targeting-same-workload.md)
   * [Migrate jwt Handlers](/api-gateway/user/apirule-migration/01-83-migrate-jwt-v1beta1-to-v2.md)
   * [Migrate noop, no_auth, allow Handlers](/api-gateway/user/apirule-migration/01-82-migrate-allow-noop-no_auth-v1beta1-to-v2.md)
   * [Migrate Ory-based Handlers](/api-gateway/user/apirule-migration/01-84-migrate-oauth2-v1beta1-to-v2.md)

--- a/docs/user/apirule-migration/01-82-migrate-allow-noop-no_auth-v1beta1-to-v2.md
+++ b/docs/user/apirule-migration/01-82-migrate-allow-noop-no_auth-v1beta1-to-v2.md
@@ -22,6 +22,11 @@ Version `v1beta1` of APIRule is deprecated and scheduled for removal. Once the A
 
 This example demonstrates a migration from an APIRule `v1beta1` with **noop**, **allow**, and **no_auth** handlers to an APIRule `v2` with the **noAuth** handler.
 The example uses an HTTPBin service, exposing the `/anything`, `/headers`, and `/.*` endpoints. The HTTPBin service is deployed in its own namespace, with Istio enabled, ensuring the workload is part of the Istio service mesh.
+This example assumes that the targeted workload is only exposed by a single APIRule in version `v1beta1`.
+
+> [!WARNING]
+> If multiple APIRules target the same workload, you must perform an additional migration step to avoid traffic disruption. This step involves creating an additional, temporary AuthorizationPolicy before applying the first migrated APIRule `v2`. For detailed instructions, refer to the [Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md) documentation before proceeding.
+> 
 
 1. Obtain a configuration of the APIRule in version `v1beta1` and save it for further modifications. 
     For instructions, see [Retrieve the Complete **spec** of an APIRule in Version `v1beta1`](./01-81-retrieve-v1beta1-spec.md). See a sample of the retrieved **spec** in the YAML format:
@@ -99,6 +104,7 @@ The example uses an HTTPBin service, exposing the `/anything`, `/headers`, and `
     >
     > For more information, see the [Changes Introduced in APIRule `v2`](../custom-resources/apirule/04-70-changes-in-apirule-v2.md) document. **Read this document before applying the new APIRule `v2`.**
 
+
 3. To update the APIRule to version `v2`, apply the adjusted configuration. 
 
    To verify the version of the applied APIRule, check the value of the `gateway.kyma-project.io/original-version` annotation in the APIRule **spec**. If the APIRule has been successfully migrated, you see the value `v2`. Use the following command:
@@ -146,6 +152,10 @@ The example uses an HTTPBin service, exposing the `/anything`, `/headers`, and `
 6. To retain the CORS configuration from the APIRule `v1beta1`, update the APIRule in version `v2` to include the same CORS settings. 
 
    For preflight requests to work correctly, you must explicitly add the `"OPTIONS"` method to the **rules.methods** field of your APIRule `v2`. For guidance, see the [APIRule `v2` examples](../custom-resources/apirule/04-10-apirule-custom-resource.md#sample-custom-resource).
+
+> [!WARNING]
+> If you migrated multiple APIRules that target the same workload, and you applied an additional AuthorizationPolicy to avoid traffic disruption during migration, delete it. For instructions, see the last point of the procedure [Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md).
+>
 
 ### Access Your Workload
 

--- a/docs/user/apirule-migration/01-83-migrate-jwt-v1beta1-to-v2.md
+++ b/docs/user/apirule-migration/01-83-migrate-jwt-v1beta1-to-v2.md
@@ -19,6 +19,11 @@ APIRule in version `v1beta1` is deprecated and scheduled for removal. Once the A
 
 This example demonstrates a migration from an APIRule `v1beta1` with the **jwt** handler to an APIRule `v2` with the **jwt** handler.
 The example uses an HTTPBin service, exposing the `/anything` and `/.*` endpoints. The HTTPBin service is deployed in its own namespace, with Istio enabled, ensuring the workload is part of the Istio service mesh.
+This example assumes that the targeted workload is only exposed by a single APIRule in version `v1beta1`.
+
+> [!WARNING]
+> If multiple APIRules target the same workload, you must perform an additional migration step to avoid traffic disruption. This step involves creating an additional, temporary AuthorizationPolicy before applying the first migrated APIRule `v2`. For detailed instructions, refer to the [Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md) documentation before proceeding.
+>
 
 1. Retrieve a configuration of the APIRule in version `v1beta1` and save it for further modifications. For instructions, see [Retrieve the Complete **spec** of an APIRule in Version `v1beta1`](./01-81-retrieve-v1beta1-spec.md). See a sample of the retrieved **spec** in the YAML format:
     The following configuration uses the **jwt** handler to expose the HTTPBin service's `/anything` and `/.*` endpoints.
@@ -145,6 +150,10 @@ The example uses an HTTPBin service, exposing the `/anything` and `/.*` endpoint
 5. To retain the CORS configuration from the APIRule `v1beta1`, update the APIRule in version `v2` to include the same CORS settings. 
 
    For preflight requests to work correctly, you must explicitly add the `"OPTIONS"` method to the **rules.methods** field of your APIRule `v2`. For guidance, see the [APIRule `v2` examples](../custom-resources/apirule/04-10-apirule-custom-resource.md#sample-custom-resource).
+
+> [!WARNING]
+> If you migrated multiple APIRules that target the same workload, and you applied an additional AuthorizationPolicy to avoid traffic disruption during migration, delete it. For instructions, see the last point of the procedure [Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md).
+>
 
 ### Access Your Workload
 

--- a/docs/user/apirule-migration/01-84-migrate-oauth2-v1beta1-to-v2.md
+++ b/docs/user/apirule-migration/01-84-migrate-oauth2-v1beta1-to-v2.md
@@ -18,6 +18,11 @@ APIRule in version `v1beta1` is deprecated and scheduled for removal. Once the A
 ## Steps
 
 In this example, the APIRule `v1beta1` was created with the **oauth2_introspection** handler, so the migration targets an APIRule `v2` using the **extAuth** handler. To illustrate the migration, the HTTPBin service is used, exposing the `/anything` and `/.*` endpoints. The HTTPBin service is deployed in its own namespace, with Istio enabled, ensuring the workload is part of the Istio service mesh.
+This example assumes that the targeted workload is only exposed by a single APIRule in version `v1beta1`.
+
+> [!WARNING]
+> If multiple APIRules target the same workload, you must perform an additional migration step to avoid traffic disruption. This step involves creating an additional, temporary AuthorizationPolicy before applying the first migrated APIRule `v2`. For detailed instructions, refer to the [Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md) documentation before proceeding.
+>
 
 1. Retrieve a configuration of the APIRule in version `v1beta1` and save it for further modifications. For instructions, see [Retrieve the Complete **spec** of an APIRule in Version `v1beta1`](./01-81-retrieve-v1beta1-spec.md). 
 
@@ -210,6 +215,8 @@ The following APIRule example delegates token validation to the previously confi
 
     For preflight requests to work correctly, you must explicitly add the `"OPTIONS"` method to the **rules.methods** field of your APIRule `v2`. For guidance, see the [APIRule `v2` examples](../custom-resources/apirule/04-10-apirule-custom-resource.md#sample-custom-resource).
 
+> [!WARNING]
+> If you migrated multiple APIRules that target the same workload, and you applied an additional AuthorizationPolicy to avoid traffic disruption during migration, delete it. For instructions, see the last point of the procedure [Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md).
 ### Access Your Workload
 
 - Send a `GET` request to the exposed workload using JWT authentication::

--- a/docs/user/apirule-migration/01-85-apirule-migration-faq.md
+++ b/docs/user/apirule-migration/01-85-apirule-migration-faq.md
@@ -17,6 +17,7 @@ APIRule CRD `v2` is the latest stable version. Version `v1beta1` has been deprec
   - [I used **oauth2-introspection** in APIRule `v1beta1`. How do I migrate it to `v2`?](#i-used-oauth2-introspection-in-apirule-v1beta1-how-do-i-migrate-it-to-v2)
   - [I used regexp in the paths of APIRule `v1beta1`. How do I migrate it to `v2`?](#i-used-regexp-in-the-paths-of-apirule-v1beta1-how-do-i-migrate-it-to-v2)
   - [Why do I get a validation error for the legacy gateway format while trying to migrate to `v2`?](#why-do-i-get-a-validation-error-for-the-legacy-gateway-format-while-trying-to-migrate-to-v2)
+  - [How to migrate multiple APIRules `v1beta1` targeting same workload to version `v2`?](#how-to-migrate-multiple-apirules-v1beta1-targeting-same-workload-to-version-v2)
 - [Using APIRules `v1beta1`](#using-apirules-v1beta1)
   - [Why can't I create an APIRule `v1beta1` in a new cluster?](#why-cant-i-create-an-apirule-v1beta1-in-a-new-cluster)
   - [Why are my APIRules `v1beta1` in the `Warning` state?](#why-are-my-apirules-v1beta1-in-the-warning-state)
@@ -103,6 +104,9 @@ APIRule `v2` does not support regexp in the **spec.rules.path** field of APIRule
 ### Why do I get a validation error for the legacy gateway format while trying to migrate to `v2`?
 
 In APIRule `v2`, you must provide the Gateway using the format `namespace/gateway-name`. The legacy formats are not supported.
+
+### How to migrate multiple APIRules `v1beta1` targeting same workload to version `v2`?
+When multiple APIRules `v1beta1` target the same workload using different host names, you must apply an additional, temporary AuthorizationPolicy in order to have continuous access to endpoints exposed by APIRules `v1beta1` during the migration. For more information, see [Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md) and [Migration guidelines](./README.md).
 
 ## Using APIRules `v1beta1`
 

--- a/docs/user/apirule-migration/01-90-migrate-multiple-apirules-targeting-same-workload.md
+++ b/docs/user/apirule-migration/01-90-migrate-multiple-apirules-targeting-same-workload.md
@@ -1,0 +1,243 @@
+# Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`
+
+Learn how to migrate multiple APIRules `v1beta1` that expose the same workload using different host names. To keep all endpoints available during migration, you must create an additional, temporary AuthorizationPolicy. This ensures that service requests to APIRules `v1beta1` are handled as intended, while another APIRule targeting the same workload has already been migrated to `v2`.
+
+## Context
+When you have multiple APIRules `v1beta1` that expose the same workload but use different host values, and you migrate only one of those APIRules to version `v2`, you may get `HTTP/2 403 RBAC: Access Denied` errors when making requests to the endpoints of the remaining `v1beta1` APIRules. However, requests to the endpoint of the migrated `v2` APIRule are successful, returning `HTTP/2 200 OK` responses.
+
+`HTTP/2 403 RBAC: Access Denied` errors are caused by Istio subresources created by the migrated APIRule `v2`. Because the other APIRules exposing the same workload remain in version `v1beta1` and do not use Istio subresources, requests from these APIRules `v1beta1` to the workload are no longer allowed. In such cases, access to the target workload is permitted only for requests that match the rules specified in the APIRule `v2`.
+
+For example, suppose a scenario where you have applied the following two `v1beta1` APIRules configured to expose the same HTTPBin Service, each with a different host value, and you want to maintain uninterrupted access to service endpoints during migration.
+
+```yaml
+apiVersion: gateway.kyma-project.io/v1beta1
+kind: APIRule
+metadata:
+  name: example1
+  namespace: test
+spec:
+  host: example1
+  service:
+    name: httpbin
+    namespace: default
+    port: 8000
+  gateway: kyma-gateway.kyma-system
+  rules:
+    - path: /post
+      methods: ["POST"]
+      accessStrategies:
+        - handler: no_auth
+    - path: /.*
+      methods: ["GET"]
+      mutators: []
+      accessStrategies:
+        - handler: jwt
+          config:
+            trusted_issuers:
+              - https://{IAS_TENANT}.accounts.ondemand.com
+            jwks_urls:
+              - https://{IAS_TENANT}.accounts.ondemand.com/oauth2/certs
+---
+apiVersion: gateway.kyma-project.io/v1beta1
+kind: APIRule
+metadata:
+  name: example2
+  namespace: test
+spec:
+  host: example2
+  service:
+    name: httpbin
+    namespace: default
+    port: 8000
+  gateway: kyma-gateway.kyma-system
+  rules:
+    - path: /post
+      methods: ["POST"]
+      accessStrategies:
+        - handler: no_auth
+    - path: /.*
+      methods: ["GET"]
+      mutators: []
+      accessStrategies:
+        - handler: jwt
+          config:
+            trusted_issuers:
+              - https://{IAS_TENANT}.accounts.ondemand.com
+            jwks_urls:
+              - https://{IAS_TENANT}.accounts.ondemand.com/oauth2/certs
+```
+To ensure a seamless migration to `v2` without any downtime, you must create an  **additional, temporary** AuthorizationPolicy before applying the first migrated APIRule `v2`.
+
+To learn how to do this, follow the procedure.
+
+> [!NOTE] Using both versions of APIRules for one target workload is not recommended. Instead, migrate all APIRules targeting the same workload at once to version `v2`. Creating a temporary AuthorizationPolicy blocks internal traffic to the workload, which migration to APIRule `v2` causes anyway. Get acquainted with every step of [migration tutorials](./README.md). Note that any ALLOW-type AuthorizationPolicy automatically blocks traffic that doesn't meet the requirements of policies specified there. 
+> 
+> We recommend the following course of action:  
+> 1. Apply the temporary AuthorizationPolicy that blocks in-cluster communication and unblocks `v1beta1` exposure to external traffic during the migration. 
+> 2. Migrate APIRules to `v2`. For instructions, follow the [migration guidelines](../apirule-migration/README.md).
+> 3. Delete the temporary AuthorizationPolicy.
+
+
+## Procedure
+1. For each of your APIRules `v1beta1` targeting the same workload, list hosts that contain at least one **allow** or **no_auth** handler. Specify those hosts in the FQDN format.
+
+    > [!NOTE] If your APIRules `v1beta1` don't use the `allow` or `no_auth` handlers, skip this step. Specifying these hosts is only necessary for APIRules with **allow** or **no_auth** access strategies to allow traffic from Istio ingress gateway to the target workload during migration. Other handlers, such as **jwt**, **oauth2_introspection**, and **noop**, use the Ory Oathkeeper service, and the traffic doesn't come directly from the ingress gateway to the target workload.
+    >
+
+    In the example, two APIRules `v1beta1` with `no_auth` handler expose the same `httpbin` Service on different hosts: 
+    - `example1`  
+    - `example2`
+    
+    To obtain the FQDN format of the hosts, get the domain of the referenced Gateway. For this, you use the following command:
+
+   ```bash
+   kubectl get gateway <GATEWAY_NAME> -n <GATEWAY_NAMESPACE> -o jsonpath='{.spec.servers[0].hosts}'
+    ```
+   
+   In the example scenario, the APIRules reference the `kyma-gateway` Gateway in the namespace `kyma-system`, so the command looks like this:
+
+    ```bash
+    kubectl get gateway -n kyma-system kyma-gateway -o jsonpath='{.spec.servers[0].hosts}'
+   ["*.local.kyma.dev"]%
+    ```
+    Assuming the default domain is `local.kyma.dev`, the FQDN format of the hosts is:
+    - `example1.local.kyma.dev`
+    - `example2.local.kyma.dev`
+
+
+2. To identify the label key and value for the target workload, check the selector from the Service that the APIRules expose. 
+
+    ```bash 
+    kubectl get service <SERVICE_NAME> -n <NAMESPACE> -o jsonpath='{.spec.selector}'
+    ```
+
+   In the example, the selector for the `httpbin` Service in the `default` namespace is `app: httpbin`:
+    ```bash
+   kubectl get service httpbin -n default -o jsonpath='{.spec.selector}'
+    {"app":"httpbin"}%
+    ```
+   
+3. Create a temporary AuthorizationPolicy using the gathered information in the previous steps.
+
+    | Option                             | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+    |------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+    | **{NAMESPACE}**                    | The namespace to which the AuthorizationPolicy applies. This namespace must include the target workload for which you allow traffic. The selector matches workloads in the same namespace as the AuthorizationPolicy.                                                                                                                                                                                                                                                                                                                |
+    | **{HOSTNAME}**                     | List all host names that are exposed by the `v1beta1` APIRules being migrated which contain handler `no_auth` or `allow`. These hostnames represent the external endpoints through which clients access the workload. List all relevant hostnames in FQDN format to ensure the AuthorizationPolicy allows traffic for each endpoint during migration.                                                                                                                                                                                |
+    | **{LABEL_KEY}**: **{LABEL_VALUE}** | To further restrict the scope of the AuthorizationPolicy, specify label selectors that match the target workload. Replace these placeholders with the actual key and value of the label. The label indicates a specific set of Pods to which a policy should be applied. The scope of the label search is restricted to the configuration namespace in which the AuthorizationPolicy is present. <br>For more information, see [Authorization Policy](https://istio.io/latest/docs/reference/config/security/authorization-policy/). |
+
+   This AuthorizationPolicy allows traffic from the Ory Oathkeeper service and the Istio ingress gateway to the target workload only for the specified hosts. Applying this AuthorizationPolicy before starting the migration process ensures uninterrupted access to service endpoints during the migration.
+
+    ```yaml
+    apiVersion: security.istio.io/v1
+    kind: AuthorizationPolicy
+    metadata:
+      name: allow-migration
+      namespace: {NAMESPACE}
+    spec:
+      action: ALLOW
+      rules:
+        - from:
+            - source:
+                principals:
+                  - "cluster.local/ns/kyma-system/sa/oathkeeper-maester-account"
+        - from:
+            - source:
+                principals:
+                  - "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
+          to:
+            - operation:
+                hosts:
+                  - {HOSTNAME1}
+                  - {HOSTNAME2}
+      selector:
+        matchLabels:
+          {LABEL_KEY}: {LABEL_VALUE}
+    ```
+    
+     If you don't migrate any APIRules `v1beta1` with **allow** or **no_auth** handlers, remove the second rule from the AuthorizationPolicy. The AuthorizationPolicy then allows all traffic from the Ory Oathkeeper service to the target workload.
+
+    ```yaml
+    apiVersion: security.istio.io/v1
+    kind: AuthorizationPolicy
+    metadata:
+      name: allow-migration
+      namespace: {NAMESPACE}
+    spec:
+      action: ALLOW
+      rules:
+        - from:
+            - source:
+                principals:
+                  - "cluster.local/ns/kyma-system/sa/oathkeeper-maester-account"
+      selector:
+        matchLabels:
+          {LABEL_KEY}: {LABEL_VALUE}
+    ```
+   
+   If you migrate APIRules `v1beta1` that specify only the **allow** or **no_auth** handlers, remove the first rule from the AuthorizationPolicy. The policy then allows all traffic from the ingress gateway to the target workload for the specified hosts.
+
+    ```yaml
+    apiVersion: security.istio.io/v1
+    kind: AuthorizationPolicy
+    metadata:
+      name: allow-migration
+      namespace: {NAMESPACE}
+    spec:
+      action: ALLOW
+      rules:
+        - from:
+            - source:
+                principals:
+                  - "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
+          to:
+            - operation:
+                hosts:
+                  - {HOSTNAME1}
+                  - {HOSTNAME2}
+      selector:
+        matchLabels:
+          {LABEL_KEY}: {LABEL_VALUE}
+    ```
+
+    In the example scenario, APIRules `v1beta1` spacify both **no_auth** and **jwt** handlers. Therefore, the temporarily applied AuthorizationPolicy looks like this:
+
+    ```yaml
+    apiVersion: security.istio.io/v1
+    kind: AuthorizationPolicy
+    metadata:
+      name: allow-migration
+      namespace: default
+    spec:
+      action: ALLOW
+      rules:
+        - from:
+            - source:
+                principals:
+                  - "cluster.local/ns/kyma-system/sa/oathkeeper-maester-account"
+        - from:
+            - source:
+                principals:
+                  - "cluster.local/ns/istio-system/sa/istio-ingressgateway-service-account"
+          to:
+            - operation:
+                hosts:
+                  - example1.local.kyma.dev
+                  - example2.local.kyma.dev
+      selector:
+        matchLabels:
+          app: httpbin
+    ```
+
+4. To migrate APIRules `v1beta1` to `v2`, follow the steps in [migration guidelines](../apirule-migration/README.md). During this process, the temporary AuthorizationPolicy ensures that requests from both `v1beta1` APIRules to the target workload are allowed.
+
+
+5. After all APIRules targeting the same workload are migrated to `v2`, delete the temporary AuthorizationPolicy.
+
+    ```bash
+    kubectl delete authorizationpolicy <AUTHORIZATION_POLICY_NAME> -n <NAMESPACE>
+    ```
+    
+    See an example:
+    ```bash
+    kubectl delete authorizationpolicy allow-migration -n default
+    ```

--- a/docs/user/apirule-migration/README.md
+++ b/docs/user/apirule-migration/README.md
@@ -14,9 +14,11 @@ To migrate to version v2, follow the steps:
     kubectl get apirules.gateway.kyma-project.io -A -o json | jq '.items[] | select(.metadata.annotations["gateway.kyma-project.io/original-version"] == "v1beta1") | {namespace: .metadata.namespace, name: .metadata.name}'
     ```
 
-2. To retrieve the complete **spec** with the rules field of an APIRule in version `v1beta1`, see [Retrieving the Complete **spec** of an APIRule in Version `v1beta1`](./01-81-retrieve-v1beta1-spec.md).
+2. If two or more of your APIRules target the same workload, apply an additional AuthorizationPolicy to avoid traffic disruption during migration. See [Migrate Multiple APIRules Targeting the Same Workload from `v1beta1` to `v2`](./01-90-migrate-multiple-apirules-targeting-same-workload.md).
 
-3. To migrate an APIRule from version `v1beta1` to version `v2`, follow the relevant guide:
+3. To retrieve the complete **spec** with the rules field of an APIRule in version `v1beta1`, see [Retrieving the Complete **spec** of an APIRule in Version `v1beta1`](./01-81-retrieve-v1beta1-spec.md).
+
+4. To migrate an APIRule from version `v1beta1` to version `v2`, follow the relevant guide:
     - [Migrating APIRule v1beta1 of Type jwt to Version v2](./01-83-migrate-jwt-v1beta1-to-v2.md)
     - [Migrating APIRule v1beta1 of Type noop, allow, or no_auth to Version v2](./01-82-migrate-allow-noop-no_auth-v1beta1-to-v2.md)
     - [Migrating APIRule v1beta1 of type oauth2_introspection to version v2](./01-84-migrate-oauth2-v1beta1-to-v2.md)


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- tutorial migration addition in case when there are multiple APIRules v1beta1 targeting same workload - additional AP is needed in order to maintain uniterrupted traffic by thos apirules v1beta1 

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] ~~The code coverage is acceptable.~~
- [ ] ~~Release notes for the introduced changes are created.~~
- [ ] ~~If Kubebuilder changes were made, you ran `make generate-manifests` and committed the changes before the merge.~~
- [ ] ~~Pre-existing managed resources are correctly handled.~~
- [ ] ~~The change works on all hyperscalers supported by SAP BTP, Kyma runtime.~~
- [ ] ~~There is no upgrade downtime.~~
- [ ] ~~For infrastructure changes, you checked if the changes affect the hyperscaler's costs.~~
- [ ] ~~RBAC settings are as restrictive as possible.~~
- [ ] ~~If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.~~
- [x] You checked if this change should be cherry-picked to active release branches. Needs cp to 3.3
- [ ] ~~The configuration does not introduce any additional latency.~~

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
