### PR TITLE
fix(ui): change hosts in APIRule details to link

### DIFF
--- a/config/ui-extensions/apirules/details
+++ b/config/ui-extensions/apirules/details
@@ -20,7 +20,7 @@ status:
     - source: 'spec.hosts[0]'
       name: host
       widget: ExternalLink
-      link: " (status.state = 'Ready') ? 'https://' & $virtualServices().items[0].spec.hosts[0] : 'https://' & spec.hosts[0]"
+      link: "'https://' & $virtualServices().items[0].spec.hosts[0]"
       visibility: "status.state = 'Ready'"
     - source: 'spec.hosts[0]'
       name: host

--- a/config/ui-extensions/apirules/details
+++ b/config/ui-extensions/apirules/details
@@ -17,9 +17,14 @@ status:
   body:
     - source: spec.gateway
       name: gateway
-    - source: spec.hosts
+    - source: 'spec.hosts[0]'
       name: host
-      widget: JoinedArray
+      widget: ExternalLink
+      link: " (status.state = 'Ready') ? 'https://' & $virtualServices().items[0].spec.hosts[0] : 'https://' & spec.hosts[0]"
+      visibility: "status.state = 'Ready'"
+    - source: 'spec.hosts[0]'
+      name: host
+      visibility: "status.state != 'Ready'"
     - source: spec.timeout
       name: timeout
       visibility: $exists(spec.timeout)

--- a/docs/release-notes/3.5.0.md
+++ b/docs/release-notes/3.5.0.md
@@ -2,3 +2,4 @@
 - Now, the API Gateway module applies the `kyma-project.io/module` label to all the resources it creates, along with other recommended Kubernetes labels. See [issue #2307](https://github.com/kyma-project/api-gateway/issues/2307).
 - APIRule subresources are now created with two dedicated owner labels `apirule.gateway.kyma-project.io/name` and `apirule.gateway.kyma-project.io/namespace` instead of embedding long owner information in a single label. This prevents label-length-related reconciliation failures of APIRule resources.
 - RateLimit resources are now reconciled correctly when only default bucket is defined without any additional buckets. See [issue #2380](https://github.com/kyma-project/api-gateway/issues/2380).
+- In Busola, the APIRule's host in the details view is now a clickable link. [#2435](https://github.com/kyma-project/api-gateway/pull/2435)

--- a/docs/release-notes/3.5.0.md
+++ b/docs/release-notes/3.5.0.md
@@ -2,4 +2,4 @@
 - Now, the API Gateway module applies the `kyma-project.io/module` label to all the resources it creates, along with other recommended Kubernetes labels. See [issue #2307](https://github.com/kyma-project/api-gateway/issues/2307).
 - APIRule subresources are now created with two dedicated owner labels `apirule.gateway.kyma-project.io/name` and `apirule.gateway.kyma-project.io/namespace` instead of embedding long owner information in a single label. This prevents label-length-related reconciliation failures of APIRule resources.
 - RateLimit resources are now reconciled correctly when only default bucket is defined without any additional buckets. See [issue #2380](https://github.com/kyma-project/api-gateway/issues/2380).
-- In Busola, the APIRule's host in the details view is now a clickable link. [#2435](https://github.com/kyma-project/api-gateway/pull/2435)
+- In Kyma Dashboard, the APIRule's host in the details view is now a clickable link. [#2435](https://github.com/kyma-project/api-gateway/pull/2435)


### PR DESCRIPTION
 - if APIRule is in Ready state then host is a link
 - in other cases it is a static text

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- if APIRule is in Ready state then host is a link
<img width="1907" height="929" alt="Screenshot 2026-01-07 at 13 34 25" src="https://github.com/user-attachments/assets/adabd9c5-5e45-40e0-81d0-4cce3c678c96" />

- in other cases it is a static text
<img width="1919" height="925" alt="Screenshot 2026-01-07 at 13 34 58" src="https://github.com/user-attachments/assets/51048409-bd83-41b8-91b7-3c53b515b632" />

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.
- [ ] You checked if Busola updates are needed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
