### PR TITLE
Set GOMEMLIMIT env for manager deployment

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -50,6 +50,9 @@ spec:
         - --leader-elect
         - "--health-probe-bind-address=:8081"
         - "--metrics-bind-address=:8080"
+        env:
+        - name: GOMEMLIMIT
+          value: "400MiB"
         image: controller:latest
         name: manager
         securityContext:


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Set GOMEMLIMIT to prevent OOM kills by k8s
