### PR TITLE
fix: adjust netpol selector

### DIFF
--- a/internal/networkpolicy/operator_networkpolicy.yaml
+++ b/internal/networkpolicy/operator_networkpolicy.yaml
@@ -10,7 +10,6 @@ spec:
   podSelector:
     matchLabels:
       kyma-project.io/module: api-gateway
-      operator.kyma-project.io/managed-by: kyma
   policyTypes:
     - Egress
     - Ingress


### PR DESCRIPTION
We do not have label operator.kyma-project.io/managed-by: kyma in api-gateway deployments. Hence why netpol does not match the workload. Remove label from selector in netpol.
