### PR TITLE
chore: bump circl to v1.6.3 (#2610)

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -2,7 +2,7 @@ name: Pull Request
 
 permissions:
   contents: read
-  
+
 on:
   pull_request:
     types: [ synchronize, opened, reopened, ready_for_review ]
@@ -14,12 +14,19 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref_name }}
   cancel-in-progress: true
-  
+
 env:
   GITLEAKS_VERSION: 8.21.0
   IMAGE_NAME: "api-gateway-manager"
 
 jobs:
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - id: govulncheck
+        uses: golang/govulncheck-action@b625fbe08f3bccbe446d94fbf87fcc875a4f50ee # v1.0.4
+        with:
+          go-version-input: '1.26.2'
   gitleaks:
     runs-on: ubuntu-latest
     steps:

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/kyma-project/api-gateway
 
 go 1.26
 
+// TODO: remove this once ProtonMail/gopenpgp is updated upstream
+replace github.com/cloudflare/circl v1.6.2 => github.com/cloudflare/circl v1.6.3
+
 require (
 	github.com/ProtonMail/gopenpgp/v3 v3.4.0
 	github.com/avast/retry-go/v4 v4.7.0

--- a/go.sum
+++ b/go.sum
@@ -15,8 +15,8 @@ github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2y
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/cheekybits/is v0.0.0-20150225183255-68e9c0620927/go.mod h1:h/aW8ynjgkuj+NQRlZcDbAbM1ORAbXjXX77sX7T289U=
-github.com/cloudflare/circl v1.6.2 h1:hL7VBpHHKzrV5WTfHCaBsgx/HGbBYlgrwvNXEVDYYsQ=
-github.com/cloudflare/circl v1.6.2/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
+github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
+github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/cucumber/gherkin/go/v26 v26.2.0 h1:EgIjePLWiPeslwIWmNQ3XHcypPsWAHoMCz/YEBKP4GI=


### PR DESCRIPTION
this is patch release not yet fixed in upstream ProtonMail package. Bump the dependency using replace to mitigate found vulnerability.

Backports:
- #2610
- #2609 