### PR TITLE
bug: apirule: filter events by event type

### DIFF
--- a/controllers/gateway/apirule_controller.go
+++ b/controllers/gateway/apirule_controller.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/kyma-project/api-gateway/internal/predicateutil"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 
 	"github.com/kyma-project/api-gateway/internal/gatewaytranslator"
@@ -507,7 +508,11 @@ func (r *APIRuleReconciler) SetupWithManager(mgr ctrl.Manager, c controllers.Rat
 				annotationChangedPredicate{annotation: "gateway.kyma-project.io/v1beta1-spec"},
 			))).
 		Watches(&corev1.ConfigMap{}, &handler.EnqueueRequestForObject{}, builder.WithPredicates(&isApiGatewayConfigMapPredicate{Log: r.Log})).
-		Watches(&corev1.Service{}, NewServiceInformer(r)).
+		Watches(&corev1.Service{}, NewServiceInformer(r),
+			builder.WithPredicates(
+				// Filter out CREATE event types.
+				// We will probably have to reiterate this in the future.
+				predicateutil.ForEventTypes(predicateutil.UpdateEvent, predicateutil.DeleteEvent, predicateutil.GenericEvent))).
 		WithOptions(controller.Options{
 			RateLimiter: controllers.NewRateLimiter(c),
 		}).

--- a/controllers/gateway/informers.go
+++ b/controllers/gateway/informers.go
@@ -17,6 +17,8 @@ import (
 func NewServiceInformer(r *APIRuleReconciler) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
 		var apiRules gatewayv2alpha1.APIRuleList
+		// This call queries apiserver on every service change.
+		// This needs to be improved
 		if err := r.List(ctx, &apiRules); err != nil {
 			return nil
 		}

--- a/docs/release-notes/3.6.1.md
+++ b/docs/release-notes/3.6.1.md
@@ -1,0 +1,2 @@
+## Bug Fixes
+- The controller now filters out Service CREATE events in the Service watcher instead of querying the API server for every event during cache initialization. The new behavior reduces startup time. See [PR #2623](https://github.com/kyma-project/api-gateway/pull/2623).

--- a/internal/predicateutil/predicateutil.go
+++ b/internal/predicateutil/predicateutil.go
@@ -1,0 +1,38 @@
+package predicateutil
+
+import (
+	"slices"
+
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+)
+
+const (
+	CreateEvent EventType = iota
+	UpdateEvent
+	DeleteEvent
+	GenericEvent
+)
+
+// EventType represents a controller-runtime event kind (Create, Update, Delete, or Generic).
+type EventType int
+
+// ForEventTypes returns a predicate that only allows the specified event types to pass through.
+func ForEventTypes(eventType ...EventType) predicate.Predicate {
+	has := func(t EventType) bool {
+		return slices.Contains(eventType, t)
+	}
+	return predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return has(CreateEvent)
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return has(UpdateEvent)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return has(DeleteEvent)
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return has(GenericEvent)
+		}}
+}

--- a/main.go
+++ b/main.go
@@ -23,24 +23,23 @@ import (
 	"os"
 	"time"
 
+	"github.com/kyma-project/api-gateway/controllers/gateway/external"
+	"github.com/kyma-project/api-gateway/controllers/gateway/ratelimit"
+	"github.com/kyma-project/api-gateway/controllers/operator"
+	"github.com/kyma-project/api-gateway/internal/reconciliations/oathkeeper"
 	"go.uber.org/zap/zapcore"
 	corev1 "k8s.io/api/core/v1"
 	networkingv1 "k8s.io/api/networking/v1"
 
 	ratelimitv1alpha1 "github.com/kyma-project/api-gateway/apis/gateway/ratelimit/v1alpha1"
 	"github.com/kyma-project/api-gateway/internal/memlimit"
-	"github.com/kyma-project/api-gateway/internal/reconciliations/oathkeeper"
 	"github.com/kyma-project/api-gateway/internal/version"
-
-	"github.com/kyma-project/api-gateway/controllers"
-	"github.com/kyma-project/api-gateway/controllers/certificate"
-	"github.com/kyma-project/api-gateway/controllers/gateway"
-	"github.com/kyma-project/api-gateway/controllers/gateway/external"
-	"github.com/kyma-project/api-gateway/controllers/gateway/ratelimit"
-	"github.com/kyma-project/api-gateway/controllers/operator"
 
 	gatewayv1beta1 "github.com/kyma-project/api-gateway/apis/gateway/v1beta1"
 	gatewayv2alpha1 "github.com/kyma-project/api-gateway/apis/gateway/v2alpha1"
+	"github.com/kyma-project/api-gateway/controllers"
+	"github.com/kyma-project/api-gateway/controllers/certificate"
+	"github.com/kyma-project/api-gateway/controllers/gateway"
 	apiGatewayMetrics "github.com/kyma-project/api-gateway/internal/metrics"
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)


### PR DESCRIPTION
introduce helper function to filter events by event type

controller-runtime during cold-boots initializes waits for the cache to be done. With many-to-many constraints, where we have to list all apirules and match the service to it, querying APIServer takes a lot of time on large clusters.

As a workaround, we filter out CREATE events, so we only care about the Service update, not creation.

This is needed, because on cold-startup controller waits for all events to be preprocessed before readiness. Since we make API call on every event, with 20k+ resources, we need around 30 minutes to initialize controller. With overloaded apiserver that adds 200-500ms of delay between events. When we ignore CREATE events, we don't query problematic List() calls on startup.
