### PR TITLE
More verbose logs while getting the OIDC configuration, used retryOpts like in other places

### DIFF
--- a/tests/integration/pkg/auth/oauth2-server.go
+++ b/tests/integration/pkg/auth/oauth2-server.go
@@ -56,16 +56,18 @@ func EnsureOAuth2Server(resourceMgr *resource.Manager, k8sClient dynamic.Interfa
 			return "", "", fmt.Errorf("OAuth2 mock server deployment does not work: %w", err)
 		}
 		log.Printf("OAuth2 mock deployed")
+		log.Printf("OIDC configuration of OAuth2 mock: issuer: %s, token endpoint: %s", issuerUrl, tokenUrl)
 		return issuerUrl, tokenUrl, nil
 	} else {
 		log.Printf("OIDC url provided, getting configuration")
-		oidcConfiguration, err := helpers.GetOIDCConfiguration(config.OIDCConfigUrl)
+		oidcConfiguration, err := helpers.GetOIDCConfiguration(config.OIDCConfigUrl, retryOpts)
 		if err != nil {
+			log.Printf("Error while getting the OIDC configuration: %s", err)
 			return "", "", err
 		}
-		log.Printf("OIDC configuration received")
 		issuerUrl := oidcConfiguration.Issuer
 		tokenUrl := oidcConfiguration.TokenEndpoint
+		log.Printf("OIDC configuration of OAuth2 server: issuer: %s, token endpoint: %s", issuerUrl, tokenUrl)
 		return issuerUrl, tokenUrl, nil
 	}
 }

--- a/tests/integration/pkg/helpers/http_client.go
+++ b/tests/integration/pkg/helpers/http_client.go
@@ -6,6 +6,7 @@ import (
 	"github.com/avast/retry-go/v4"
 	"github.com/pkg/errors"
 	"io"
+	"log"
 	"net/http"
 	"time"
 )
@@ -143,20 +144,30 @@ type OIDCConfiguration struct {
 	FrontchannelLogoutSessionSupported    bool     `json:"frontchannel_logout_session_supported"`
 }
 
-func GetOIDCConfiguration(oidcConfigurationEndpoint string) (oidcConfiguration OIDCConfiguration, err error) {
+func GetOIDCConfiguration(oidcConfigurationEndpoint string, retryOpts []retry.Option) (oidcConfiguration OIDCConfiguration, err error) {
 	var resp *http.Response
 	err = retry.Do(func() error {
+		log.Printf("Getting OIDC configuration from %s, time: %s", oidcConfigurationEndpoint, time.Now())
 		response, err := http.Get(oidcConfigurationEndpoint)
+		if err != nil {
+			log.Printf("Error while getting OIDC configuration from %s: %s", oidcConfigurationEndpoint, err)
+		}
+		if (response != nil) && (response.StatusCode != 200) {
+			log.Printf("Received response from %s, status code: %d", oidcConfigurationEndpoint, response.StatusCode)
+		}
 		resp = response
 		return err
-	}, retry.Attempts(20), retry.Delay(2*time.Second), retry.DelayType(retry.FixedDelay))
+	}, retryOpts...)
 
 	if err != nil {
+		log.Printf("Giving up getting OIDC configuration from %s: %s", oidcConfigurationEndpoint, err)
 		return OIDCConfiguration{}, err
 	}
+	log.Printf("Decoding OIDC configuration")
 	err = json.NewDecoder(resp.Body).Decode(&oidcConfiguration)
 	if err != nil {
 		return OIDCConfiguration{}, err
 	}
+	log.Printf("OIDC configuration decoded")
 	return oidcConfiguration, err
 }


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- more verbose logs while getting the OIDC configuration
- used retryOpts like in other places

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.
- [ ] You checked if Busola updates are needed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
