### PR TITLE
fix: add kyma-project.io/module label to api-gateway resources

### DIFF
--- a/deployment/api-gateway-config.operator.kyma-project.io.yaml
+++ b/deployment/api-gateway-config.operator.kyma-project.io.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: api-gateway-config.operator.kyma-project.io
+  namespace: kyma-system
+  labels:
+    kyma-project.io/module: api-gateway

--- a/deployment/api-gateway-controller-manager-vpa-manager.yaml
+++ b/deployment/api-gateway-controller-manager-vpa-manager.yaml
@@ -1,0 +1,7 @@
+apiVersion: autoscaling.k8s.io/v1
+kind: VerticalPodAutoscalerCheckpoint
+metadata:
+  name: api-gateway-controller-manager-vpa-manager
+  namespace: kyma-system
+  labels:
+    kyma-project.io/module: api-gateway

--- a/deployment/kyma-gateway-certs-cacert.yaml
+++ b/deployment/kyma-gateway-certs-cacert.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kyma-gateway-certs-cacert
+  namespace: istio-system
+  labels:
+    kyma-project.io/module: api-gateway

--- a/deployment/kyma-gateway-certs.yaml
+++ b/deployment/kyma-gateway-certs.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: kyma-gateway-certs
+  namespace: istio-system
+  labels:
+    kyma-project.io/module: api-gateway


### PR DESCRIPTION
## Problem
The api-gateway module/component is missing the `kyma-project.io/module=<module-name>` label on its resources.

## Solution
Added the `kyma-project.io/module: api-gateway` label to the api-gateway-config ConfigMap, api-gateway-controller-manager-vpa-manager VerticalPodAutoscalerCheckpoint, kyma-gateway-certs Secret, and kyma-gateway-certs-cacert Secret.

## Testing
Verified that the label is correctly applied to all resources using `kubectl` commands.

---
*Closes #2634*

> 🤖 Generated by AutoGit
> *(Contribution guidelines followed)*