### PR TITLE
Split new e2e tests

### DIFF
--- a/.github/workflows/post-main-release-integration.yaml
+++ b/.github/workflows/post-main-release-integration.yaml
@@ -85,7 +85,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2" ]
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/e2e-test-k3d
@@ -108,7 +108,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2" ]
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/e2e-test-gardener

--- a/.github/workflows/post-main-release-integration.yaml
+++ b/.github/workflows/post-main-release-integration.yaml
@@ -68,62 +68,62 @@ jobs:
     uses: ./.github/workflows/call-unit-lint.yaml
     secrets: inherit
 
-    #############################################
-    #
-    # E2E tests
-    # Run on: AWS, K3D
-    #
-    #############################################
+  #############################################
+  #
+  # E2E tests
+  # Run on: AWS, K3D
+  #
+  #############################################
 
-    e2e-tests-k3d:
-      name: E2E tests K3D
-      environment:
-        name: e2e
-        deployment: false
-      runs-on: ubuntu-latest
-      needs: [ get-image ]
-      strategy:
-        fail-fast: false
-        matrix:
-          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
-      steps:
-        - uses: actions/checkout@v7
-        - uses: ./.github/actions/e2e-test-k3d
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-            manager_image: ${{ needs.get-image.outputs.image }}
-            test_client_id: ${{ vars.CLIENT_ID }}
-            test_client_secret: ${{ secrets.CLIENT_SECRET }}
-            test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-            test_make_target: ${{ matrix.test_make_target }}
-    
-    e2e-tests-aws:
-      name: E2E tests AWS
-      environment:
-        name: e2e
-        deployment: false
-      runs-on: ubuntu-latest
-      needs: [ get-image ]
-      strategy:
-        fail-fast: false
-        matrix:
-          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
-      steps:
-        - uses: actions/checkout@v7
-        - uses: ./.github/actions/e2e-test-gardener
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
-          with:
-            manager_image: ${{ needs.get-image.outputs.image }}
-            gardener_secret: ${{ secrets.GARDENER_TOKEN }}
-            gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
-            gardener_provider: aws
-            test_client_id: ${{ vars.CLIENT_ID }}
-            test_client_secret: ${{ secrets.CLIENT_SECRET }}
-            test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-            test_make_target: ${{ matrix.test_make_target }}
+  e2e-tests-k3d:
+    name: E2E tests K3D
+    environment:
+      name: e2e
+      deployment: false
+    runs-on: ubuntu-latest
+    needs: [ get-image ]
+    strategy:
+      fail-fast: false
+      matrix:
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/e2e-test-k3d
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manager_image: ${{ needs.get-image.outputs.image }}
+          test_client_id: ${{ vars.CLIENT_ID }}
+          test_client_secret: ${{ secrets.CLIENT_SECRET }}
+          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+          test_make_target: ${{ matrix.test_make_target }}
+
+  e2e-tests-aws:
+    name: E2E tests AWS
+    environment:
+      name: e2e
+      deployment: false
+    runs-on: ubuntu-latest
+    needs: [ get-image ]
+    strategy:
+      fail-fast: false
+      matrix:
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/e2e-test-gardener
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
+        with:
+          manager_image: ${{ needs.get-image.outputs.image }}
+          gardener_secret: ${{ secrets.GARDENER_TOKEN }}
+          gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
+          gardener_provider: aws
+          test_client_id: ${{ vars.CLIENT_ID }}
+          test_client_secret: ${{ secrets.CLIENT_SECRET }}
+          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+          test_make_target: ${{ matrix.test_make_target }}
 
   #############################################
   #

--- a/.github/workflows/post-main-release-integration.yaml
+++ b/.github/workflows/post-main-release-integration.yaml
@@ -76,54 +76,54 @@ jobs:
   #############################################
 
   e2e-tests-k3d:
-    name: E2E tests K3D
-    environment:
-      name: e2e
-      deployment: false
-    runs-on: ubuntu-latest
-    needs: [ get-image ]
-    strategy:
-      fail-fast: false
-      matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2" ]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/e2e-test-k3d
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          manager_image: ${{ needs.get-image.outputs.image }}
-          test_client_id: ${{ vars.CLIENT_ID }}
-          test_client_secret: ${{ secrets.CLIENT_SECRET }}
-          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-          test_make_target: ${{ matrix.test_make_target }}
+     name: E2E tests K3D
+     environment:
+       name: e2e
+       deployment: false
+     runs-on: ubuntu-latest
+     needs: [ get-image ]
+     strategy:
+       fail-fast: false
+       matrix:
+         test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+     steps:
+       - uses: actions/checkout@v7
+       - uses: ./.github/actions/e2e-test-k3d
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+         with:
+           manager_image: ${{ needs.get-image.outputs.image }}
+           test_client_id: ${{ vars.CLIENT_ID }}
+           test_client_secret: ${{ secrets.CLIENT_SECRET }}
+           test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+           test_make_target: ${{ matrix.test_make_target }}
 
   e2e-tests-aws:
-    name: E2E tests AWS
-    environment:
-      name: e2e
-      deployment: false
-    runs-on: ubuntu-latest
-    needs: [ get-image ]
-    strategy:
-      fail-fast: false
-      matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2" ]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/e2e-test-gardener
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
-        with:
-          manager_image: ${{ needs.get-image.outputs.image }}
-          gardener_secret: ${{ secrets.GARDENER_TOKEN }}
-          gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
-          gardener_provider: aws
-          test_client_id: ${{ vars.CLIENT_ID }}
-          test_client_secret: ${{ secrets.CLIENT_SECRET }}
-          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-          test_make_target: ${{ matrix.test_make_target }}
+     name: E2E tests AWS
+     environment:
+       name: e2e
+       deployment: false
+     runs-on: ubuntu-latest
+     needs: [ get-image ]
+     strategy:
+       fail-fast: false
+       matrix:
+         test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+     steps:
+       - uses: actions/checkout@v7
+       - uses: ./.github/actions/e2e-test-gardener
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+           APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
+         with:
+           manager_image: ${{ needs.get-image.outputs.image }}
+           gardener_secret: ${{ secrets.GARDENER_TOKEN }}
+           gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
+           gardener_provider: aws
+           test_client_id: ${{ vars.CLIENT_ID }}
+           test_client_secret: ${{ secrets.CLIENT_SECRET }}
+           test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+           test_make_target: ${{ matrix.test_make_target }}
 
   #############################################
   #

--- a/.github/workflows/post-main-release-integration.yaml
+++ b/.github/workflows/post-main-release-integration.yaml
@@ -125,12 +125,22 @@ jobs:
           test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
           test_make_target: ${{ matrix.test_make_target }}
 
-  #############################################
-  #
-  # Zero downtime tests
-  # Run on: AWS, K3D
-  #
-  #############################################
+  new-e2e-tests-k3d:
+   name: New E2E tests K3D
+   runs-on: ubuntu-latest
+   needs: [ get-image ]
+   strategy:
+     fail-fast: false
+     matrix:
+       test_make_target: [ "e2e-test-part1", "e2e-test-part2" ]
+   steps:
+     - uses: actions/checkout@v7
+     - uses: ./.github/actions/e2e-k3d
+       env:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+       with:
+         manager_image: ${{ needs.get-image.outputs.image }}
+         test_make_target: ${{ matrix.test_make_target }}
 
   migration-downtime-tests-k3d:
     name: Zero Downtime Migration Tests K3D
@@ -270,7 +280,7 @@ jobs:
       deployment: false
     runs-on: ubuntu-latest
     if: ${{ failure() }}
-    needs: [ e2e-tests-k3d, e2e-tests-aws, upgrade-tests-k3d, e2e-custom-domain-gcp, e2e-custom-domain-aws, migration-downtime-tests-k3d, migration-downtime-tests-aws ]
+    needs: [ e2e-tests-k3d, e2e-tests-aws, new-e2e-tests-k3d, upgrade-tests-k3d, e2e-custom-domain-gcp, e2e-custom-domain-aws, migration-downtime-tests-k3d, migration-downtime-tests-aws ]
     steps:
       - uses: actions/checkout@v7
       - name: Notify

--- a/.github/workflows/post-main-release-integration.yaml
+++ b/.github/workflows/post-main-release-integration.yaml
@@ -76,54 +76,54 @@ jobs:
   #############################################
 
   e2e-tests-k3d:
-     name: E2E tests K3D
-     environment:
-       name: e2e
-       deployment: false
-     runs-on: ubuntu-latest
-     needs: [ get-image ]
-     strategy:
-       fail-fast: false
-       matrix:
-         test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
-     steps:
-       - uses: actions/checkout@v7
-       - uses: ./.github/actions/e2e-test-k3d
-         env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-         with:
-           manager_image: ${{ needs.get-image.outputs.image }}
-           test_client_id: ${{ vars.CLIENT_ID }}
-           test_client_secret: ${{ secrets.CLIENT_SECRET }}
-           test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-           test_make_target: ${{ matrix.test_make_target }}
+    name: E2E tests K3D
+    environment:
+      name: e2e
+      deployment: false
+    runs-on: ubuntu-latest
+    needs: [ get-image ]
+    strategy:
+      fail-fast: false
+      matrix:
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/e2e-test-k3d
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manager_image: ${{ needs.get-image.outputs.image }}
+          test_client_id: ${{ vars.CLIENT_ID }}
+          test_client_secret: ${{ secrets.CLIENT_SECRET }}
+          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+          test_make_target: ${{ matrix.test_make_target }}
 
   e2e-tests-aws:
-     name: E2E tests AWS
-     environment:
-       name: e2e
-       deployment: false
-     runs-on: ubuntu-latest
-     needs: [ get-image ]
-     strategy:
-       fail-fast: false
-       matrix:
-         test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
-     steps:
-       - uses: actions/checkout@v7
-       - uses: ./.github/actions/e2e-test-gardener
-         env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-           APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
-         with:
-           manager_image: ${{ needs.get-image.outputs.image }}
-           gardener_secret: ${{ secrets.GARDENER_TOKEN }}
-           gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
-           gardener_provider: aws
-           test_client_id: ${{ vars.CLIENT_ID }}
-           test_client_secret: ${{ secrets.CLIENT_SECRET }}
-           test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-           test_make_target: ${{ matrix.test_make_target }}
+    name: E2E tests AWS
+    environment:
+      name: e2e
+      deployment: false
+    runs-on: ubuntu-latest
+    needs: [ get-image ]
+    strategy:
+      fail-fast: false
+      matrix:
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/e2e-test-gardener
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
+        with:
+          manager_image: ${{ needs.get-image.outputs.image }}
+          gardener_secret: ${{ secrets.GARDENER_TOKEN }}
+          gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
+          gardener_provider: aws
+          test_client_id: ${{ vars.CLIENT_ID }}
+          test_client_secret: ${{ secrets.CLIENT_SECRET }}
+          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+          test_make_target: ${{ matrix.test_make_target }}
 
   #############################################
   #
@@ -270,7 +270,7 @@ jobs:
       deployment: false
     runs-on: ubuntu-latest
     if: ${{ failure() }}
-    needs: [e2e-tests-k3d, e2e-tests-aws, upgrade-tests-k3d, e2e-custom-domain-gcp, e2e-custom-domain-aws, migration-downtime-tests-k3d, migration-downtime-tests-aws]
+    needs: [ e2e-tests-k3d, e2e-tests-aws, upgrade-tests-k3d, e2e-custom-domain-gcp, e2e-custom-domain-aws, migration-downtime-tests-k3d, migration-downtime-tests-aws ]
     steps:
       - uses: actions/checkout@v7
       - name: Notify

--- a/.github/workflows/post-main-release-integration.yaml
+++ b/.github/workflows/post-main-release-integration.yaml
@@ -68,62 +68,62 @@ jobs:
     uses: ./.github/workflows/call-unit-lint.yaml
     secrets: inherit
 
-  #############################################
-  #
-  # E2E tests
-  # Run on: AWS, K3D
-  #
-  #############################################
+    #############################################
+    #
+    # E2E tests
+    # Run on: AWS, K3D
+    #
+    #############################################
 
-  e2e-tests-k3d:
-    name: E2E tests K3D
-    environment:
-      name: e2e
-      deployment: false
-    runs-on: ubuntu-latest
-    needs: [ get-image ]
-    strategy:
-      fail-fast: false
-      matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/e2e-test-k3d
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          manager_image: ${{ needs.get-image.outputs.image }}
-          test_client_id: ${{ vars.CLIENT_ID }}
-          test_client_secret: ${{ secrets.CLIENT_SECRET }}
-          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-          test_make_target: ${{ matrix.test_make_target }}
-
-  e2e-tests-aws:
-    name: E2E tests AWS
-    environment:
-      name: e2e
-      deployment: false
-    runs-on: ubuntu-latest
-    needs: [ get-image ]
-    strategy:
-      fail-fast: false
-      matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/e2e-test-gardener
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
-        with:
-          manager_image: ${{ needs.get-image.outputs.image }}
-          gardener_secret: ${{ secrets.GARDENER_TOKEN }}
-          gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
-          gardener_provider: aws
-          test_client_id: ${{ vars.CLIENT_ID }}
-          test_client_secret: ${{ secrets.CLIENT_SECRET }}
-          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-          test_make_target: ${{ matrix.test_make_target }}
+    e2e-tests-k3d:
+      name: E2E tests K3D
+      environment:
+        name: e2e
+        deployment: false
+      runs-on: ubuntu-latest
+      needs: [ get-image ]
+      strategy:
+        fail-fast: false
+        matrix:
+          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+      steps:
+        - uses: actions/checkout@v7
+        - uses: ./.github/actions/e2e-test-k3d
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            manager_image: ${{ needs.get-image.outputs.image }}
+            test_client_id: ${{ vars.CLIENT_ID }}
+            test_client_secret: ${{ secrets.CLIENT_SECRET }}
+            test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+            test_make_target: ${{ matrix.test_make_target }}
+    
+    e2e-tests-aws:
+      name: E2E tests AWS
+      environment:
+        name: e2e
+        deployment: false
+      runs-on: ubuntu-latest
+      needs: [ get-image ]
+      strategy:
+        fail-fast: false
+        matrix:
+          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+      steps:
+        - uses: actions/checkout@v7
+        - uses: ./.github/actions/e2e-test-gardener
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
+          with:
+            manager_image: ${{ needs.get-image.outputs.image }}
+            gardener_secret: ${{ secrets.GARDENER_TOKEN }}
+            gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
+            gardener_provider: aws
+            test_client_id: ${{ vars.CLIENT_ID }}
+            test_client_secret: ${{ secrets.CLIENT_SECRET }}
+            test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+            test_make_target: ${{ matrix.test_make_target }}
 
   #############################################
   #

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -100,7 +100,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2" ]
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/load-manager-image
@@ -118,7 +118,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "e2e-test" ]
+        test_make_target: [ "e2e-test-part1", "e2e-test-part2" ]
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/load-manager-image

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -94,22 +94,22 @@ jobs:
     secrets: inherit
 
   e2e-tests-k3d:
-    name: E2E tests K3D
-    runs-on: ubuntu-latest
-    needs: [ get-image ]
-    strategy:
-      fail-fast: false
-      matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2" ]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/load-manager-image
-      - uses: ./.github/actions/e2e-test-k3d
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          manager_image: ${{ needs.get-image.outputs.image }}
-          test_make_target: ${{ matrix.test_make_target }}
+     name: E2E tests K3D
+     runs-on: ubuntu-latest
+     needs: [ get-image ]
+     strategy:
+       fail-fast: false
+       matrix:
+         test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+     steps:
+       - uses: actions/checkout@v7
+       - uses: ./.github/actions/load-manager-image
+       - uses: ./.github/actions/e2e-test-k3d
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+         with:
+           manager_image: ${{ needs.get-image.outputs.image }}
+           test_make_target: ${{ matrix.test_make_target }}
 
   new-e2e-tests-k3d:
     name: New E2E tests K3D

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -92,24 +92,23 @@ jobs:
     name: Unit tests & lint
     uses: ./.github/workflows/call-unit-lint.yaml
     secrets: inherit
-
-  e2e-tests-k3d:
-    name: E2E tests K3D
-    runs-on: ubuntu-latest
-    needs: [ get-image ]
-    strategy:
-      fail-fast: false
-      matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/load-manager-image
-      - uses: ./.github/actions/e2e-test-k3d
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          manager_image: ${{ needs.get-image.outputs.image }}
-          test_make_target: ${{ matrix.test_make_target }}
+    e2e-tests-k3d:
+      name: E2E tests K3D
+      runs-on: ubuntu-latest
+      needs: [ get-image ]
+      strategy:
+        fail-fast: false
+        matrix:
+          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+      steps:
+        - uses: actions/checkout@v7
+        - uses: ./.github/actions/load-manager-image
+        - uses: ./.github/actions/e2e-test-k3d
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            manager_image: ${{ needs.get-image.outputs.image }}
+            test_make_target: ${{ matrix.test_make_target }}
 
   new-e2e-tests-k3d:
     name: New E2E tests K3D

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -92,23 +92,24 @@ jobs:
     name: Unit tests & lint
     uses: ./.github/workflows/call-unit-lint.yaml
     secrets: inherit
-    e2e-tests-k3d:
-      name: E2E tests K3D
-      runs-on: ubuntu-latest
-      needs: [ get-image ]
-      strategy:
-        fail-fast: false
-        matrix:
-          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
-      steps:
-        - uses: actions/checkout@v7
-        - uses: ./.github/actions/load-manager-image
-        - uses: ./.github/actions/e2e-test-k3d
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-            manager_image: ${{ needs.get-image.outputs.image }}
-            test_make_target: ${{ matrix.test_make_target }}
+
+  e2e-tests-k3d:
+    name: E2E tests K3D
+    runs-on: ubuntu-latest
+    needs: [ get-image ]
+    strategy:
+      fail-fast: false
+      matrix:
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/load-manager-image
+      - uses: ./.github/actions/e2e-test-k3d
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manager_image: ${{ needs.get-image.outputs.image }}
+          test_make_target: ${{ matrix.test_make_target }}
 
   new-e2e-tests-k3d:
     name: New E2E tests K3D

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -94,22 +94,22 @@ jobs:
     secrets: inherit
 
   e2e-tests-k3d:
-     name: E2E tests K3D
-     runs-on: ubuntu-latest
-     needs: [ get-image ]
-     strategy:
-       fail-fast: false
-       matrix:
-         test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
-     steps:
-       - uses: actions/checkout@v7
-       - uses: ./.github/actions/load-manager-image
-       - uses: ./.github/actions/e2e-test-k3d
-         env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-         with:
-           manager_image: ${{ needs.get-image.outputs.image }}
-           test_make_target: ${{ matrix.test_make_target }}
+    name: E2E tests K3D
+    runs-on: ubuntu-latest
+    needs: [ get-image ]
+    strategy:
+      fail-fast: false
+      matrix:
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/load-manager-image
+      - uses: ./.github/actions/e2e-test-k3d
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manager_image: ${{ needs.get-image.outputs.image }}
+          test_make_target: ${{ matrix.test_make_target }}
 
   new-e2e-tests-k3d:
     name: New E2E tests K3D

--- a/.github/workflows/release-api-gateway.yaml
+++ b/.github/workflows/release-api-gateway.yaml
@@ -138,62 +138,62 @@ jobs:
     uses: ./.github/workflows/call-unit-lint.yaml
     secrets: inherit
 
-    #############################################
-    #
-    # E2E tests
-    # Run on: AWS, K3D
-    #
-    #############################################
+  #############################################
+  #
+  # E2E tests
+  # Run on: AWS, K3D
+  #
+  #############################################
 
-    e2e-tests-k3d:
-      name: E2E tests K3D
-      environment:
-        name: e2e
-        deployment: false
-      runs-on: ubuntu-latest
-      needs: [ get-image ]
-      strategy:
-        fail-fast: false
-        matrix:
-          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
-      steps:
-        - uses: actions/checkout@v7
-        - uses: ./.github/actions/e2e-test-k3d
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-            manager_image: ${{ needs.get-image.outputs.image }}
-            test_client_id: ${{ secrets.CLIENT_ID }}
-            test_client_secret: ${{ secrets.CLIENT_SECRET }}
-            test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-            test_make_target: ${{ matrix.test_make_target }}
+  e2e-tests-k3d:
+    name: E2E tests K3D
+    environment:
+      name: e2e
+      deployment: false
+    runs-on: ubuntu-latest
+    needs: [ get-image ]
+    strategy:
+      fail-fast: false
+      matrix:
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/e2e-test-k3d
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manager_image: ${{ needs.get-image.outputs.image }}
+          test_client_id: ${{ secrets.CLIENT_ID }}
+          test_client_secret: ${{ secrets.CLIENT_SECRET }}
+          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+          test_make_target: ${{ matrix.test_make_target }}
 
-    e2e-tests-aws:
-      name: E2E tests AWS
-      environment:
-        name: e2e
-        deployment: false
-      runs-on: ubuntu-latest
-      needs: [ get-image ]
-      strategy:
-        fail-fast: false
-        matrix:
-          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
-      steps:
-        - uses: actions/checkout@v7
-        - uses: ./.github/actions/e2e-test-gardener
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
-          with:
-            manager_image: ${{ needs.get-image.outputs.image }}
-            gardener_secret: ${{ secrets.GARDENER_TOKEN }}
-            gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
-            gardener_provider: aws
-            test_client_id: ${{ secrets.CLIENT_ID }}
-            test_client_secret: ${{ secrets.CLIENT_SECRET }}
-            test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-            test_make_target: ${{ matrix.test_make_target }}
+  e2e-tests-aws:
+    name: E2E tests AWS
+    environment:
+      name: e2e
+      deployment: false
+    runs-on: ubuntu-latest
+    needs: [ get-image ]
+    strategy:
+      fail-fast: false
+      matrix:
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/e2e-test-gardener
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
+        with:
+          manager_image: ${{ needs.get-image.outputs.image }}
+          gardener_secret: ${{ secrets.GARDENER_TOKEN }}
+          gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
+          gardener_provider: aws
+          test_client_id: ${{ secrets.CLIENT_ID }}
+          test_client_secret: ${{ secrets.CLIENT_SECRET }}
+          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+          test_make_target: ${{ matrix.test_make_target }}
 
   #############################################
   #

--- a/.github/workflows/release-api-gateway.yaml
+++ b/.github/workflows/release-api-gateway.yaml
@@ -146,54 +146,54 @@ jobs:
   #############################################
 
   e2e-tests-k3d:
-    name: E2E tests K3D
-    environment:
-      name: e2e
-      deployment: false
-    runs-on: ubuntu-latest
-    needs: [ get-image ]
-    strategy:
-      fail-fast: false
-      matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2" ]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/e2e-test-k3d
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          manager_image: ${{ needs.get-image.outputs.image }}
-          test_client_id: ${{ secrets.CLIENT_ID }}
-          test_client_secret: ${{ secrets.CLIENT_SECRET }}
-          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-          test_make_target: ${{ matrix.test_make_target }}
+     name: E2E tests K3D
+     environment:
+       name: e2e
+       deployment: false
+     runs-on: ubuntu-latest
+     needs: [ get-image ]
+     strategy:
+       fail-fast: false
+       matrix:
+         test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+     steps:
+       - uses: actions/checkout@v7
+       - uses: ./.github/actions/e2e-test-k3d
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+         with:
+           manager_image: ${{ needs.get-image.outputs.image }}
+           test_client_id: ${{ secrets.CLIENT_ID }}
+           test_client_secret: ${{ secrets.CLIENT_SECRET }}
+           test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+           test_make_target: ${{ matrix.test_make_target }}
 
   e2e-tests-aws:
-    name: E2E tests AWS
-    environment:
-      name: e2e
-      deployment: false
-    runs-on: ubuntu-latest
-    needs: [ get-image ]
-    strategy:
-      fail-fast: false
-      matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2" ]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/e2e-test-gardener
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
-        with:
-          manager_image: ${{ needs.get-image.outputs.image }}
-          gardener_secret: ${{ secrets.GARDENER_TOKEN }}
-          gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
-          gardener_provider: aws
-          test_client_id: ${{ secrets.CLIENT_ID }}
-          test_client_secret: ${{ secrets.CLIENT_SECRET }}
-          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-          test_make_target: ${{ matrix.test_make_target }}
+     name: E2E tests AWS
+     environment:
+       name: e2e
+       deployment: false
+     runs-on: ubuntu-latest
+     needs: [ get-image ]
+     strategy:
+       fail-fast: false
+       matrix:
+         test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+     steps:
+       - uses: actions/checkout@v7
+       - uses: ./.github/actions/e2e-test-gardener
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+           APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
+         with:
+           manager_image: ${{ needs.get-image.outputs.image }}
+           gardener_secret: ${{ secrets.GARDENER_TOKEN }}
+           gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
+           gardener_provider: aws
+           test_client_id: ${{ secrets.CLIENT_ID }}
+           test_client_secret: ${{ secrets.CLIENT_SECRET }}
+           test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+           test_make_target: ${{ matrix.test_make_target }}
 
   #############################################
   #

--- a/.github/workflows/release-api-gateway.yaml
+++ b/.github/workflows/release-api-gateway.yaml
@@ -138,62 +138,62 @@ jobs:
     uses: ./.github/workflows/call-unit-lint.yaml
     secrets: inherit
 
-  #############################################
-  #
-  # E2E tests
-  # Run on: AWS, K3D
-  #
-  #############################################
+    #############################################
+    #
+    # E2E tests
+    # Run on: AWS, K3D
+    #
+    #############################################
 
-  e2e-tests-k3d:
-    name: E2E tests K3D
-    environment:
-      name: e2e
-      deployment: false
-    runs-on: ubuntu-latest
-    needs: [ get-image ]
-    strategy:
-      fail-fast: false
-      matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/e2e-test-k3d
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          manager_image: ${{ needs.get-image.outputs.image }}
-          test_client_id: ${{ secrets.CLIENT_ID }}
-          test_client_secret: ${{ secrets.CLIENT_SECRET }}
-          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-          test_make_target: ${{ matrix.test_make_target }}
+    e2e-tests-k3d:
+      name: E2E tests K3D
+      environment:
+        name: e2e
+        deployment: false
+      runs-on: ubuntu-latest
+      needs: [ get-image ]
+      strategy:
+        fail-fast: false
+        matrix:
+          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+      steps:
+        - uses: actions/checkout@v7
+        - uses: ./.github/actions/e2e-test-k3d
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            manager_image: ${{ needs.get-image.outputs.image }}
+            test_client_id: ${{ secrets.CLIENT_ID }}
+            test_client_secret: ${{ secrets.CLIENT_SECRET }}
+            test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+            test_make_target: ${{ matrix.test_make_target }}
 
-  e2e-tests-aws:
-    name: E2E tests AWS
-    environment:
-      name: e2e
-      deployment: false
-    runs-on: ubuntu-latest
-    needs: [ get-image ]
-    strategy:
-      fail-fast: false
-      matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/e2e-test-gardener
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
-        with:
-          manager_image: ${{ needs.get-image.outputs.image }}
-          gardener_secret: ${{ secrets.GARDENER_TOKEN }}
-          gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
-          gardener_provider: aws
-          test_client_id: ${{ secrets.CLIENT_ID }}
-          test_client_secret: ${{ secrets.CLIENT_SECRET }}
-          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-          test_make_target: ${{ matrix.test_make_target }}
+    e2e-tests-aws:
+      name: E2E tests AWS
+      environment:
+        name: e2e
+        deployment: false
+      runs-on: ubuntu-latest
+      needs: [ get-image ]
+      strategy:
+        fail-fast: false
+        matrix:
+          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+      steps:
+        - uses: actions/checkout@v7
+        - uses: ./.github/actions/e2e-test-gardener
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
+          with:
+            manager_image: ${{ needs.get-image.outputs.image }}
+            gardener_secret: ${{ secrets.GARDENER_TOKEN }}
+            gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
+            gardener_provider: aws
+            test_client_id: ${{ secrets.CLIENT_ID }}
+            test_client_secret: ${{ secrets.CLIENT_SECRET }}
+            test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+            test_make_target: ${{ matrix.test_make_target }}
 
   #############################################
   #

--- a/.github/workflows/release-api-gateway.yaml
+++ b/.github/workflows/release-api-gateway.yaml
@@ -168,6 +168,23 @@ jobs:
           test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
           test_make_target: ${{ matrix.test_make_target }}
 
+  new-e2e-tests-k3d:
+   name: New E2E tests K3D
+   runs-on: ubuntu-latest
+   needs: [ get-image ]
+   strategy:
+     fail-fast: false
+     matrix:
+       test_make_target: [ "e2e-test-part1", "e2e-test-part2" ]
+   steps:
+     - uses: actions/checkout@v7
+     - uses: ./.github/actions/e2e-k3d
+       env:
+         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+       with:
+         manager_image: ${{ needs.get-image.outputs.image }}
+         test_make_target: ${{ matrix.test_make_target }}
+
   e2e-tests-aws:
     name: E2E tests AWS
     environment:
@@ -335,7 +352,7 @@ jobs:
   create-draft-release:
     name: Create draft release
     runs-on: ubuntu-latest
-    needs: [ check-prerequisites, build-image, unit-tests, e2e-tests-k3d, e2e-tests-aws, upgrade-tests-k3d, e2e-custom-domain-gcp, e2e-custom-domain-aws, migration-downtime-tests-k3d, migration-downtime-tests-aws ]
+    needs: [ check-prerequisites, build-image, unit-tests, e2e-tests-k3d, new-e2e-tests-k3d, e2e-tests-aws, upgrade-tests-k3d, e2e-custom-domain-gcp, e2e-custom-domain-aws, migration-downtime-tests-k3d, migration-downtime-tests-aws ]
     outputs:
       release_id: ${{ steps.create-draft-release.outputs.release_id }}
     steps:
@@ -419,4 +436,3 @@ jobs:
           payload: |
             repository: ${{ github.repository }},
             release: "${{ inputs.version }}"
-

--- a/.github/workflows/release-api-gateway.yaml
+++ b/.github/workflows/release-api-gateway.yaml
@@ -27,7 +27,7 @@ env:
   IMAGE_NAME: "europe-docker.pkg.dev/kyma-project/prod/api-gateway/releases/api-gateway-manager"
 
 jobs:
-  check-prerequisites: 
+  check-prerequisites:
     name: Check prerequisites
     runs-on: ubuntu-latest
     steps:
@@ -146,54 +146,54 @@ jobs:
   #############################################
 
   e2e-tests-k3d:
-     name: E2E tests K3D
-     environment:
-       name: e2e
-       deployment: false
-     runs-on: ubuntu-latest
-     needs: [ get-image ]
-     strategy:
-       fail-fast: false
-       matrix:
-         test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
-     steps:
-       - uses: actions/checkout@v7
-       - uses: ./.github/actions/e2e-test-k3d
-         env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-         with:
-           manager_image: ${{ needs.get-image.outputs.image }}
-           test_client_id: ${{ secrets.CLIENT_ID }}
-           test_client_secret: ${{ secrets.CLIENT_SECRET }}
-           test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-           test_make_target: ${{ matrix.test_make_target }}
+    name: E2E tests K3D
+    environment:
+      name: e2e
+      deployment: false
+    runs-on: ubuntu-latest
+    needs: [ get-image ]
+    strategy:
+      fail-fast: false
+      matrix:
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/e2e-test-k3d
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manager_image: ${{ needs.get-image.outputs.image }}
+          test_client_id: ${{ secrets.CLIENT_ID }}
+          test_client_secret: ${{ secrets.CLIENT_SECRET }}
+          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+          test_make_target: ${{ matrix.test_make_target }}
 
   e2e-tests-aws:
-     name: E2E tests AWS
-     environment:
-       name: e2e
-       deployment: false
-     runs-on: ubuntu-latest
-     needs: [ get-image ]
-     strategy:
-       fail-fast: false
-       matrix:
-         test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
-     steps:
-       - uses: actions/checkout@v7
-       - uses: ./.github/actions/e2e-test-gardener
-         env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-           APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
-         with:
-           manager_image: ${{ needs.get-image.outputs.image }}
-           gardener_secret: ${{ secrets.GARDENER_TOKEN }}
-           gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
-           gardener_provider: aws
-           test_client_id: ${{ secrets.CLIENT_ID }}
-           test_client_secret: ${{ secrets.CLIENT_SECRET }}
-           test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-           test_make_target: ${{ matrix.test_make_target }}
+    name: E2E tests AWS
+    environment:
+      name: e2e
+      deployment: false
+    runs-on: ubuntu-latest
+    needs: [ get-image ]
+    strategy:
+      fail-fast: false
+      matrix:
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/e2e-test-gardener
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
+        with:
+          manager_image: ${{ needs.get-image.outputs.image }}
+          gardener_secret: ${{ secrets.GARDENER_TOKEN }}
+          gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
+          gardener_provider: aws
+          test_client_id: ${{ secrets.CLIENT_ID }}
+          test_client_secret: ${{ secrets.CLIENT_SECRET }}
+          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+          test_make_target: ${{ matrix.test_make_target }}
 
   #############################################
   #
@@ -335,7 +335,7 @@ jobs:
   create-draft-release:
     name: Create draft release
     runs-on: ubuntu-latest
-    needs: [check-prerequisites, build-image, unit-tests, e2e-tests-k3d, e2e-tests-aws, upgrade-tests-k3d, e2e-custom-domain-gcp, e2e-custom-domain-aws, migration-downtime-tests-k3d, migration-downtime-tests-aws ]
+    needs: [ check-prerequisites, build-image, unit-tests, e2e-tests-k3d, e2e-tests-aws, upgrade-tests-k3d, e2e-custom-domain-gcp, e2e-custom-domain-aws, migration-downtime-tests-k3d, migration-downtime-tests-aws ]
     outputs:
       release_id: ${{ steps.create-draft-release.outputs.release_id }}
     steps:
@@ -373,7 +373,7 @@ jobs:
 
   publish-release:
     name: Publish release
-    needs: [create-draft-release, check-prerequisites]
+    needs: [ create-draft-release, check-prerequisites ]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -408,7 +408,7 @@ jobs:
       name: notifications
       deployment: false
     runs-on: ubuntu-latest
-    needs: [check-prerequisites, publish-release, upload-release-report]
+    needs: [ check-prerequisites, publish-release, upload-release-report ]
     steps:
       - name: Notify
         uses: slackapi/slack-github-action@af78098f536edbc4de71162a307590698245be95

--- a/.github/workflows/release-api-gateway.yaml
+++ b/.github/workflows/release-api-gateway.yaml
@@ -155,7 +155,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2" ]
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/e2e-test-k3d
@@ -178,7 +178,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2" ]
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/e2e-test-gardener

--- a/.github/workflows/schedule-main-integration.yaml
+++ b/.github/workflows/schedule-main-integration.yaml
@@ -47,54 +47,54 @@ jobs:
   #############################################
 
   e2e-tests-k3d:
-     name: E2E tests K3D
-     environment:
-       name: e2e
-       deployment: false
-     runs-on: ubuntu-latest
-     needs: [ get-image ]
-     strategy:
-       fail-fast: false
-       matrix:
-         test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
-     steps:
-       - uses: actions/checkout@v7
-       - uses: ./.github/actions/e2e-test-k3d
-         env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-         with:
-           manager_image: ${{ needs.get-image.outputs.image }}
-           test_client_id: ${{ secrets.CLIENT_ID }}
-           test_client_secret: ${{ secrets.CLIENT_SECRET }}
-           test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-           test_make_target: ${{ matrix.test_make_target }}
+    name: E2E tests K3D
+    environment:
+      name: e2e
+      deployment: false
+    runs-on: ubuntu-latest
+    needs: [ get-image ]
+    strategy:
+      fail-fast: false
+      matrix:
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/e2e-test-k3d
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manager_image: ${{ needs.get-image.outputs.image }}
+          test_client_id: ${{ secrets.CLIENT_ID }}
+          test_client_secret: ${{ secrets.CLIENT_SECRET }}
+          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+          test_make_target: ${{ matrix.test_make_target }}
 
   e2e-tests-aws:
-     name: E2E tests AWS
-     environment:
-       name: e2e
-       deployment: false
-     runs-on: ubuntu-latest
-     needs: [ get-image ]
-     strategy:
-       fail-fast: false
-       matrix:
-         test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
-     steps:
-       - uses: actions/checkout@v7
-       - uses: ./.github/actions/e2e-test-gardener
-         env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-           APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
-         with:
-           manager_image: ${{ needs.get-image.outputs.image }}
-           gardener_secret: ${{ secrets.GARDENER_TOKEN }}
-           gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
-           gardener_provider: aws
-           test_client_id: ${{ secrets.CLIENT_ID }}
-           test_client_secret: ${{ secrets.CLIENT_SECRET }}
-           test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-           test_make_target: ${{ matrix.test_make_target }}
+    name: E2E tests AWS
+    environment:
+      name: e2e
+      deployment: false
+    runs-on: ubuntu-latest
+    needs: [ get-image ]
+    strategy:
+      fail-fast: false
+      matrix:
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/e2e-test-gardener
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
+        with:
+          manager_image: ${{ needs.get-image.outputs.image }}
+          gardener_secret: ${{ secrets.GARDENER_TOKEN }}
+          gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
+          gardener_provider: aws
+          test_client_id: ${{ secrets.CLIENT_ID }}
+          test_client_secret: ${{ secrets.CLIENT_SECRET }}
+          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+          test_make_target: ${{ matrix.test_make_target }}
 
   #############################################
   #
@@ -148,56 +148,56 @@ jobs:
           test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
           test_make_target: test-migration-zero-downtime-${{ matrix.handler }}
 
-  #############################################
-  #
-  # Kubernetes version compatibility tests
-  # Run on: AWS, K3D
-  #
-  #############################################
+    #############################################
+    #
+    # Kubernetes version compatibility tests
+    # Run on: AWS, K3D
+    #
+    #############################################
 
-   k8s-compatibility-check-k3d:
-     name: Kubernetes version compatibility test K3D
-     runs-on: ubuntu-latest
-     needs: [ get-image ]
-     strategy:
-       fail-fast: false
-       matrix:
-         test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
-     steps:
-       - uses: actions/checkout@v7
-       - uses: ./.github/actions/k8s-compatibility-test
-         env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-         with:
-           manager_image: ${{ needs.get-image.outputs.image }}
-           test_make_target: ${{ matrix.test_make_target }}
+    k8s-compatibility-check-k3d:
+      name: Kubernetes version compatibility test K3D
+      runs-on: ubuntu-latest
+      needs: [ get-image ]
+      strategy:
+        fail-fast: false
+        matrix:
+          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+      steps:
+        - uses: actions/checkout@v7
+        - uses: ./.github/actions/k8s-compatibility-test
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            manager_image: ${{ needs.get-image.outputs.image }}
+            test_make_target: ${{ matrix.test_make_target }}
 
-   k8s-compatibility-check-aws:
-     name: Kubernetes version compatibility test AWS
-     environment:
-       name: e2e
-       deployment: false
-     runs-on: ubuntu-latest
-     needs: [ get-image ]
-     strategy:
-       fail-fast: false
-       matrix:
-         test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
-     steps:
-       - uses: actions/checkout@v7
-       - uses: ./.github/actions/k8s-compatibility-test-aws
-         env:
-           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-           APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
-         with:
-           manager_image: ${{ needs.get-image.outputs.image }}
-           test_client_id: ${{ secrets.CLIENT_ID }}
-           test_client_secret: ${{ secrets.CLIENT_SECRET }}
-           test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-           test_make_target: ${{ matrix.test_make_target }}
-           gardener_secret: ${{ secrets.GARDENER_TOKEN }}
-           gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
-           gardener_provider: aws
+    k8s-compatibility-check-aws:
+      name: Kubernetes version compatibility test AWS
+      environment:
+        name: e2e
+        deployment: false
+      runs-on: ubuntu-latest
+      needs: [ get-image ]
+      strategy:
+        fail-fast: false
+        matrix:
+          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+      steps:
+        - uses: actions/checkout@v7
+        - uses: ./.github/actions/k8s-compatibility-test-aws
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
+          with:
+            manager_image: ${{ needs.get-image.outputs.image }}
+            test_client_id: ${{ secrets.CLIENT_ID }}
+            test_client_secret: ${{ secrets.CLIENT_SECRET }}
+            test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+            test_make_target: ${{ matrix.test_make_target }}
+            gardener_secret: ${{ secrets.GARDENER_TOKEN }}
+            gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
+            gardener_provider: aws
 
   #############################################
   #
@@ -292,7 +292,7 @@ jobs:
       deployment: false
     runs-on: ubuntu-latest
     if: ${{ failure() }}
-    needs: [e2e-tests-k3d, e2e-tests-aws, upgrade-tests-k3d, e2e-custom-domain-gcp, e2e-custom-domain-aws, migration-downtime-tests-k3d, migration-downtime-tests-aws, k8s-compatibility-check-k3d, k8s-compatibility-check-aws]
+    needs: [ e2e-tests-k3d, e2e-tests-aws, upgrade-tests-k3d, e2e-custom-domain-gcp, e2e-custom-domain-aws, migration-downtime-tests-k3d, migration-downtime-tests-aws, k8s-compatibility-check-k3d, k8s-compatibility-check-aws ]
     steps:
       - uses: actions/checkout@v7
       - name: Notify

--- a/.github/workflows/schedule-main-integration.yaml
+++ b/.github/workflows/schedule-main-integration.yaml
@@ -56,7 +56,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2" ]
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/e2e-test-k3d
@@ -79,7 +79,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2" ]
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/e2e-test-gardener
@@ -162,7 +162,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2" ]
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/k8s-compatibility-test
@@ -182,7 +182,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2" ]
     steps:
       - uses: actions/checkout@v7
       - uses: ./.github/actions/k8s-compatibility-test-aws

--- a/.github/workflows/schedule-main-integration.yaml
+++ b/.github/workflows/schedule-main-integration.yaml
@@ -148,56 +148,56 @@ jobs:
           test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
           test_make_target: test-migration-zero-downtime-${{ matrix.handler }}
 
-    #############################################
-    #
-    # Kubernetes version compatibility tests
-    # Run on: AWS, K3D
-    #
-    #############################################
+  #############################################
+  #
+  # Kubernetes version compatibility tests
+  # Run on: AWS, K3D
+  #
+  #############################################
 
-    k8s-compatibility-check-k3d:
-      name: Kubernetes version compatibility test K3D
-      runs-on: ubuntu-latest
-      needs: [ get-image ]
-      strategy:
-        fail-fast: false
-        matrix:
-          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
-      steps:
-        - uses: actions/checkout@v7
-        - uses: ./.github/actions/k8s-compatibility-test
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-            manager_image: ${{ needs.get-image.outputs.image }}
-            test_make_target: ${{ matrix.test_make_target }}
+  k8s-compatibility-check-k3d:
+    name: Kubernetes version compatibility test K3D
+    runs-on: ubuntu-latest
+    needs: [ get-image ]
+    strategy:
+      fail-fast: false
+      matrix:
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/k8s-compatibility-test
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manager_image: ${{ needs.get-image.outputs.image }}
+          test_make_target: ${{ matrix.test_make_target }}
 
-    k8s-compatibility-check-aws:
-      name: Kubernetes version compatibility test AWS
-      environment:
-        name: e2e
-        deployment: false
-      runs-on: ubuntu-latest
-      needs: [ get-image ]
-      strategy:
-        fail-fast: false
-        matrix:
-          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
-      steps:
-        - uses: actions/checkout@v7
-        - uses: ./.github/actions/k8s-compatibility-test-aws
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
-          with:
-            manager_image: ${{ needs.get-image.outputs.image }}
-            test_client_id: ${{ secrets.CLIENT_ID }}
-            test_client_secret: ${{ secrets.CLIENT_SECRET }}
-            test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-            test_make_target: ${{ matrix.test_make_target }}
-            gardener_secret: ${{ secrets.GARDENER_TOKEN }}
-            gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
-            gardener_provider: aws
+  k8s-compatibility-check-aws:
+    name: Kubernetes version compatibility test AWS
+    environment:
+      name: e2e
+      deployment: false
+    runs-on: ubuntu-latest
+    needs: [ get-image ]
+    strategy:
+      fail-fast: false
+      matrix:
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/k8s-compatibility-test-aws
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
+        with:
+          manager_image: ${{ needs.get-image.outputs.image }}
+          test_client_id: ${{ secrets.CLIENT_ID }}
+          test_client_secret: ${{ secrets.CLIENT_SECRET }}
+          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+          test_make_target: ${{ matrix.test_make_target }}
+          gardener_secret: ${{ secrets.GARDENER_TOKEN }}
+          gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
+          gardener_provider: aws
 
   #############################################
   #

--- a/.github/workflows/schedule-main-integration.yaml
+++ b/.github/workflows/schedule-main-integration.yaml
@@ -39,62 +39,62 @@ jobs:
         shell: bash
         run: docker pull "${{ steps.get-image.outputs.image }}"
 
-  #############################################
-  #
-  # E2E tests
-  # Run on: AWS, K3D
-  #
-  #############################################
+    #############################################
+    #
+    # E2E tests
+    # Run on: AWS, K3D
+    #
+    #############################################
 
-  e2e-tests-k3d:
-    name: E2E tests K3D
-    environment:
-      name: e2e
-      deployment: false
-    runs-on: ubuntu-latest
-    needs: [ get-image ]
-    strategy:
-      fail-fast: false
-      matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/e2e-test-k3d
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          manager_image: ${{ needs.get-image.outputs.image }}
-          test_client_id: ${{ secrets.CLIENT_ID }}
-          test_client_secret: ${{ secrets.CLIENT_SECRET }}
-          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-          test_make_target: ${{ matrix.test_make_target }}
+    e2e-tests-k3d:
+      name: E2E tests K3D
+      environment:
+        name: e2e
+        deployment: false
+      runs-on: ubuntu-latest
+      needs: [ get-image ]
+      strategy:
+        fail-fast: false
+        matrix:
+          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+      steps:
+        - uses: actions/checkout@v7
+        - uses: ./.github/actions/e2e-test-k3d
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          with:
+            manager_image: ${{ needs.get-image.outputs.image }}
+            test_client_id: ${{ secrets.CLIENT_ID }}
+            test_client_secret: ${{ secrets.CLIENT_SECRET }}
+            test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+            test_make_target: ${{ matrix.test_make_target }}
 
-  e2e-tests-aws:
-    name: E2E tests AWS
-    environment:
-      name: e2e
-      deployment: false
-    runs-on: ubuntu-latest
-    needs: [ get-image ]
-    strategy:
-      fail-fast: false
-      matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/e2e-test-gardener
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
-        with:
-          manager_image: ${{ needs.get-image.outputs.image }}
-          gardener_secret: ${{ secrets.GARDENER_TOKEN }}
-          gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
-          gardener_provider: aws
-          test_client_id: ${{ secrets.CLIENT_ID }}
-          test_client_secret: ${{ secrets.CLIENT_SECRET }}
-          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-          test_make_target: ${{ matrix.test_make_target }}
+    e2e-tests-aws:
+      name: E2E tests AWS
+      environment:
+        name: e2e
+        deployment: false
+      runs-on: ubuntu-latest
+      needs: [ get-image ]
+      strategy:
+        fail-fast: false
+        matrix:
+          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+      steps:
+        - uses: actions/checkout@v7
+        - uses: ./.github/actions/e2e-test-gardener
+          env:
+            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
+          with:
+            manager_image: ${{ needs.get-image.outputs.image }}
+            gardener_secret: ${{ secrets.GARDENER_TOKEN }}
+            gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
+            gardener_provider: aws
+            test_client_id: ${{ secrets.CLIENT_ID }}
+            test_client_secret: ${{ secrets.CLIENT_SECRET }}
+            test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+            test_make_target: ${{ matrix.test_make_target }}
 
   #############################################
   #
@@ -162,7 +162,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
       steps:
         - uses: actions/checkout@v7
         - uses: ./.github/actions/k8s-compatibility-test
@@ -182,7 +182,7 @@ jobs:
       strategy:
         fail-fast: false
         matrix:
-          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
       steps:
         - uses: actions/checkout@v7
         - uses: ./.github/actions/k8s-compatibility-test-aws

--- a/.github/workflows/schedule-main-integration.yaml
+++ b/.github/workflows/schedule-main-integration.yaml
@@ -39,62 +39,62 @@ jobs:
         shell: bash
         run: docker pull "${{ steps.get-image.outputs.image }}"
 
-    #############################################
-    #
-    # E2E tests
-    # Run on: AWS, K3D
-    #
-    #############################################
+  #############################################
+  #
+  # E2E tests
+  # Run on: AWS, K3D
+  #
+  #############################################
 
-    e2e-tests-k3d:
-      name: E2E tests K3D
-      environment:
-        name: e2e
-        deployment: false
-      runs-on: ubuntu-latest
-      needs: [ get-image ]
-      strategy:
-        fail-fast: false
-        matrix:
-          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
-      steps:
-        - uses: actions/checkout@v7
-        - uses: ./.github/actions/e2e-test-k3d
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          with:
-            manager_image: ${{ needs.get-image.outputs.image }}
-            test_client_id: ${{ secrets.CLIENT_ID }}
-            test_client_secret: ${{ secrets.CLIENT_SECRET }}
-            test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-            test_make_target: ${{ matrix.test_make_target }}
+  e2e-tests-k3d:
+    name: E2E tests K3D
+    environment:
+      name: e2e
+      deployment: false
+    runs-on: ubuntu-latest
+    needs: [ get-image ]
+    strategy:
+      fail-fast: false
+      matrix:
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/e2e-test-k3d
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manager_image: ${{ needs.get-image.outputs.image }}
+          test_client_id: ${{ secrets.CLIENT_ID }}
+          test_client_secret: ${{ secrets.CLIENT_SECRET }}
+          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+          test_make_target: ${{ matrix.test_make_target }}
 
-    e2e-tests-aws:
-      name: E2E tests AWS
-      environment:
-        name: e2e
-        deployment: false
-      runs-on: ubuntu-latest
-      needs: [ get-image ]
-      strategy:
-        fail-fast: false
-        matrix:
-          test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
-      steps:
-        - uses: actions/checkout@v7
-        - uses: ./.github/actions/e2e-test-gardener
-          env:
-            GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
-          with:
-            manager_image: ${{ needs.get-image.outputs.image }}
-            gardener_secret: ${{ secrets.GARDENER_TOKEN }}
-            gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
-            gardener_provider: aws
-            test_client_id: ${{ secrets.CLIENT_ID }}
-            test_client_secret: ${{ secrets.CLIENT_SECRET }}
-            test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-            test_make_target: ${{ matrix.test_make_target }}
+  e2e-tests-aws:
+    name: E2E tests AWS
+    environment:
+      name: e2e
+      deployment: false
+    runs-on: ubuntu-latest
+    needs: [ get-image ]
+    strategy:
+      fail-fast: false
+      matrix:
+        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-part1", "test-integration-v2-part2" ]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/e2e-test-gardener
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
+        with:
+          manager_image: ${{ needs.get-image.outputs.image }}
+          gardener_secret: ${{ secrets.GARDENER_TOKEN }}
+          gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
+          gardener_provider: aws
+          test_client_id: ${{ secrets.CLIENT_ID }}
+          test_client_secret: ${{ secrets.CLIENT_SECRET }}
+          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+          test_make_target: ${{ matrix.test_make_target }}
 
   #############################################
   #

--- a/.github/workflows/schedule-main-integration.yaml
+++ b/.github/workflows/schedule-main-integration.yaml
@@ -47,54 +47,54 @@ jobs:
   #############################################
 
   e2e-tests-k3d:
-    name: E2E tests K3D
-    environment:
-      name: e2e
-      deployment: false
-    runs-on: ubuntu-latest
-    needs: [ get-image ]
-    strategy:
-      fail-fast: false
-      matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2" ]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/e2e-test-k3d
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          manager_image: ${{ needs.get-image.outputs.image }}
-          test_client_id: ${{ secrets.CLIENT_ID }}
-          test_client_secret: ${{ secrets.CLIENT_SECRET }}
-          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-          test_make_target: ${{ matrix.test_make_target }}
+     name: E2E tests K3D
+     environment:
+       name: e2e
+       deployment: false
+     runs-on: ubuntu-latest
+     needs: [ get-image ]
+     strategy:
+       fail-fast: false
+       matrix:
+         test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+     steps:
+       - uses: actions/checkout@v7
+       - uses: ./.github/actions/e2e-test-k3d
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+         with:
+           manager_image: ${{ needs.get-image.outputs.image }}
+           test_client_id: ${{ secrets.CLIENT_ID }}
+           test_client_secret: ${{ secrets.CLIENT_SECRET }}
+           test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+           test_make_target: ${{ matrix.test_make_target }}
 
   e2e-tests-aws:
-    name: E2E tests AWS
-    environment:
-      name: e2e
-      deployment: false
-    runs-on: ubuntu-latest
-    needs: [ get-image ]
-    strategy:
-      fail-fast: false
-      matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2" ]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/e2e-test-gardener
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
-        with:
-          manager_image: ${{ needs.get-image.outputs.image }}
-          gardener_secret: ${{ secrets.GARDENER_TOKEN }}
-          gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
-          gardener_provider: aws
-          test_client_id: ${{ secrets.CLIENT_ID }}
-          test_client_secret: ${{ secrets.CLIENT_SECRET }}
-          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-          test_make_target: ${{ matrix.test_make_target }}
+     name: E2E tests AWS
+     environment:
+       name: e2e
+       deployment: false
+     runs-on: ubuntu-latest
+     needs: [ get-image ]
+     strategy:
+       fail-fast: false
+       matrix:
+         test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+     steps:
+       - uses: actions/checkout@v7
+       - uses: ./.github/actions/e2e-test-gardener
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+           APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
+         with:
+           manager_image: ${{ needs.get-image.outputs.image }}
+           gardener_secret: ${{ secrets.GARDENER_TOKEN }}
+           gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
+           gardener_provider: aws
+           test_client_id: ${{ secrets.CLIENT_ID }}
+           test_client_secret: ${{ secrets.CLIENT_SECRET }}
+           test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+           test_make_target: ${{ matrix.test_make_target }}
 
   #############################################
   #
@@ -155,49 +155,49 @@ jobs:
   #
   #############################################
 
-  k8s-compatibility-check-k3d:
-    name: Kubernetes version compatibility test K3D
-    runs-on: ubuntu-latest
-    needs: [ get-image ]
-    strategy:
-      fail-fast: false
-      matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2" ]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/k8s-compatibility-test
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          manager_image: ${{ needs.get-image.outputs.image }}
-          test_make_target: ${{ matrix.test_make_target }}
+   k8s-compatibility-check-k3d:
+     name: Kubernetes version compatibility test K3D
+     runs-on: ubuntu-latest
+     needs: [ get-image ]
+     strategy:
+       fail-fast: false
+       matrix:
+         test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+     steps:
+       - uses: actions/checkout@v7
+       - uses: ./.github/actions/k8s-compatibility-test
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+         with:
+           manager_image: ${{ needs.get-image.outputs.image }}
+           test_make_target: ${{ matrix.test_make_target }}
 
-  k8s-compatibility-check-aws:
-    name: Kubernetes version compatibility test AWS
-    environment:
-      name: e2e
-      deployment: false
-    runs-on: ubuntu-latest
-    needs: [ get-image ]
-    strategy:
-      fail-fast: false
-      matrix:
-        test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2" ]
-    steps:
-      - uses: actions/checkout@v7
-      - uses: ./.github/actions/k8s-compatibility-test-aws
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
-        with:
-          manager_image: ${{ needs.get-image.outputs.image }}
-          test_client_id: ${{ secrets.CLIENT_ID }}
-          test_client_secret: ${{ secrets.CLIENT_SECRET }}
-          test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
-          test_make_target: ${{ matrix.test_make_target }}
-          gardener_secret: ${{ secrets.GARDENER_TOKEN }}
-          gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
-          gardener_provider: aws
+   k8s-compatibility-check-aws:
+     name: Kubernetes version compatibility test AWS
+     environment:
+       name: e2e
+       deployment: false
+     runs-on: ubuntu-latest
+     needs: [ get-image ]
+     strategy:
+       fail-fast: false
+       matrix:
+         test_make_target: [ "test-integration-ory", "test-integration-istio", "test-integration-v2alpha1", "test-integration-gateway", "test-integration-rate-limit", "test-integration-v2-asterisk", "test-integration-v2-cors", "test-integration-v2-ext-auth", "test-integration-v2-expose-methods-on-paths", "test-integration-v2-jwt", "test-integration-v2-no-auth", "test-integration-v2-request", "test-integration-v2-service", "test-integration-v2-short-host", "test-integration-v2-validation" ]
+     steps:
+       - uses: actions/checkout@v7
+       - uses: ./.github/actions/k8s-compatibility-test-aws
+         env:
+           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+           APIGATEWAY_ACCESS_SIG_BASE64: ${{ secrets.GARDENER_APIRULE_ACCESS }}
+         with:
+           manager_image: ${{ needs.get-image.outputs.image }}
+           test_client_id: ${{ secrets.CLIENT_ID }}
+           test_client_secret: ${{ secrets.CLIENT_SECRET }}
+           test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
+           test_make_target: ${{ matrix.test_make_target }}
+           gardener_secret: ${{ secrets.GARDENER_TOKEN }}
+           gardener_project_name: ${{ vars.GARDENER_PROJECT_NAME }}
+           gardener_provider: aws
 
   #############################################
   #

--- a/.github/workflows/schedule-main-integration.yaml
+++ b/.github/workflows/schedule-main-integration.yaml
@@ -96,6 +96,23 @@ jobs:
           test_oidc_well_known_url: "${{ secrets.OIDC_ISSUER_URL }}/.well-known/openid-configuration"
           test_make_target: ${{ matrix.test_make_target }}
 
+  new-e2e-tests-k3d:
+    name: New E2E tests K3D
+    runs-on: ubuntu-latest
+    needs: [ get-image ]
+    strategy:
+      fail-fast: false
+      matrix:
+        test_make_target: [ "e2e-test-part1", "e2e-test-part2" ]
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/e2e-k3d
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          manager_image: ${{ needs.get-image.outputs.image }}
+          test_make_target: ${{ matrix.test_make_target }}
+
   #############################################
   #
   # Zero downtime tests
@@ -292,7 +309,7 @@ jobs:
       deployment: false
     runs-on: ubuntu-latest
     if: ${{ failure() }}
-    needs: [ e2e-tests-k3d, e2e-tests-aws, upgrade-tests-k3d, e2e-custom-domain-gcp, e2e-custom-domain-aws, migration-downtime-tests-k3d, migration-downtime-tests-aws, k8s-compatibility-check-k3d, k8s-compatibility-check-aws ]
+    needs: [ e2e-tests-k3d, e2e-tests-aws, new-e2e-tests-k3d, upgrade-tests-k3d, e2e-custom-domain-gcp, e2e-custom-domain-aws, migration-downtime-tests-k3d, migration-downtime-tests-aws, k8s-compatibility-check-k3d, k8s-compatibility-check-aws ]
     steps:
       - uses: actions/checkout@v7
       - name: Notify

--- a/Makefile
+++ b/Makefile
@@ -142,45 +142,13 @@ test-integration-rate-limit: generate
 test-integration-v2: generate ## Run API Gateway integration tests with v2 API.
 	go test -timeout 1h ./tests/integration -v -race -run "^TestV2$$"
 
-.PHONY: test-integration-v2-asterisk
-test-integration-v2-asterisk: generate
-	go test -timeout 1h ./tests/integration -v -race -run "^TestV2Asterisk$$"
+.PHONY: test-integration-v2-part1
+test-integration-v2-part1: generate
+	go test -timeout 1h ./tests/integration -v -race -run "^TestV2Part1$$"
 
-.PHONY: test-integration-v2-cors
-test-integration-v2-cors: generate
-	go test -timeout 1h ./tests/integration -v -race -run "^TestV2Cors$$"
-
-.PHONY: test-integration-v2-ext-auth
-test-integration-v2-ext-auth: generate
-	go test -timeout 1h ./tests/integration -v -race -run "^TestV2ExtAuth$$"
-
-.PHONY: test-integration-v2-expose-methods-on-paths
-test-integration-v2-expose-methods-on-paths: generate
-	go test -timeout 1h ./tests/integration -v -race -run "^TestV2ExposeMethodsOnPaths$$"
-
-.PHONY: test-integration-v2-jwt
-test-integration-v2-jwt: generate
-	go test -timeout 1h ./tests/integration -v -race -run "^TestV2Jwt$$"
-
-.PHONY: test-integration-v2-no-auth
-test-integration-v2-no-auth: generate
-	go test -timeout 1h ./tests/integration -v -race -run "^TestV2NoAuth$$"
-
-.PHONY: test-integration-v2-request
-test-integration-v2-request: generate
-	go test -timeout 1h ./tests/integration -v -race -run "^TestV2Request$$"
-
-.PHONY: test-integration-v2-service
-test-integration-v2-service: generate
-	go test -timeout 1h ./tests/integration -v -race -run "^TestV2Service$$"
-
-.PHONY: test-integration-v2-short-host
-test-integration-v2-short-host: generate
-	go test -timeout 1h ./tests/integration -v -race -run "^TestV2ShortHost$$"
-
-.PHONY: test-integration-v2-validation
-test-integration-v2-validation: generate
-	go test -timeout 1h ./tests/integration -v -race -run "^TestV2Validation$$"
+.PHONY: test-integration-v2-part2
+test-integration-v2-part2: generate
+	go test -timeout 1h ./tests/integration -v -race -run "^TestV2Part2$$"
 
 .PHONY: install-istio
 install-istio: create-namespace

--- a/Makefile
+++ b/Makefile
@@ -142,6 +142,46 @@ test-integration-rate-limit: generate
 test-integration-v2: generate ## Run API Gateway integration tests with v2 API.
 	go test -timeout 1h ./tests/integration -v -race -run "^TestV2$$"
 
+.PHONY: test-integration-v2-asterisk
+test-integration-v2-asterisk: generate
+	go test -timeout 1h ./tests/integration -v -race -run "^TestV2Asterisk$$"
+
+.PHONY: test-integration-v2-cors
+test-integration-v2-cors: generate
+	go test -timeout 1h ./tests/integration -v -race -run "^TestV2Cors$$"
+
+.PHONY: test-integration-v2-ext-auth
+test-integration-v2-ext-auth: generate
+	go test -timeout 1h ./tests/integration -v -race -run "^TestV2ExtAuth$$"
+
+.PHONY: test-integration-v2-expose-methods-on-paths
+test-integration-v2-expose-methods-on-paths: generate
+	go test -timeout 1h ./tests/integration -v -race -run "^TestV2ExposeMethodsOnPaths$$"
+
+.PHONY: test-integration-v2-jwt
+test-integration-v2-jwt: generate
+	go test -timeout 1h ./tests/integration -v -race -run "^TestV2Jwt$$"
+
+.PHONY: test-integration-v2-no-auth
+test-integration-v2-no-auth: generate
+	go test -timeout 1h ./tests/integration -v -race -run "^TestV2NoAuth$$"
+
+.PHONY: test-integration-v2-request
+test-integration-v2-request: generate
+	go test -timeout 1h ./tests/integration -v -race -run "^TestV2Request$$"
+
+.PHONY: test-integration-v2-service
+test-integration-v2-service: generate
+	go test -timeout 1h ./tests/integration -v -race -run "^TestV2Service$$"
+
+.PHONY: test-integration-v2-short-host
+test-integration-v2-short-host: generate
+	go test -timeout 1h ./tests/integration -v -race -run "^TestV2ShortHost$$"
+
+.PHONY: test-integration-v2-validation
+test-integration-v2-validation: generate
+	go test -timeout 1h ./tests/integration -v -race -run "^TestV2Validation$$"
+
 .PHONY: install-istio
 install-istio: create-namespace
 	kubectl apply -f https://github.com/kyma-project/istio/releases/latest/download/istio-manager.yaml

--- a/Makefile
+++ b/Makefile
@@ -142,20 +142,11 @@ test-integration-rate-limit: generate
 test-integration-v2: generate ## Run API Gateway integration tests with v2 API.
 	go test -timeout 1h ./tests/integration -v -race -run "^TestV2$$"
 
-.PHONY: test-integration-v2-part1
-test-integration-v2-part1: generate
-	go test -timeout 1h ./tests/integration -v -race -run "^TestV2Part1$$"
-
-.PHONY: test-integration-v2-part2
-test-integration-v2-part2: generate
-	go test -timeout 1h ./tests/integration -v -race -run "^TestV2Part2$$"
-
 .PHONY: install-istio
 install-istio: create-namespace
 	kubectl apply -f https://github.com/kyma-project/istio/releases/latest/download/istio-manager.yaml
 	kubectl apply -f https://github.com/kyma-project/istio/releases/latest/download/istio-default-cr.yaml
 	kubectl wait -n kyma-system istios/default --for=jsonpath='{.status.state}'=Ready --timeout=300s
-
 
 .PHONY: install-istio-manager
 install-istio-manager: create-namespace

--- a/Makefile
+++ b/Makefile
@@ -206,6 +206,14 @@ undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/confi
 e2e-test:
 	make -C tests/e2e/tests e2e-test
 
+.PHONY: e2e-test-part1
+e2e-test-part1:
+	make -C tests/e2e/tests e2e-test-part1
+
+.PHONY: e2e-test-part2
+e2e-test-part2:
+	make -C tests/e2e/tests e2e-test-part2
+
 ##@ Build Dependencies
 
 ## Location to install dependencies to

--- a/tests/e2e/tests/Makefile
+++ b/tests/e2e/tests/Makefile
@@ -19,3 +19,28 @@ e2e-test: gotestsum
 	gotestsum --packages github.com/kyma-project/api-gateway/tests/e2e/tests/extgateway --format testname --rerun-fails --junitfile extgateway-tests.xml --jsonfile extgateway-tests.json
 
 	@echo "E2E tests completed successfully"
+
+.PHONY: e2e-test-part1
+e2e-test-part1: gotestsum
+	@echo "Running e2e tests part 1"
+	go clean -testcache
+	gotestsum --packages github.com/kyma-project/api-gateway/tests/e2e/tests/asterisk --format testname --rerun-fails --junitfile asterisk-tests.xml --jsonfile asterisk-tests.json
+	gotestsum --packages github.com/kyma-project/api-gateway/tests/e2e/tests/cors --format testname --rerun-fails --junitfile cors-tests.xml --jsonfile cors-tests.json
+	gotestsum --packages github.com/kyma-project/api-gateway/tests/e2e/tests/expose_methods_on_paths --format testname --rerun-fails --junitfile expose_methods_on_paths-tests.xml --jsonfile expose_methods_on_paths-tests.json
+	gotestsum --packages github.com/kyma-project/api-gateway/tests/e2e/tests/request --format testname --rerun-fails --junitfile request-tests.xml --jsonfile request-tests.json
+	gotestsum --packages github.com/kyma-project/api-gateway/tests/e2e/tests/validation --format testname --rerun-fails --junitfile validation-tests.xml --jsonfile validation-tests.json
+	gotestsum --packages github.com/kyma-project/api-gateway/tests/e2e/tests/extgateway --format testname --rerun-fails --junitfile extgateway-tests.xml --jsonfile extgateway-tests.json
+
+	@echo "E2E tests part 1 completed successfully"
+
+.PHONY: e2e-test-part2
+e2e-test-part2: gotestsum
+	@echo "Running e2e tests part 2"
+	go clean -testcache
+	gotestsum --packages github.com/kyma-project/api-gateway/tests/e2e/tests/extauth --format testname --rerun-fails --junitfile extauth-tests.xml --jsonfile extauth-tests.json
+	gotestsum --packages github.com/kyma-project/api-gateway/tests/e2e/tests/jwt --format testname --rerun-fails --junitfile jwt-tests.xml --jsonfile jwt-tests.json
+	gotestsum --packages github.com/kyma-project/api-gateway/tests/e2e/tests/no_auth --format testname --rerun-fails --junitfile no_auth-tests.xml --jsonfile no_auth-tests.json
+	gotestsum --packages github.com/kyma-project/api-gateway/tests/e2e/tests/service --format testname --rerun-fails --junitfile service-tests.xml --jsonfile service-tests.json
+	gotestsum --packages github.com/kyma-project/api-gateway/tests/e2e/tests/short_host --format testname --rerun-fails --junitfile short_host-tests.xml --jsonfile short_host-tests.json
+
+	@echo "E2E tests part 2 completed successfully"

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -136,34 +136,6 @@ func TestV2(t *testing.T) {
 	runTestsuite(t, ts)
 }
 
-func TestV2Part1(t *testing.T) {
-	ts, err := testcontext.New(v2.NewTestsuitePart1)
-	if err != nil {
-		t.Fatalf("Failed to create v2-part1 testsuite %s", err.Error())
-	}
-	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
-	if err != nil {
-		log.Print(err.Error())
-		t.Fatalf("unable to switch to Ory jwtHandler")
-	}
-	defer cleanUp(t, ts, originalJwtHandler)
-	runTestsuite(t, ts)
-}
-
-func TestV2Part2(t *testing.T) {
-	ts, err := testcontext.New(v2.NewTestsuitePart2)
-	if err != nil {
-		t.Fatalf("Failed to create v2-part2 testsuite %s", err.Error())
-	}
-	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
-	if err != nil {
-		log.Print(err.Error())
-		t.Fatalf("unable to switch to Ory jwtHandler")
-	}
-	defer cleanUp(t, ts, originalJwtHandler)
-	runTestsuite(t, ts)
-}
-
 func runTestsuite(t *testing.T, testsuite testcontext.Testsuite) {
 	log.SetFlags(log.LstdFlags | log.Llongfile)
 	opts := createGoDogOpts(t, testsuite.FeaturePath(), testsuite.TestConcurrency())

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -136,10 +136,10 @@ func TestV2(t *testing.T) {
 	runTestsuite(t, ts)
 }
 
-func TestV2Asterisk(t *testing.T) {
-	ts, err := testcontext.New(v2.NewTestsuiteAsterisk)
+func TestV2Part1(t *testing.T) {
+	ts, err := testcontext.New(v2.NewTestsuitePart1)
 	if err != nil {
-		t.Fatalf("Failed to create v2-asterisk testsuite %s", err.Error())
+		t.Fatalf("Failed to create v2-part1 testsuite %s", err.Error())
 	}
 	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
 	if err != nil {
@@ -150,122 +150,10 @@ func TestV2Asterisk(t *testing.T) {
 	runTestsuite(t, ts)
 }
 
-func TestV2Cors(t *testing.T) {
-	ts, err := testcontext.New(v2.NewTestsuiteCors)
+func TestV2Part2(t *testing.T) {
+	ts, err := testcontext.New(v2.NewTestsuitePart2)
 	if err != nil {
-		t.Fatalf("Failed to create v2-cors testsuite %s", err.Error())
-	}
-	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
-	if err != nil {
-		log.Print(err.Error())
-		t.Fatalf("unable to switch to Ory jwtHandler")
-	}
-	defer cleanUp(t, ts, originalJwtHandler)
-	runTestsuite(t, ts)
-}
-
-func TestV2ExtAuth(t *testing.T) {
-	ts, err := testcontext.New(v2.NewTestsuiteExtAuth)
-	if err != nil {
-		t.Fatalf("Failed to create v2-ext-auth testsuite %s", err.Error())
-	}
-	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
-	if err != nil {
-		log.Print(err.Error())
-		t.Fatalf("unable to switch to Ory jwtHandler")
-	}
-	defer cleanUp(t, ts, originalJwtHandler)
-	runTestsuite(t, ts)
-}
-
-func TestV2ExposeMethodsOnPaths(t *testing.T) {
-	ts, err := testcontext.New(v2.NewTestsuiteExposeMethodsOnPaths)
-	if err != nil {
-		t.Fatalf("Failed to create v2-expose-methods-on-paths testsuite %s", err.Error())
-	}
-	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
-	if err != nil {
-		log.Print(err.Error())
-		t.Fatalf("unable to switch to Ory jwtHandler")
-	}
-	defer cleanUp(t, ts, originalJwtHandler)
-	runTestsuite(t, ts)
-}
-
-func TestV2Jwt(t *testing.T) {
-	ts, err := testcontext.New(v2.NewTestsuiteJwt)
-	if err != nil {
-		t.Fatalf("Failed to create v2-jwt testsuite %s", err.Error())
-	}
-	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
-	if err != nil {
-		log.Print(err.Error())
-		t.Fatalf("unable to switch to Ory jwtHandler")
-	}
-	defer cleanUp(t, ts, originalJwtHandler)
-	runTestsuite(t, ts)
-}
-
-func TestV2NoAuth(t *testing.T) {
-	ts, err := testcontext.New(v2.NewTestsuiteNoAuth)
-	if err != nil {
-		t.Fatalf("Failed to create v2-no-auth testsuite %s", err.Error())
-	}
-	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
-	if err != nil {
-		log.Print(err.Error())
-		t.Fatalf("unable to switch to Ory jwtHandler")
-	}
-	defer cleanUp(t, ts, originalJwtHandler)
-	runTestsuite(t, ts)
-}
-
-func TestV2Request(t *testing.T) {
-	ts, err := testcontext.New(v2.NewTestsuiteRequest)
-	if err != nil {
-		t.Fatalf("Failed to create v2-request testsuite %s", err.Error())
-	}
-	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
-	if err != nil {
-		log.Print(err.Error())
-		t.Fatalf("unable to switch to Ory jwtHandler")
-	}
-	defer cleanUp(t, ts, originalJwtHandler)
-	runTestsuite(t, ts)
-}
-
-func TestV2Service(t *testing.T) {
-	ts, err := testcontext.New(v2.NewTestsuiteService)
-	if err != nil {
-		t.Fatalf("Failed to create v2-service testsuite %s", err.Error())
-	}
-	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
-	if err != nil {
-		log.Print(err.Error())
-		t.Fatalf("unable to switch to Ory jwtHandler")
-	}
-	defer cleanUp(t, ts, originalJwtHandler)
-	runTestsuite(t, ts)
-}
-
-func TestV2ShortHost(t *testing.T) {
-	ts, err := testcontext.New(v2.NewTestsuiteShortHost)
-	if err != nil {
-		t.Fatalf("Failed to create v2-short-host testsuite %s", err.Error())
-	}
-	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
-	if err != nil {
-		log.Print(err.Error())
-		t.Fatalf("unable to switch to Ory jwtHandler")
-	}
-	defer cleanUp(t, ts, originalJwtHandler)
-	runTestsuite(t, ts)
-}
-
-func TestV2Validation(t *testing.T) {
-	ts, err := testcontext.New(v2.NewTestsuiteValidation)
-	if err != nil {
-		t.Fatalf("Failed to create v2-validation testsuite %s", err.Error())
+		t.Fatalf("Failed to create v2-part2 testsuite %s", err.Error())
 	}
 	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
 	if err != nil {

--- a/tests/integration/main_test.go
+++ b/tests/integration/main_test.go
@@ -136,6 +136,146 @@ func TestV2(t *testing.T) {
 	runTestsuite(t, ts)
 }
 
+func TestV2Asterisk(t *testing.T) {
+	ts, err := testcontext.New(v2.NewTestsuiteAsterisk)
+	if err != nil {
+		t.Fatalf("Failed to create v2-asterisk testsuite %s", err.Error())
+	}
+	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
+	if err != nil {
+		log.Print(err.Error())
+		t.Fatalf("unable to switch to Ory jwtHandler")
+	}
+	defer cleanUp(t, ts, originalJwtHandler)
+	runTestsuite(t, ts)
+}
+
+func TestV2Cors(t *testing.T) {
+	ts, err := testcontext.New(v2.NewTestsuiteCors)
+	if err != nil {
+		t.Fatalf("Failed to create v2-cors testsuite %s", err.Error())
+	}
+	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
+	if err != nil {
+		log.Print(err.Error())
+		t.Fatalf("unable to switch to Ory jwtHandler")
+	}
+	defer cleanUp(t, ts, originalJwtHandler)
+	runTestsuite(t, ts)
+}
+
+func TestV2ExtAuth(t *testing.T) {
+	ts, err := testcontext.New(v2.NewTestsuiteExtAuth)
+	if err != nil {
+		t.Fatalf("Failed to create v2-ext-auth testsuite %s", err.Error())
+	}
+	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
+	if err != nil {
+		log.Print(err.Error())
+		t.Fatalf("unable to switch to Ory jwtHandler")
+	}
+	defer cleanUp(t, ts, originalJwtHandler)
+	runTestsuite(t, ts)
+}
+
+func TestV2ExposeMethodsOnPaths(t *testing.T) {
+	ts, err := testcontext.New(v2.NewTestsuiteExposeMethodsOnPaths)
+	if err != nil {
+		t.Fatalf("Failed to create v2-expose-methods-on-paths testsuite %s", err.Error())
+	}
+	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
+	if err != nil {
+		log.Print(err.Error())
+		t.Fatalf("unable to switch to Ory jwtHandler")
+	}
+	defer cleanUp(t, ts, originalJwtHandler)
+	runTestsuite(t, ts)
+}
+
+func TestV2Jwt(t *testing.T) {
+	ts, err := testcontext.New(v2.NewTestsuiteJwt)
+	if err != nil {
+		t.Fatalf("Failed to create v2-jwt testsuite %s", err.Error())
+	}
+	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
+	if err != nil {
+		log.Print(err.Error())
+		t.Fatalf("unable to switch to Ory jwtHandler")
+	}
+	defer cleanUp(t, ts, originalJwtHandler)
+	runTestsuite(t, ts)
+}
+
+func TestV2NoAuth(t *testing.T) {
+	ts, err := testcontext.New(v2.NewTestsuiteNoAuth)
+	if err != nil {
+		t.Fatalf("Failed to create v2-no-auth testsuite %s", err.Error())
+	}
+	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
+	if err != nil {
+		log.Print(err.Error())
+		t.Fatalf("unable to switch to Ory jwtHandler")
+	}
+	defer cleanUp(t, ts, originalJwtHandler)
+	runTestsuite(t, ts)
+}
+
+func TestV2Request(t *testing.T) {
+	ts, err := testcontext.New(v2.NewTestsuiteRequest)
+	if err != nil {
+		t.Fatalf("Failed to create v2-request testsuite %s", err.Error())
+	}
+	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
+	if err != nil {
+		log.Print(err.Error())
+		t.Fatalf("unable to switch to Ory jwtHandler")
+	}
+	defer cleanUp(t, ts, originalJwtHandler)
+	runTestsuite(t, ts)
+}
+
+func TestV2Service(t *testing.T) {
+	ts, err := testcontext.New(v2.NewTestsuiteService)
+	if err != nil {
+		t.Fatalf("Failed to create v2-service testsuite %s", err.Error())
+	}
+	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
+	if err != nil {
+		log.Print(err.Error())
+		t.Fatalf("unable to switch to Ory jwtHandler")
+	}
+	defer cleanUp(t, ts, originalJwtHandler)
+	runTestsuite(t, ts)
+}
+
+func TestV2ShortHost(t *testing.T) {
+	ts, err := testcontext.New(v2.NewTestsuiteShortHost)
+	if err != nil {
+		t.Fatalf("Failed to create v2-short-host testsuite %s", err.Error())
+	}
+	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
+	if err != nil {
+		log.Print(err.Error())
+		t.Fatalf("unable to switch to Ory jwtHandler")
+	}
+	defer cleanUp(t, ts, originalJwtHandler)
+	runTestsuite(t, ts)
+}
+
+func TestV2Validation(t *testing.T) {
+	ts, err := testcontext.New(v2.NewTestsuiteValidation)
+	if err != nil {
+		t.Fatalf("Failed to create v2-validation testsuite %s", err.Error())
+	}
+	originalJwtHandler, err := SwitchJwtHandler(ts, "ory")
+	if err != nil {
+		log.Print(err.Error())
+		t.Fatalf("unable to switch to Ory jwtHandler")
+	}
+	defer cleanUp(t, ts, originalJwtHandler)
+	runTestsuite(t, ts)
+}
+
 func runTestsuite(t *testing.T, testsuite testcontext.Testsuite) {
 	log.SetFlags(log.LstdFlags | log.Llongfile)
 	opts := createGoDogOpts(t, testsuite.FeaturePath(), testsuite.TestConcurrency())

--- a/tests/integration/testsuites/v2/testsuite.go
+++ b/tests/integration/testsuites/v2/testsuite.go
@@ -60,7 +60,6 @@ type testsuite struct {
 	config          testcontext.Config
 	oauth2Cfg       *clientcredentials.Config
 	jwtConfig       *clientcredentials.Config
-	featurePaths    []string
 }
 
 func (t *testsuite) InitScenarios(ctx *godog.ScenarioContext) {
@@ -68,9 +67,6 @@ func (t *testsuite) InitScenarios(ctx *godog.ScenarioContext) {
 }
 
 func (t *testsuite) FeaturePath() []string {
-	if len(t.featurePaths) > 0 {
-		return t.featurePaths
-	}
 	return []string{"testsuites/v2/features/"}
 }
 
@@ -149,35 +145,4 @@ func NewTestsuite(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Int
 		resourceManager: rm,
 		config:          config,
 	}
-}
-
-func newFeatureTestsuite(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config, name string, featurePaths []string) testcontext.Testsuite {
-	return &testsuite{
-		name:            name,
-		httpClient:      httpClient,
-		k8sClient:       k8sClient,
-		resourceManager: rm,
-		config:          config,
-		featurePaths:    featurePaths,
-	}
-}
-
-func NewTestsuitePart1(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
-	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-part1", []string{
-		"testsuites/v2/features/asterisk.feature",
-		"testsuites/v2/features/cors.feature",
-		"testsuites/v2/features/expose_methods_on_paths.feature",
-		"testsuites/v2/features/request.feature",
-		"testsuites/v2/features/validation.feature",
-	})
-}
-
-func NewTestsuitePart2(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
-	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-part2", []string{
-		"testsuites/v2/features/ext_auth.feature",
-		"testsuites/v2/features/jwt.feature",
-		"testsuites/v2/features/no_auth.feature",
-		"testsuites/v2/features/service.feature",
-		"testsuites/v2/features/short_host.feature",
-	})
 }

--- a/tests/integration/testsuites/v2/testsuite.go
+++ b/tests/integration/testsuites/v2/testsuite.go
@@ -4,10 +4,11 @@ import (
 	_ "embed"
 	"encoding/base64"
 	"fmt"
-	"github.com/kyma-project/api-gateway/tests/integration/pkg/global"
-	"github.com/kyma-project/api-gateway/tests/integration/pkg/hooks"
 	"log"
 	"path"
+
+	"github.com/kyma-project/api-gateway/tests/integration/pkg/global"
+	"github.com/kyma-project/api-gateway/tests/integration/pkg/hooks"
 
 	"github.com/cucumber/godog"
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/auth"
@@ -59,6 +60,7 @@ type testsuite struct {
 	config          testcontext.Config
 	oauth2Cfg       *clientcredentials.Config
 	jwtConfig       *clientcredentials.Config
+	featurePaths    []string
 }
 
 func (t *testsuite) InitScenarios(ctx *godog.ScenarioContext) {
@@ -66,6 +68,9 @@ func (t *testsuite) InitScenarios(ctx *godog.ScenarioContext) {
 }
 
 func (t *testsuite) FeaturePath() []string {
+	if len(t.featurePaths) > 0 {
+		return t.featurePaths
+	}
 	return []string{"testsuites/v2/features/"}
 }
 
@@ -144,4 +149,55 @@ func NewTestsuite(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Int
 		resourceManager: rm,
 		config:          config,
 	}
+}
+
+func newFeatureTestsuite(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config, name string, featurePaths []string) testcontext.Testsuite {
+	return &testsuite{
+		name:            name,
+		httpClient:      httpClient,
+		k8sClient:       k8sClient,
+		resourceManager: rm,
+		config:          config,
+		featurePaths:    featurePaths,
+	}
+}
+
+func NewTestsuiteAsterisk(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
+	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-asterisk", []string{"testsuites/v2/features/asterisk.feature"})
+}
+
+func NewTestsuiteCors(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
+	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-cors", []string{"testsuites/v2/features/cors.feature"})
+}
+
+func NewTestsuiteExtAuth(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
+	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-ext-auth", []string{"testsuites/v2/features/ext_auth.feature"})
+}
+
+func NewTestsuiteExposeMethodsOnPaths(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
+	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-expose-methods-on-paths", []string{"testsuites/v2/features/expose_methods_on_paths.feature"})
+}
+
+func NewTestsuiteJwt(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
+	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-jwt", []string{"testsuites/v2/features/jwt.feature"})
+}
+
+func NewTestsuiteNoAuth(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
+	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-no-auth", []string{"testsuites/v2/features/no_auth.feature"})
+}
+
+func NewTestsuiteRequest(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
+	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-request", []string{"testsuites/v2/features/request.feature"})
+}
+
+func NewTestsuiteService(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
+	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-service", []string{"testsuites/v2/features/service.feature"})
+}
+
+func NewTestsuiteShortHost(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
+	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-short-host", []string{"testsuites/v2/features/short_host.feature"})
+}
+
+func NewTestsuiteValidation(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
+	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-validation", []string{"testsuites/v2/features/validation.feature"})
 }

--- a/tests/integration/testsuites/v2/testsuite.go
+++ b/tests/integration/testsuites/v2/testsuite.go
@@ -162,42 +162,22 @@ func newFeatureTestsuite(httpClient *helpers.RetryableHttpClient, k8sClient dyna
 	}
 }
 
-func NewTestsuiteAsterisk(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
-	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-asterisk", []string{"testsuites/v2/features/asterisk.feature"})
+func NewTestsuitePart1(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
+	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-part1", []string{
+		"testsuites/v2/features/asterisk.feature",
+		"testsuites/v2/features/cors.feature",
+		"testsuites/v2/features/expose_methods_on_paths.feature",
+		"testsuites/v2/features/request.feature",
+		"testsuites/v2/features/validation.feature",
+	})
 }
 
-func NewTestsuiteCors(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
-	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-cors", []string{"testsuites/v2/features/cors.feature"})
-}
-
-func NewTestsuiteExtAuth(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
-	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-ext-auth", []string{"testsuites/v2/features/ext_auth.feature"})
-}
-
-func NewTestsuiteExposeMethodsOnPaths(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
-	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-expose-methods-on-paths", []string{"testsuites/v2/features/expose_methods_on_paths.feature"})
-}
-
-func NewTestsuiteJwt(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
-	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-jwt", []string{"testsuites/v2/features/jwt.feature"})
-}
-
-func NewTestsuiteNoAuth(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
-	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-no-auth", []string{"testsuites/v2/features/no_auth.feature"})
-}
-
-func NewTestsuiteRequest(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
-	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-request", []string{"testsuites/v2/features/request.feature"})
-}
-
-func NewTestsuiteService(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
-	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-service", []string{"testsuites/v2/features/service.feature"})
-}
-
-func NewTestsuiteShortHost(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
-	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-short-host", []string{"testsuites/v2/features/short_host.feature"})
-}
-
-func NewTestsuiteValidation(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
-	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-validation", []string{"testsuites/v2/features/validation.feature"})
+func NewTestsuitePart2(httpClient *helpers.RetryableHttpClient, k8sClient dynamic.Interface, rm *resource.Manager, config testcontext.Config) testcontext.Testsuite {
+	return newFeatureTestsuite(httpClient, k8sClient, rm, config, "v2-part2", []string{
+		"testsuites/v2/features/ext_auth.feature",
+		"testsuites/v2/features/jwt.feature",
+		"testsuites/v2/features/no_auth.feature",
+		"testsuites/v2/features/service.feature",
+		"testsuites/v2/features/short_host.feature",
+	})
 }


### PR DESCRIPTION

**Description**

Changes proposed in this pull request:

- Add new make target for every e2e test
- Run new e2e tests in matrix

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.
- [ ] You checked if Busola updates are needed.
