### PR TITLE
fix: order of creation external gateway resource

### DIFF
--- a/controllers/gateway/external/controller.go
+++ b/controllers/gateway/external/controller.go
@@ -207,17 +207,9 @@ func (r *ExternalGatewayReconciler) reconcileResources(ctx context.Context, log 
 		return conditions, false, fmt.Errorf("failed to reconcile CA Secret: %w", err)
 	}
 
-	if err := externalgateway.ReconcileGateway(ctx, r.Client, r.Scheme, external, internalDomain); err != nil {
-		conditions = append(conditions, metav1.Condition{
-			Type:               externalv1alpha1.ConditionTypeGatewayConfigured,
-			Status:             metav1.ConditionFalse,
-			ObservedGeneration: external.Generation,
-			Reason:             externalv1alpha1.ReasonFailed,
-			Message:            err.Error(),
-		})
-		return conditions, false, fmt.Errorf("failed to reconcile Gateway: %w", err)
-	}
-
+	// EnvoyFilters (XFCC sanitization + client-cert validation) must be reconciled BEFORE the
+	// Istio Gateway. If a filter fails to apply, the Gateway must not exist — otherwise Istio
+	// would route mTLS traffic to the workload without the UGW region/cert enforcement chain.
 	certSubjects, err := externalgateway.ResolveRegionCertSubjects(ctx, r.Client, external)
 	if err != nil {
 		conditions = append(conditions, metav1.Condition{
@@ -250,6 +242,17 @@ func (r *ExternalGatewayReconciler) reconcileResources(ctx context.Context, log 
 			Message:            err.Error(),
 		})
 		return conditions, false, fmt.Errorf("failed to reconcile certificate validation filter: %w", err)
+	}
+
+	if err := externalgateway.ReconcileGateway(ctx, r.Client, r.Scheme, external, internalDomain); err != nil {
+		conditions = append(conditions, metav1.Condition{
+			Type:               externalv1alpha1.ConditionTypeGatewayConfigured,
+			Status:             metav1.ConditionFalse,
+			ObservedGeneration: external.Generation,
+			Reason:             externalv1alpha1.ReasonFailed,
+			Message:            err.Error(),
+		})
+		return conditions, false, fmt.Errorf("failed to reconcile Gateway: %w", err)
 	}
 
 	conditions = append(conditions, metav1.Condition{

--- a/controllers/gateway/external/externalgateway_integration_test.go
+++ b/controllers/gateway/external/externalgateway_integration_test.go
@@ -396,7 +396,6 @@ func TestExternalGatewayNotCreatedWhenFiltersFail(t *testing.T) {
 		},
 	}
 	if err := waitForCondition(t, 3*time.Second, func() bool {
-		// object key from object
 		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(istioGateway), istioGateway)
 		if err != nil && apierrors.IsNotFound(err) {
 			return true

--- a/controllers/gateway/external/externalgateway_integration_test.go
+++ b/controllers/gateway/external/externalgateway_integration_test.go
@@ -389,16 +389,22 @@ func TestExternalGatewayNotCreatedWhenFiltersFail(t *testing.T) {
 
 	// Core invariant: the Istio Gateway must NOT exist while the pre-Gateway chain is failing.
 	// Poll for a short window to make sure it does not get created after a subsequent requeue.
-	istioGatewayLookupKey := types.NamespacedName{
-		Name:      externalGateway.GatewayName(),
-		Namespace: testNamespace,
+	istioGateway := &networkingv1beta1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      externalGateway.GatewayName(),
+			Namespace: testNamespace,
+		},
 	}
-	istioGateway := &networkingv1beta1.Gateway{}
 	if err := waitForCondition(t, 3*time.Second, func() bool {
-		return k8sClient.Get(ctx, istioGatewayLookupKey, istioGateway) == nil // true only if the Gateway exists
-	}); err == nil {
-		t.Fatalf("Istio Gateway %s/%s must not exist while pre-Gateway reconcile is failing, but it was created",
-			istioGatewayLookupKey.Namespace, istioGatewayLookupKey.Name)
+		// object key from object
+		err := k8sClient.Get(ctx, client.ObjectKeyFromObject(istioGateway), istioGateway)
+		if err != nil && apierrors.IsNotFound(err) {
+			return true
+		}
+		return false
+	}); err != nil {
+		t.Fatalf("Istio Gateway %s/%s must not exist while pre-Gateway reconcile is failing, but it is present on cluster",
+			istioGateway.GetNamespace(), istioGateway.GetName())
 	}
 
 	assertCondition(t, createdExternalGateway, externalv1alpha1.ConditionTypeGatewayConfigured, metav1.ConditionFalse, externalv1alpha1.ReasonFailed)

--- a/controllers/gateway/external/externalgateway_integration_test.go
+++ b/controllers/gateway/external/externalgateway_integration_test.go
@@ -346,6 +346,65 @@ func TestExternalGatewayInvalidCASecret(t *testing.T) {
 	assertCondition(t, createdExternalGateway, externalv1alpha1.ConditionTypeReady, metav1.ConditionFalse, externalv1alpha1.ReasonFailed)
 }
 
+// TestExternalGatewayNotCreatedWhenFiltersFail guards the variant that the Istio Gateway
+// must NOT be created if the reconciliation chain fails at a step that guards the Gateway
+// (region cert-subject resolution or either EnvoyFilter apply). Otherwise Istio would route
+// mTLS traffic to the workload with UGW enforcement missing.
+//
+// This test triggers a failure by pointing the ExternalGateway at a region that is not in
+// the RegionsConfigMap, which makes ResolveRegionCertSubjects (which runs before
+// ReconcileGateway in the new order) fail.
+func TestExternalGatewayNotCreatedWhenFiltersFail(t *testing.T) {
+	extGatewayName := "test-extgw-gateway-not-created-on-failure"
+
+	regionsConfigMap := getRegionsConfigMap()
+	if err := k8sClient.Create(ctx, regionsConfigMap); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("failed to create regions ConfigMap: %v", err)
+	}
+
+	// Valid CA Secret so CA reconcile succeeds — the failure must land AFTER CA and BEFORE Gateway.
+	caSecret := getCASecret("test-ca-secret-gateway-guard")
+	if err := k8sClient.Create(ctx, caSecret); err != nil && !apierrors.IsAlreadyExists(err) {
+		t.Fatalf("failed to create CA secret: %v", err)
+	}
+	defer func() { _ = k8sClient.Delete(ctx, caSecret) }()
+
+	externalGateway := getExternalGateway(extGatewayName, "test-ca-secret-gateway-guard")
+	externalGateway.Spec.Region = "nonexistent-region" // absent from the ConfigMap -> ResolveRegionCertSubjects fails
+	if err := k8sClient.Create(ctx, externalGateway); err != nil {
+		t.Fatalf("failed to create ExternalGateway: %v", err)
+	}
+	defer func() { _ = k8sClient.Delete(ctx, externalGateway) }()
+
+	externalGatewayLookupKey := types.NamespacedName{Name: extGatewayName, Namespace: testNamespace}
+	createdExternalGateway := &externalv1alpha1.ExternalGateway{}
+
+	// Wait for the reconciler to reach the Error state.
+	if err := waitForCondition(t, 10*time.Second, func() bool {
+		err := k8sClient.Get(ctx, externalGatewayLookupKey, createdExternalGateway)
+		return err == nil && createdExternalGateway.Status.State == externalv1alpha1.Error
+	}); err != nil {
+		t.Fatalf("Status was not updated to Error: %v, state: %s", err, createdExternalGateway.Status.State)
+	}
+
+	// Core invariant: the Istio Gateway must NOT exist while the pre-Gateway chain is failing.
+	// Poll for a short window to make sure it does not get created after a subsequent requeue.
+	istioGatewayLookupKey := types.NamespacedName{
+		Name:      externalGateway.GatewayName(),
+		Namespace: testNamespace,
+	}
+	istioGateway := &networkingv1beta1.Gateway{}
+	if err := waitForCondition(t, 3*time.Second, func() bool {
+		return k8sClient.Get(ctx, istioGatewayLookupKey, istioGateway) == nil // true only if the Gateway exists
+	}); err == nil {
+		t.Fatalf("Istio Gateway %s/%s must not exist while pre-Gateway reconcile is failing, but it was created",
+			istioGatewayLookupKey.Namespace, istioGatewayLookupKey.Name)
+	}
+
+	assertCondition(t, createdExternalGateway, externalv1alpha1.ConditionTypeGatewayConfigured, metav1.ConditionFalse, externalv1alpha1.ReasonFailed)
+	assertCondition(t, createdExternalGateway, externalv1alpha1.ConditionTypeReady, metav1.ConditionFalse, externalv1alpha1.ReasonFailed)
+}
+
 func TestEnvoyFilters(t *testing.T) {
 	extGatewayName := "test-envoyfilters-external-gateway"
 


### PR DESCRIPTION
move creation of gateway to point in time where envoy filters are created, to avoid situation where gateway is Ready but no EFs in place to guard workloads.

<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- ...

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.
- [ ] You checked if Busola updates are needed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
