### PR TITLE
Solidify tests and fix Oathkeeper CRD deletion issue

### DIFF
--- a/internal/reconciliations/oathkeeper/oathkeeper.go
+++ b/internal/reconciliations/oathkeeper/oathkeeper.go
@@ -115,6 +115,7 @@ func DeleteOathkeeperIfNoRulesLeft(ctx context.Context, k8sClient client.Client)
 		deleteOathkeeperServices(ctx, k8sClient),
 		deleteDeployment(ctx, k8sClient, deploymentName),
 		deletePdb(ctx, k8sClient, pdbName, reconciliations.Namespace),
+		deleteCRD(ctx, k8sClient, crdName),
 	)
 
 	if err != nil {

--- a/tests/e2e/pkg/helpers/httpbin/manifest.yaml
+++ b/tests/e2e/pkg/helpers/httpbin/manifest.yaml
@@ -62,3 +62,6 @@ spec:
             httpGet:
               path: /status/200
               port: 8080
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 30

--- a/tests/e2e/pkg/helpers/httpbin/manifest_second.yaml
+++ b/tests/e2e/pkg/helpers/httpbin/manifest_second.yaml
@@ -62,3 +62,6 @@ spec:
                       httpGet:
                           path: /status/200
                           port: 8080
+                      initialDelaySeconds: 5
+                      periodSeconds: 5
+                      failureThreshold: 30

--- a/tests/integration/pkg/helpers/response_validation.go
+++ b/tests/integration/pkg/helpers/response_validation.go
@@ -1,6 +1,7 @@
 package helpers
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -26,7 +27,84 @@ func (s *StatusPredicate) Assert(response http.Response) (bool, string) {
 	return false, fmt.Sprintf("Status code %d on url %s is not between %d and %d", response.StatusCode, response.Request.URL, s.LowerStatusBound, s.UpperStatusBound)
 }
 
-// BodyContainsPredicate is a struct representing desired HTTP response body containing expected strings
+// BodyHasHeaderValuePredicate checks that go-httpbin's /headers response
+// contains each expected key-value pair. Header matching is case-insensitive.
+type BodyHasHeaderValuePredicate struct {
+	Expected [][2]string
+}
+
+func (b *BodyHasHeaderValuePredicate) Assert(response http.Response) (bool, string) {
+	bodyBytes, err := io.ReadAll(response.Body)
+	if err != nil {
+		return false, fmt.Sprintf("Failed to read response body from url %s", response.Request.URL)
+	}
+
+	var parsed struct {
+		Headers map[string][]string `json:"headers"`
+	}
+	if err := json.Unmarshal(bodyBytes, &parsed); err != nil {
+		return false, fmt.Sprintf("Failed to parse JSON body from url %s: %v", response.Request.URL, err)
+	}
+
+	var missing []string
+	for _, kv := range b.Expected {
+		key, wantVal := kv[0], kv[1]
+		if !headersContain(parsed.Headers, key, wantVal) {
+			missing = append(missing, fmt.Sprintf("%s=%s", key, wantVal))
+		}
+	}
+
+	if len(missing) > 0 {
+		return false, fmt.Sprintf("Response from %s missing headers: %s", response.Request.URL, strings.Join(missing, ", "))
+	}
+	return true, ""
+}
+
+func headersContain(headers map[string][]string, key, wantVal string) bool {
+	for hk, vals := range headers {
+		if strings.EqualFold(hk, key) {
+			for _, v := range vals {
+				if strings.EqualFold(v, wantVal) {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// BodyHasCookieValuePredicate checks that go-httpbin's /cookies response
+// contains each expected key-value pair. The endpoint returns a flat
+// JSON map of cookie name to value.
+type BodyHasCookieValuePredicate struct {
+	Expected [][2]string
+}
+
+func (b *BodyHasCookieValuePredicate) Assert(response http.Response) (bool, string) {
+	bodyBytes, err := io.ReadAll(response.Body)
+	if err != nil {
+		return false, fmt.Sprintf("Failed to read response body from url %s", response.Request.URL)
+	}
+
+	var cookies map[string]string
+	if err := json.Unmarshal(bodyBytes, &cookies); err != nil {
+		return false, fmt.Sprintf("Failed to parse JSON body from url %s: %v", response.Request.URL, err)
+	}
+
+	var missing []string
+	for _, kv := range b.Expected {
+		key, wantVal := kv[0], kv[1]
+		if got, ok := cookies[key]; !ok || got != wantVal {
+			missing = append(missing, fmt.Sprintf("%s=%s", key, wantVal))
+		}
+	}
+
+	if len(missing) > 0 {
+		return false, fmt.Sprintf("Response from %s missing cookies: %s", response.Request.URL, strings.Join(missing, ", "))
+	}
+	return true, ""
+}
+
 type BodyContainsPredicate struct {
 	Expected []string
 }

--- a/tests/integration/pkg/helpers/response_validation.go
+++ b/tests/integration/pkg/helpers/response_validation.go
@@ -42,7 +42,7 @@ func (s *BodyContainsPredicate) Assert(response http.Response) (bool, string) {
 
 	var notContained []string
 	for _, e := range s.Expected {
-		if !strings.Contains(bodyString, e) {
+		if !strings.Contains(strings.ToLower(bodyString), strings.ToLower(e)) {
 			notContained = append(notContained, e)
 		}
 	}

--- a/tests/integration/testsuites/custom-domain/manifests/testing-app.yaml
+++ b/tests/integration/testsuites/custom-domain/manifests/testing-app.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - name: http
     port: 8000
-    targetPort: 8000
+    targetPort: 8080
   selector:
     app: httpbin-{{.TestID}}
 ---
@@ -31,17 +31,18 @@ spec:
         version: v1
     spec:
       containers:
-      - image: europe-docker.pkg.dev/kyma-project/prod/external/kennethreitz/httpbin
-        command:
-          - /bin/bash
-          - -c
-          - |
-            sleep 20
-            gunicorn -b 0.0.0.0:8000 httpbin:app -k gevent
+      - image: docker.io/mccutchen/go-httpbin:v2.15.0
         imagePullPolicy: IfNotPresent
         name: httpbin
         ports:
-        - containerPort: 8000
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /status/200
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 30
         securityContext:
           runAsUser: 65534
           runAsNonRoot: true

--- a/tests/integration/testsuites/gateway/features/kyma_gateway.feature
+++ b/tests/integration/testsuites/gateway/features/kyma_gateway.feature
@@ -40,7 +40,7 @@ Feature: Checking default kyma gateway
     Then APIGateway CR is in "Ready" state with description ""
     And there "is no" "Deployment" "ory-oathkeeper" in namespace "kyma-system"
     And there "is no" "ConfigMap" "ory-oathkeeper-config" in namespace "kyma-system"
-    And there "is" "CustomResourceDefinition" "rules.oathkeeper.ory.sh" in the cluster
+    And there "is no" "CustomResourceDefinition" "rules.oathkeeper.ory.sh" in the cluster
     And there "is no" "Secret" "ory-oathkeeper-jwks-secret" in namespace "kyma-system"
     And there "is no" "Service" "ory-oathkeeper-api" in namespace "kyma-system"
     And there "is no" "Service" "ory-oathkeeper-proxy" in namespace "kyma-system"

--- a/tests/integration/testsuites/istio-jwt/manifests/testing-app.yaml
+++ b/tests/integration/testsuites/istio-jwt/manifests/testing-app.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - name: http
     port: 8000
-    targetPort: 8000
+    targetPort: 8080
   selector:
     app: httpbin-{{.TestID}}
 ---
@@ -31,17 +31,18 @@ spec:
         version: v1
     spec:
       containers:
-      - image: europe-docker.pkg.dev/kyma-project/prod/external/kennethreitz/httpbin
-        command:
-          - /bin/bash
-          - -c
-          - |
-            sleep 20
-            gunicorn -b 0.0.0.0:8000 httpbin:app -k gevent
+      - image: docker.io/mccutchen/go-httpbin:v2.15.0
         imagePullPolicy: IfNotPresent
         name: httpbin
         ports:
-        - containerPort: 8000
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /status/200
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 30
         securityContext:
           runAsUser: 65534
           runAsNonRoot: true

--- a/tests/integration/testsuites/istio-jwt/scenario_jwt_multiple_mutators.go
+++ b/tests/integration/testsuites/istio-jwt/scenario_jwt_multiple_mutators.go
@@ -22,12 +22,13 @@ func initMultipleMutators(ctx *godog.ScenarioContext, ts *testsuite) {
 }
 
 func (s *scenario) shouldReturnResponseWithKeyValuePairs(endpoint, k1, v1, k2, v2 string) error {
-	expectedInBody := []string{
-		fmt.Sprintf(`"%s": "%s"`, k1, v1),
-		fmt.Sprintf(`"%s": "%s"`, k2, v2),
+	var asserter helpers.HttpResponseAsserter
+	pairs := [][2]string{{k1, v1}, {k2, v2}}
+	if strings.Contains(endpoint, "cookies") {
+		asserter = &helpers.BodyHasCookieValuePredicate{Expected: pairs}
+	} else {
+		asserter = &helpers.BodyHasHeaderValuePredicate{Expected: pairs}
 	}
-
-	asserter := &helpers.BodyContainsPredicate{Expected: expectedInBody}
 	tokenFrom := tokenFrom{
 		From:     testcontext.AuthorizationHeaderName,
 		Prefix:   testcontext.AuthorizationHeaderPrefix,

--- a/tests/integration/testsuites/istio-jwt/scenario_jwt_mutator_cookie.go
+++ b/tests/integration/testsuites/istio-jwt/scenario_jwt_mutator_cookie.go
@@ -2,8 +2,12 @@ package istiojwt
 
 import (
 	"fmt"
+	"net/http"
+	"strings"
 
 	"github.com/cucumber/godog"
+	"github.com/kyma-project/api-gateway/tests/integration/pkg/helpers"
+	"github.com/kyma-project/api-gateway/tests/integration/pkg/testcontext"
 )
 
 func initMutatorCookie(ctx *godog.ScenarioContext, ts *testsuite) {
@@ -16,6 +20,11 @@ func initMutatorCookie(ctx *godog.ScenarioContext, ts *testsuite) {
 }
 
 func (s *scenario) shouldReturnResponseWithCookie(path, cookie, cookieValue string) error {
-	bodyContent := fmt.Sprintf(`"%s": "%s"`, cookie, cookieValue)
-	return s.callingTheEndpointWithValidTokenShouldResultInBodyContaining(path, "JWT", bodyContent)
+	asserter := &helpers.BodyHasCookieValuePredicate{Expected: [][2]string{{cookie, cookieValue}}}
+	tokenFrom := tokenFrom{
+		From:     testcontext.AuthorizationHeaderName,
+		Prefix:   testcontext.AuthorizationHeaderPrefix,
+		AsHeader: true,
+	}
+	return s.callingEndpointWithMethodAndHeaders(fmt.Sprintf("%s/%s", s.Url, strings.TrimLeft(path, "/")), http.MethodGet, "JWT", asserter, nil, &tokenFrom)
 }

--- a/tests/integration/testsuites/istio-jwt/scenario_jwt_mutator_header.go
+++ b/tests/integration/testsuites/istio-jwt/scenario_jwt_mutator_header.go
@@ -2,8 +2,12 @@ package istiojwt
 
 import (
 	"fmt"
+	"net/http"
+	"strings"
 
 	"github.com/cucumber/godog"
+	"github.com/kyma-project/api-gateway/tests/integration/pkg/helpers"
+	"github.com/kyma-project/api-gateway/tests/integration/pkg/testcontext"
 )
 
 func initMutatorHeader(ctx *godog.ScenarioContext, ts *testsuite) {
@@ -16,6 +20,11 @@ func initMutatorHeader(ctx *godog.ScenarioContext, ts *testsuite) {
 }
 
 func (s *scenario) shouldReturnResponseWithHeader(path, header, headerValue string) error {
-	bodyContent := fmt.Sprintf(`"%s": "%s"`, header, headerValue)
-	return s.callingTheEndpointWithValidTokenShouldResultInBodyContaining(path, "JWT", bodyContent)
+	asserter := &helpers.BodyHasHeaderValuePredicate{Expected: [][2]string{{header, headerValue}}}
+	tokenFrom := tokenFrom{
+		From:     testcontext.AuthorizationHeaderName,
+		Prefix:   testcontext.AuthorizationHeaderPrefix,
+		AsHeader: true,
+	}
+	return s.callingEndpointWithMethodAndHeaders(fmt.Sprintf("%s/%s", s.Url, strings.TrimLeft(path, "/")), http.MethodGet, "JWT", asserter, nil, &tokenFrom)
 }

--- a/tests/integration/testsuites/istio-jwt/scenario_jwt_mutators_overwrite.go
+++ b/tests/integration/testsuites/istio-jwt/scenario_jwt_mutators_overwrite.go
@@ -38,8 +38,7 @@ func (s *scenario) thereIsAnEndpointWithHeaderMutator(_, header, headerValue str
 func (s *scenario) shouldOverwriteHeaderValue(endpoint, headerName, requestValue, responseValue string) error {
 	requestHeaders := map[string]string{headerName: requestValue}
 
-	expectedInBody := []string{fmt.Sprintf(`"%s": "%s"`, headerName, responseValue)}
-	asserter := &helpers.BodyContainsPredicate{Expected: expectedInBody}
+	asserter := &helpers.BodyHasHeaderValuePredicate{Expected: [][2]string{{headerName, responseValue}}}
 	tokenFrom := tokenFrom{
 		From:     testcontext.AuthorizationHeaderName,
 		Prefix:   testcontext.AuthorizationHeaderPrefix,
@@ -52,8 +51,7 @@ func (s *scenario) shouldOverwriteHeaderValue(endpoint, headerName, requestValue
 func (s *scenario) shouldOverwriteCookieValue(endpoint, requestValue, responseValue string) error {
 	requestHeaders := map[string]string{"Cookie": requestValue}
 
-	expectedInBody := []string{fmt.Sprintf(`"%s": "%s"`, "Cookie", responseValue)}
-	asserter := &helpers.BodyContainsPredicate{Expected: expectedInBody}
+	asserter := &helpers.BodyHasHeaderValuePredicate{Expected: [][2]string{{"Cookie", responseValue}}}
 	tokenFrom := tokenFrom{
 		From:     testcontext.AuthorizationHeaderName,
 		Prefix:   testcontext.AuthorizationHeaderPrefix,

--- a/tests/integration/testsuites/ory/manifests/testing-app-istio-injection.yaml
+++ b/tests/integration/testsuites/ory/manifests/testing-app-istio-injection.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - name: http
     port: 8000
-    targetPort: 8000
+    targetPort: 8080
   selector:
     app: httpbin-{{.TestID}}
 ---
@@ -32,23 +32,18 @@ spec:
         sidecar.istio.io/inject: "true"
     spec:
       containers:
-      - image: europe-docker.pkg.dev/kyma-project/prod/external/kennethreitz/httpbin
-        command:
-          - /bin/bash
-          - -c
-          - |
-            sleep 20
-            gunicorn -b 0.0.0.0:8000 httpbin:app -k gevent
+      - image: docker.io/mccutchen/go-httpbin:v2.15.0
         imagePullPolicy: IfNotPresent
         name: httpbin
         ports:
-        - containerPort: 8000
+        - containerPort: 8080
         readinessProbe:
           httpGet:
-            path: /headers
-            port: 8000
-          initialDelaySeconds: 15
-          periodSeconds: 10
+            path: /status/200
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 30
         securityContext:
           runAsUser: 65534
           runAsNonRoot: true

--- a/tests/integration/testsuites/ory/manifests/testing-app.yaml
+++ b/tests/integration/testsuites/ory/manifests/testing-app.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - name: http
     port: 8000
-    targetPort: 8000
+    targetPort: 8080
   selector:
     app: httpbin-{{.TestID}}
 ---
@@ -31,22 +31,16 @@ spec:
         version: v1
     spec:
       containers:
-      - image: europe-docker.pkg.dev/kyma-project/prod/external/kennethreitz/httpbin
-        command:
-          - /bin/bash
-          - -c
-          - |
-            sleep 20
-            gunicorn -b 0.0.0.0:8000 httpbin:app -k gevent
+      - image: docker.io/mccutchen/go-httpbin:v2.15.0
         imagePullPolicy: IfNotPresent
         name: httpbin
         ports:
-        - containerPort: 8000
+        - containerPort: 8080
         readinessProbe:
           httpGet:
             path: /status/200
-            port: 8000
-          initialDelaySeconds: 20
+            port: 8080
+          initialDelaySeconds: 5
           periodSeconds: 5
           failureThreshold: 30
         securityContext:

--- a/tests/integration/testsuites/ory/manifests/testing-app.yaml
+++ b/tests/integration/testsuites/ory/manifests/testing-app.yaml
@@ -42,6 +42,13 @@ spec:
         name: httpbin
         ports:
         - containerPort: 8000
+        readinessProbe:
+          httpGet:
+            path: /status/200
+            port: 8000
+          initialDelaySeconds: 20
+          periodSeconds: 5
+          failureThreshold: 30
         securityContext:
           runAsUser: 65534
           runAsNonRoot: true

--- a/tests/integration/testsuites/ory/scenario.go
+++ b/tests/integration/testsuites/ory/scenario.go
@@ -199,6 +199,11 @@ func (s *scenario) thereIsAHttpbinService() error {
 		return err
 	}
 
+	err = helpers.WaitForDeployment(s.resourceManager, s.k8sClient, s.Namespace, fmt.Sprintf("httpbin-%s", s.TestID), testcontext.GetRetryOpts())
+	if err != nil {
+		return err
+	}
+
 	s.Url = "https://" + s.GetHostUnderTest()
 
 	return nil

--- a/tests/integration/testsuites/ory/scenario_migration_jwt_v1beta1.go
+++ b/tests/integration/testsuites/ory/scenario_migration_jwt_v1beta1.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/kyma-project/api-gateway/internal/processing"
+	"github.com/kyma-project/api-gateway/tests/integration/pkg/helpers"
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/manifestprocessor"
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/resource"
 	"github.com/kyma-project/api-gateway/tests/integration/pkg/testcontext"
@@ -116,6 +117,11 @@ func (s *scenario) thereIsAHttpbinServiceWithIstioInjection() error {
 		return err
 	}
 	_, err = s.resourceManager.CreateResources(s.k8sClient, resources...)
+	if err != nil {
+		return err
+	}
+
+	err = helpers.WaitForDeployment(s.resourceManager, s.k8sClient, s.Namespace, fmt.Sprintf("httpbin-%s", s.TestID), testcontext.GetRetryOpts())
 	if err != nil {
 		return err
 	}

--- a/tests/integration/testsuites/upgrade/manifests/testing-app.yaml
+++ b/tests/integration/testsuites/upgrade/manifests/testing-app.yaml
@@ -9,7 +9,7 @@ spec:
   ports:
   - name: http
     port: 8000
-    targetPort: 8000
+    targetPort: 8080
   selector:
     app: httpbin-{{.TestID}}
 ---
@@ -31,17 +31,18 @@ spec:
         version: v1
     spec:
       containers:
-      - image: europe-docker.pkg.dev/kyma-project/prod/external/kennethreitz/httpbin
-        command:
-          - /bin/bash
-          - -c
-          - |
-            sleep 20
-            gunicorn -b 0.0.0.0:8000 httpbin:app -k gevent
+      - image: docker.io/mccutchen/go-httpbin:v2.15.0
         imagePullPolicy: IfNotPresent
         name: httpbin
         ports:
-        - containerPort: 8000
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /status/200
+            port: 8080
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          failureThreshold: 30
         securityContext:
           runAsUser: 65534
           runAsNonRoot: true


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- Solidify header and cookie checks
- Switch to go-httpbin
- Fix oathkeeper CRD deletion issue

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.
- [ ] You checked if Busola updates are needed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
