### PR TITLE
fix: skip Istio CR creation if already exists

### DIFF
--- a/tests/e2e/pkg/helpers/modules/istio.go
+++ b/tests/e2e/pkg/helpers/modules/istio.go
@@ -3,6 +3,7 @@ package modules
 import (
 	"bytes"
 	_ "embed"
+	"os"
 	"github.com/kyma-project/api-gateway/tests/e2e/pkg/helpers/client"
 	"testing"
 	"time"
@@ -37,6 +38,10 @@ func WithIstioOperatorTemplate(template string) IstioCROption {
 
 func CreateIstioOperatorCR(t *testing.T, options ...IstioCROption) error {
 	t.Helper()
+	if os.Getenv("IS_GARDENER") == "true" {
+		t.Log("Skipping Istio CR creation, already provisioned by the Gardener setup script")
+		return nil
+	}
 	t.Log("Creating Istio custom resource")
 	opts := &IstioCROptions{
 		Template: []byte(IstioDefaultTemplate),

--- a/tests/e2e/pkg/helpers/modules/istio.go
+++ b/tests/e2e/pkg/helpers/modules/istio.go
@@ -63,7 +63,18 @@ func CreateIstioOperatorCR(t *testing.T, options ...IstioCROption) error {
 	err = r.Create(t.Context(), icr)
 	if err != nil {
 		if k8serrors.IsAlreadyExists(err) {
-			t.Log("Istio custom resource already exists, skipping creation")
+			t.Log("Istio custom resource already exists, updating")
+			existing := &unstructured.Unstructured{}
+			existing.SetGroupVersionKind(icr.GroupVersionKind())
+			if err := r.Get(t.Context(), icr.GetName(), icr.GetNamespace(), existing); err != nil {
+				t.Logf("Failed to get existing Istio custom resource: %v", err)
+				return err
+			}
+			icr.SetResourceVersion(existing.GetResourceVersion())
+			if err := r.Update(t.Context(), icr); err != nil {
+				t.Logf("Failed to update Istio custom resource: %v", err)
+				return err
+			}
 			return nil
 		}
 		t.Logf("Failed to create Istio custom resource: %v", err)

--- a/tests/e2e/pkg/helpers/modules/istio.go
+++ b/tests/e2e/pkg/helpers/modules/istio.go
@@ -3,19 +3,17 @@ package modules
 import (
 	"bytes"
 	_ "embed"
-	"os"
-	"github.com/kyma-project/api-gateway/tests/e2e/pkg/helpers/client"
 	"testing"
 	"time"
 
+	"github.com/kyma-project/api-gateway/tests/e2e/pkg/helpers/client"
+	"github.com/kyma-project/api-gateway/tests/e2e/pkg/setup"
 	k8serrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"sigs.k8s.io/e2e-framework/klient/decoder"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/klient/wait"
 	"sigs.k8s.io/e2e-framework/klient/wait/conditions"
-
-	"github.com/kyma-project/api-gateway/tests/e2e/pkg/setup"
 )
 
 //go:embed operator_v1alpha2_istio_ext_authorizers.yaml
@@ -38,10 +36,6 @@ func WithIstioOperatorTemplate(template string) IstioCROption {
 
 func CreateIstioOperatorCR(t *testing.T, options ...IstioCROption) error {
 	t.Helper()
-	if os.Getenv("IS_GARDENER") == "true" {
-		t.Log("Skipping Istio CR creation, already provisioned by the Gardener setup script")
-		return nil
-	}
 	t.Log("Creating Istio custom resource")
 	opts := &IstioCROptions{
 		Template: []byte(IstioDefaultTemplate),

--- a/tests/e2e/pkg/helpers/modules/istio.go
+++ b/tests/e2e/pkg/helpers/modules/istio.go
@@ -68,6 +68,10 @@ func CreateIstioOperatorCR(t *testing.T, options ...IstioCROption) error {
 
 	err = r.Create(t.Context(), icr)
 	if err != nil {
+		if k8serrors.IsAlreadyExists(err) {
+			t.Log("Istio custom resource already exists, skipping creation")
+			return nil
+		}
 		t.Logf("Failed to create Istio custom resource: %v", err)
 		return err
 	}


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- ...

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.
- [ ] You checked if Busola updates are needed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
