### PR TITLE
fix: increase custom domain e2e test timeout to 20m

### DIFF
--- a/.github/workflows/post-main-release-integration.yaml
+++ b/.github/workflows/post-main-release-integration.yaml
@@ -297,7 +297,7 @@ jobs:
           test_make_target: 'test-custom-domain'
 
   new-e2e-custom-domain-gcp:
-    name: E2E custom domain tests GCP
+    name: New E2E custom domain tests GCP
     environment:
       name: e2e
       deployment: false
@@ -322,7 +322,7 @@ jobs:
           test_make_target: 'e2e-test-custom-domain'
 
   new-e2e-custom-domain-aws:
-    name: E2E custom domain tests AWS
+    name: New E2E custom domain tests AWS
     environment:
       name: e2e
       deployment: false

--- a/tests/e2e/tests/Makefile
+++ b/tests/e2e/tests/Makefile
@@ -55,7 +55,7 @@ e2e-test-part2: gotestsum
 e2e-test-custom-domain: gotestsum
 	@echo "Running e2e tests for custom domain"
 	go clean -testcache
-	gotestsum --packages github.com/kyma-project/api-gateway/tests/e2e/tests/custom_domain --format testname --rerun-fails --junitfile custom_domain-tests.xml --jsonfile custom_domain-tests.json
+	gotestsum --packages github.com/kyma-project/api-gateway/tests/e2e/tests/custom_domain --format testname --rerun-fails --junitfile custom_domain-tests.xml --jsonfile custom_domain-tests.json -- -timeout 20m
 	@echo "E2E tests for custom domain completed successfully"
 
 .PHONY: e2e-test-gateway-gardener

--- a/tests/e2e/tests/custom_domain/custom_domain_test.go
+++ b/tests/e2e/tests/custom_domain/custom_domain_test.go
@@ -312,7 +312,7 @@ func assertCertificateReady(t *testing.T, r *resources.Resources, name, namespac
 				state, _, _ := unstructured.NestedString(u.Object, "status", "state")
 				return state == "Ready"
 			}),
-			wait.WithTimeout(5*time.Minute),
+			wait.WithTimeout(15*time.Minute),
 		),
 		"Gardener Certificate %s/%s did not become ready", namespace, name,
 	)


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- ...

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.
- [ ] You checked if Busola updates are needed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
