### PR TITLE
fix: create DNSEntry before waiting for DNS resolution

### DIFF
--- a/tests/e2e/tests/custom_domain/custom_domain_test.go
+++ b/tests/e2e/tests/custom_domain/custom_domain_test.go
@@ -67,7 +67,7 @@ const (
 // a DNSEntry pointing the wildcard subdomain to the ingress LB (ip/hostname, based on which is stored in the status),
 // and returns a "namespace/name" gateway reference for use in APIRule.
 // certName is the name of the Gardener Certificate (and its resulting secret) in istio-system.
-func setupCustomGateway(t *testing.T, namespace, name, subdomain, certName, loadBalancerTarget string) (string, error) {
+func setupCustomGateway(t *testing.T, namespace, name, subdomain, certName string) (string, error) {
 	t.Helper()
 	gatewayName := fmt.Sprintf("custom-domain-%s", name)
 	hostWildcard := fmt.Sprintf("*.%s", subdomain)
@@ -84,20 +84,6 @@ func setupCustomGateway(t *testing.T, namespace, name, subdomain, certName, load
 	)
 	if err != nil {
 		return "", fmt.Errorf("creating custom Istio Gateway %s/%s: %w", namespace, gatewayName, err)
-	}
-
-	_, err = infrahelpers.CreateResourceWithTemplateValues(
-		t,
-		DNSEntryTemplate,
-		map[string]any{
-			"Name":               gatewayName,
-			"Subdomain":          subdomain,
-			"LoadBalancerTarget": loadBalancerTarget,
-		},
-		decoder.MutateNamespace(namespace),
-	)
-	if err != nil {
-		return "", fmt.Errorf("creating custom DNSEntry %s/%s: %w", namespace, gatewayName, err)
 	}
 
 	return fmt.Sprintf("%s/%s", namespace, gatewayName), nil
@@ -202,6 +188,18 @@ func TestAPIRuleCustomDomain(t *testing.T) {
 
 	subdomain := fmt.Sprintf("%s.%s", suiteID, customDomain)
 
+	_, err = infrahelpers.CreateResourceWithTemplateValues(
+		t,
+		DNSEntryTemplate,
+		map[string]any{
+			"Name":               certName,
+			"Subdomain":          subdomain,
+			"LoadBalancerTarget": loadBalancerTarget,
+		},
+		decoder.MutateNamespace("default"),
+	)
+	require.NoError(t, err, "Failed to create suite-level DNSEntry")
+
 	dnsAttempt, err := customdomainhelper.WaitUntilDNSReady(subdomain, loadBalancerTarget,
 		retry.Attempts(dnsResolutionAttempts),
 		retry.Delay(dnsResolutionTimeout),
@@ -217,7 +215,7 @@ func TestAPIRuleCustomDomain(t *testing.T) {
 
 		host := fmt.Sprintf("httpbin-%s.%s", testBackground.TestName, subdomain)
 
-		gatewayRef, err := setupCustomGateway(t, testBackground.Namespace, testBackground.TestName, subdomain, certName, loadBalancerTarget)
+		gatewayRef, err := setupCustomGateway(t, testBackground.Namespace, testBackground.TestName, subdomain, certName)
 		require.NoError(t, err, "Failed to create custom Istio Gateway")
 
 		_, err = infrahelpers.CreateResourceWithTemplateValues(
@@ -255,7 +253,7 @@ func TestAPIRuleCustomDomain(t *testing.T) {
 
 		host := fmt.Sprintf("httpbin-%s.%s", testBackground.TestName, subdomain)
 
-		gatewayRef, err := setupCustomGateway(t, testBackground.Namespace, testBackground.TestName, subdomain, certName, loadBalancerTarget)
+		gatewayRef, err := setupCustomGateway(t, testBackground.Namespace, testBackground.TestName, subdomain, certName)
 		require.NoError(t, err, "Failed to create custom Istio Gateway")
 
 		_, err = infrahelpers.CreateResourceWithTemplateValues(


### PR DESCRIPTION
<!-- Thank you for your contribution. Before you submit the pull request:
1. Follow contributing guidelines, templates, the recommended Git workflow, and any related documentation.
2. Read and submit the required Contributor Licence Agreements (https://github.com/kyma-project/community/blob/main/docs/contributing/02-contributing.md#agreements-and-licenses).
3. Test your changes and attach their results to the pull request.
4. Update the relevant documentation.
-->

**Description**

Changes proposed in this pull request:

- ...

**Pre-Merge Checklist**

Consider all the following items. If your contribution violates any of them, or you are not sure about it, add a comment to the PR.

- [ ] The code coverage is acceptable.
- [ ] Release notes for the introduced changes are created.
- [ ] If Kubebuilder changes were made, you ran `make manifests` and committed the changes before the merge.
- [ ] Pre-existing managed resources are correctly handled.
- [ ] The change works on all hyperscalers supported by SAP BTP, Kyma runtime.
- [ ] There is no upgrade downtime.
- [ ] For infrastructure changes, you checked if the changes affect the hyperscaler's costs.
- [ ] RBAC settings are as restrictive as possible.
- [ ] If any new libraries are added, you verified license compliance and maintainability, and made a comment in the PR with details. We only allow stable releases to be included in the project.
- [ ] You checked if this change should be cherry-picked to active release branches.
- [ ] The configuration does not introduce any additional latency.
- [ ] You checked if Busola updates are needed.

**Related issues**
<!-- If you refer to a particular issue, provide its number. For example, `Resolves #123`, `Fixes #43`, or `See also #33`. -->
